### PR TITLE
Decomplexify/document result-rendering switches

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -24,7 +24,10 @@ from textwrap import wrap
 
 from datalad import __version__
 from ..cmd import WitlessRunner as Runner
-from ..interface.common_opts import eval_defaults
+from ..interface.common_opts import (
+    eval_defaults,
+    eval_params,
+)
 from ..log import is_interactive
 from datalad.support.exceptions import CapturedException
 from ..ui.utils import get_console_width
@@ -240,25 +243,15 @@ def parser_add_common_options(parser, version=None):
     # and a different default: in Python API we have None as default and do not render
     # the results but return them.  In CLI we default to "default" renderer
     parser.add_argument(
-        '-f', '--output-format', dest='common_output_format',
+        # this should really have --result-renderer for homogeneity with the
+        # Python API, but adding it in addition makes the help output
+        # monsterous
+        '-f', '--output-format', # '--result-renderer',
+        dest='common_result_renderer',
         default='tailored',
         type=ensure_unicode,
-        metavar="{default,json,json_pp,tailored,'<template>'}",
-        help="""select format for returned command results. 'tailored'
-        enables a command-specific rendering style that is typically
-        tailored to human consumption, if there is one for a specific
-        command, or otherwise falls back on the the 'default' output
-        format (this is the standard behavior); 'default' give one line
-        per result reporting action, status, path and an optional message;
-        'json' renders a JSON object with all properties for each result (one per
-        line); 'json_pp' pretty-prints JSON spanning multiple lines;
-        '<template>' reports any value(s) of any result properties in any format
-        indicated by the template (e.g. '{path}'; compare with JSON
-        output for all key-value choices). The template syntax follows the Python
-        "format() language". It is possible to report individual
-        dictionary values, e.g. '{metadata[name]}'. If a 2nd-level key contains
-        a colon, e.g. 'music:Genre', ':' must be substituted by '#' in the template,
-        like so: '{metadata[music#Genre]}'. [Default: '%(default)s']""")
+        metavar="{generic,json,json_pp,tailored,disabled,'<template>'}",
+        help=eval_params['result_renderer']._doc + " [Default: '%(default)s']")
     parser.add_argument(
         '--report-status', dest='common_report_status',
         choices=['success', 'failure', 'ok', 'notneeded', 'impossible', 'error'],

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -113,7 +113,7 @@ def mk_push_target(ds, name, path, annex=True, bare=True):
                     where='local')
     else:
         target = GitRepo(path=path, bare=bare, create=True)
-    ds.siblings('add', name=name, url=path, result_renderer=None)
+    ds.siblings('add', name=name, url=path, result_renderer='disabled')
     if annex and not bare and target.is_managed_branch():
         # maximum complication
         # the target repo already has a commit that is unrelated
@@ -594,7 +594,7 @@ def test_gh1763(src, target1, target2):
     target1 = mk_push_target(src, 'target1', target1, bare=False)
     target2 = mk_push_target(src, 'target2', target2, bare=False)
     src.siblings('configure', name='target2', publish_depends='target1',
-                 result_renderer=None)
+                 result_renderer='disabled')
     # a file to annex
     (src.pathobj / 'probe1').write_text('probe1')
     src.save('probe1', to_git=False)

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -29,7 +29,7 @@ from datalad.distribution.install import Install
 from datalad.interface.unlock import Unlock
 
 from datalad.interface.base import Interface
-from datalad.interface.utils import default_result_renderer
+from datalad.interface.utils import generic_result_renderer
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
@@ -288,7 +288,7 @@ class Run(Interface):
             else:
                 raise ValueError(f"Unknown dry-run mode: {dry_run!r}")
         else:
-            default_result_renderer(res)
+            generic_result_renderer(res)
 
 
 def _display_basic(res):

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -165,17 +165,17 @@ def test_diff(path, norepo):
     assert_repo_status(ds.path)
     # reports stupid revision input
     assert_result_count(
-        ds.diff(fr='WTF', on_failure='ignore', result_renderer=None),
+        ds.diff(fr='WTF', on_failure='ignore', result_renderer='disabled'),
         1,
         status='impossible',
         message="Git reference 'WTF' invalid")
     # no diff
-    assert_result_count(_dirty_results(ds.diff(result_renderer=None)), 0)
+    assert_result_count(_dirty_results(ds.diff(result_renderer='disabled')), 0)
     assert_result_count(
-        _dirty_results(ds.diff(fr='HEAD', result_renderer=None)), 0)
+        _dirty_results(ds.diff(fr='HEAD', result_renderer='disabled')), 0)
     # bogus path makes no difference
     assert_result_count(
-        _dirty_results(ds.diff(path='THIS', fr='HEAD', result_renderer=None)),
+        _dirty_results(ds.diff(path='THIS', fr='HEAD', result_renderer='disabled')),
         0)
     # let's introduce a known change
     create_tree(ds.path, {'new': 'empty'})
@@ -189,7 +189,7 @@ def test_diff(path, norepo):
         fr_base = "HEAD"
         to = None
 
-    res = _dirty_results(ds.diff(fr=fr_base + '~1', to=to, result_renderer=None))
+    res = _dirty_results(ds.diff(fr=fr_base + '~1', to=to, result_renderer='disabled'))
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, action='diff', path=op.join(ds.path, 'new'), state='added')
@@ -197,59 +197,59 @@ def test_diff(path, norepo):
     with chpwd(ds.path):
         assert_result_count(
             _dirty_results(diff(fr=fr_base + '~1', to=to,
-                                result_renderer=None)),
+                                result_renderer='disabled')),
             1,
             action='diff', path=op.join(ds.path, 'new'), state='added')
     # no diff against HEAD
-    assert_result_count(_dirty_results(ds.diff(result_renderer=None)), 0)
+    assert_result_count(_dirty_results(ds.diff(result_renderer='disabled')), 0)
     # modify known file
     create_tree(ds.path, {'new': 'notempty'})
-    res = _dirty_results(ds.diff(result_renderer=None))
+    res = _dirty_results(ds.diff(result_renderer='disabled'))
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, action='diff', path=op.join(ds.path, 'new'),
         state='modified')
     # but if we give another path, it doesn't show up
-    assert_result_count(ds.diff(path='otherpath', result_renderer=None), 0)
+    assert_result_count(ds.diff(path='otherpath', result_renderer='disabled'), 0)
     # giving the right path must work though
     assert_result_count(
-        ds.diff(path='new', result_renderer=None), 1,
+        ds.diff(path='new', result_renderer='disabled'), 1,
         action='diff', path=op.join(ds.path, 'new'), state='modified')
     # stage changes
     ds.repo.add('.', git=True)
     # no change in diff, staged is not committed
-    assert_result_count(_dirty_results(ds.diff(result_renderer=None)), 1)
+    assert_result_count(_dirty_results(ds.diff(result_renderer='disabled')), 1)
     ds.save()
     assert_repo_status(ds.path)
-    assert_result_count(_dirty_results(ds.diff(result_renderer=None)), 0)
+    assert_result_count(_dirty_results(ds.diff(result_renderer='disabled')), 0)
 
     # untracked stuff
     create_tree(ds.path, {'deep': {'down': 'untracked', 'down2': 'tobeadded'}})
     # a plain diff should report the untracked file
     # but not directly, because the parent dir is already unknown
-    res = _dirty_results(ds.diff(result_renderer=None))
+    res = _dirty_results(ds.diff(result_renderer='disabled'))
     assert_result_count(res, 1)
     assert_result_count(
         res, 1, state='untracked', type='directory',
         path=op.join(ds.path, 'deep'))
     # report of individual files is also possible
     assert_result_count(
-        ds.diff(untracked='all', result_renderer=None), 2, state='untracked',
+        ds.diff(untracked='all', result_renderer='disabled'), 2, state='untracked',
         type='file')
     # an unmatching path will hide this result
-    assert_result_count(ds.diff(path='somewhere', result_renderer=None), 0)
+    assert_result_count(ds.diff(path='somewhere', result_renderer='disabled'), 0)
     # perfect match and anything underneath will do
     assert_result_count(
-        ds.diff(path='deep', result_renderer=None), 1, state='untracked',
+        ds.diff(path='deep', result_renderer='disabled'), 1, state='untracked',
         path=op.join(ds.path, 'deep'),
         type='directory')
     assert_result_count(
-        ds.diff(path='deep', result_renderer=None), 1,
+        ds.diff(path='deep', result_renderer='disabled'), 1,
         state='untracked', path=op.join(ds.path, 'deep'))
     ds.repo.add(op.join('deep', 'down2'), git=True)
     # now the remaining file is the only untracked one
     assert_result_count(
-        ds.diff(result_renderer=None), 1, state='untracked',
+        ds.diff(result_renderer='disabled'), 1, state='untracked',
         path=op.join(ds.path, 'deep', 'down'),
         type='file')
 
@@ -260,12 +260,12 @@ def test_diff_recursive(path):
     sub = ds.create('sub')
     # look at the last change, and confirm a dataset was added
     res = ds.diff(fr=DEFAULT_BRANCH + '~1', to=DEFAULT_BRANCH,
-                  result_renderer=None)
+                  result_renderer='disabled')
     assert_result_count(
         res, 1, action='diff', state='added', path=sub.path, type='dataset')
     # now recursive
     res = ds.diff(recursive=True, fr=DEFAULT_BRANCH + '~1', to=DEFAULT_BRANCH,
-                  result_renderer=None)
+                  result_renderer='disabled')
     # we also get the entire diff of the subdataset from scratch
     assert_status('ok', res)
     ok_(len(res) > 3)
@@ -278,7 +278,7 @@ def test_diff_recursive(path):
     create_tree(
         ds.path,
         {'onefile': 'tobeadded', 'sub': {'twofile': 'tobeadded'}})
-    res = ds.diff(recursive=True, untracked='all', result_renderer=None)
+    res = ds.diff(recursive=True, untracked='all', result_renderer='disabled')
     assert_result_count(_dirty_results(res), 3)
     assert_result_count(
         res, 1,
@@ -300,7 +300,7 @@ def test_diff_recursive(path):
 
     # look at the last change, only one file was added
     res = ds.diff(fr=head_ref + '~1', to=head_ref, annex='basic',
-                  result_renderer=None)
+                  result_renderer='disabled')
     assert_result_count(_dirty_results(res), 1)
     assert_result_count(
         res, 1,
@@ -310,7 +310,7 @@ def test_diff_recursive(path):
     # now the exact same thing with recursion, must not be different from the
     # call above
     res = ds.diff(recursive=True, fr=head_ref + '~1', to=head_ref,
-                  annex='basic', result_renderer=None)
+                  annex='basic', result_renderer='disabled')
     assert_result_count(_dirty_results(res), 1)
     # last change in parent
     assert_result_count(
@@ -323,7 +323,7 @@ def test_diff_recursive(path):
     # one further back brings in the modified subdataset, and the added file
     # within it
     res = ds.diff(recursive=True, fr=head_ref + '~2', to=head_ref,
-                  annex='basic', result_renderer=None)
+                  annex='basic', result_renderer='disabled')
     assert_result_count(_dirty_results(res), 3)
     assert_result_count(
         res, 1,
@@ -357,7 +357,7 @@ def test_path_diff(_path, linkpath):
     if has_symlink_capability():
         assert ds.pathobj != ds.repo.pathobj
 
-    plain_recursive = ds.diff(recursive=True, annex='all', result_renderer=None)
+    plain_recursive = ds.diff(recursive=True, annex='all', result_renderer='disabled')
     # check integrity of individual reports with a focus on how symlinks
     # are reported
     for res in plain_recursive:
@@ -376,26 +376,26 @@ def test_path_diff(_path, linkpath):
     # bunch of smoke tests
     # query of '.' is same as no path
     eq_(plain_recursive, ds.diff(path='.', recursive=True, annex='all',
-                                 result_renderer=None))
+                                 result_renderer='disabled'))
     # duplicate paths do not change things
     eq_(plain_recursive, ds.diff(path=['.', '.'], recursive=True, annex='all',
-                                 result_renderer=None))
+                                 result_renderer='disabled'))
     # neither do nested paths
     if not "2.24.0" <= ds.repo.git_version < "2.25.0":
         # Release 2.24.0 contained a regression that was fixed with 072a231016
         # (2019-12-10).
         eq_(plain_recursive,
             ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all',
-                    result_renderer=None))
+                    result_renderer='disabled'))
     # when invoked in a subdir of a dataset it still reports on the full thing
     # just like `git status`, as long as there are no paths specified
     with chpwd(op.join(path, 'directory_untracked')):
         plain_recursive = diff(recursive=True, annex='all',
-                               result_renderer=None)
+                               result_renderer='disabled')
     # should be able to take absolute paths and yield the same
     # output
     eq_(plain_recursive, ds.diff(path=ds.path, recursive=True, annex='all',
-                                 result_renderer=None))
+                                 result_renderer='disabled'))
 
     # query for a deeply nested path from the top, should just work with a
     # variety of approaches
@@ -411,12 +411,12 @@ def test_path_diff(_path, linkpath):
                 res = ds.diff(
                     path=op.join('.', rpath),
                     recursive=True,
-                    annex='all', result_renderer=None)
+                    annex='all', result_renderer='disabled')
         else:
             res = ds.diff(
                 path=p,
                 recursive=True,
-                annex='all', result_renderer=None)
+                annex='all', result_renderer='disabled')
         assert_result_count(
             res,
             1,
@@ -429,20 +429,20 @@ def test_path_diff(_path, linkpath):
 
     assert_result_count(
         ds.diff(
-            recursive=True, result_renderer=None),
+            recursive=True, result_renderer='disabled'),
         1,
         path=apath)
     # limiting recursion will exclude this particular path
     assert_result_count(
         ds.diff(
             recursive=True,
-            recursion_limit=1, result_renderer=None),
+            recursion_limit=1, result_renderer='disabled'),
         0,
         path=apath)
     # negative limit is unlimited limit
     eq_(
-        ds.diff(recursive=True, recursion_limit=-1, result_renderer=None),
-        ds.diff(recursive=True, result_renderer=None)
+        ds.diff(recursive=True, recursion_limit=-1, result_renderer='disabled'),
+        ds.diff(recursive=True, result_renderer='disabled')
     )
 
 
@@ -451,13 +451,13 @@ def test_path_diff(_path, linkpath):
 def test_diff_nods(path, otherpath):
     ds = Dataset(path).create()
     assert_result_count(
-        ds.diff(path=otherpath, on_failure='ignore', result_renderer=None),
+        ds.diff(path=otherpath, on_failure='ignore', result_renderer='disabled'),
         1,
         status='error',
         message='path not underneath this dataset')
     otherds = Dataset(otherpath).create()
     assert_result_count(
-        ds.diff(path=otherpath, on_failure='ignore', result_renderer=None),
+        ds.diff(path=otherpath, on_failure='ignore', result_renderer='disabled'),
         1,
         path=otherds.path,
         status='error',
@@ -473,13 +473,13 @@ def test_diff_rsync_syntax(path):
     ds = Dataset(path).create()
     subds = ds.create('sub')
     subsubds = subds.create(Path('subdir', 'deep'))
-    justtop = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub', result_renderer=None)
+    justtop = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub', result_renderer='disabled')
     # we only get a single result, the subdataset in question
     assert_result_count(justtop, 1)
     assert_result_count(justtop, 1, type='dataset', path=subds.path)
     # now with "peak inside the dataset" syntax
     inside = ds.diff(fr=PRE_INIT_COMMIT_SHA, path='sub' + os.sep,
-                     result_renderer=None)
+                     result_renderer='disabled')
     # we get both subdatasets, but nothing else inside the nested one
     assert_result_count(inside, 2, type='dataset')
     assert_result_count(inside, 1, type='dataset', path=subds.path)
@@ -490,7 +490,7 @@ def test_diff_rsync_syntax(path):
     # subds, but because the subsubds is still underneath it, nothing changes
     inside_subdir = ds.diff(
         fr=PRE_INIT_COMMIT_SHA, path=op.join('sub', 'subdir'),
-        result_renderer=None)
+        result_renderer='disabled')
     assert_result_count(inside_subdir, 2, type='dataset')
     assert_result_count(inside_subdir, 1, type='dataset', path=subds.path)
     assert_result_count(inside_subdir, 1, type='dataset', path=subsubds.path)
@@ -499,7 +499,7 @@ def test_diff_rsync_syntax(path):
     neq_(inside, inside_subdir)
     # just for completeness, we get more when going full recursive
     rec = ds.diff(fr=PRE_INIT_COMMIT_SHA, recursive=True, path='sub' + os.sep,
-                  result_renderer=None)
+                  result_renderer='disabled')
     assert(len(inside) < len(rec))
 
 
@@ -507,7 +507,7 @@ def test_diff_rsync_syntax(path):
 def test_diff_nonexistent_ref_unicode(path):
     ds = Dataset(path).create()
     assert_result_count(
-        ds.diff(fr="HEAD", to=u"β", on_failure="ignore", result_renderer=None),
+        ds.diff(fr="HEAD", to=u"β", on_failure="ignore", result_renderer='disabled'),
         1,
         path=ds.path,
         status="impossible")
@@ -529,7 +529,7 @@ def test_no_worktree_impact_false_deletions(path):
     # identifical
     ds.repo.call_git(['checkout', 'test'])
     res = ds.diff(fr=DEFAULT_BRANCH + '~1', to=DEFAULT_BRANCH,
-                  result_renderer=None)
+                  result_renderer='disabled')
     # under no circumstances can there be any reports on deleted files
     # because we never deleted anything
     assert_result_count(res, 0, state='deleted')
@@ -551,5 +551,5 @@ def test_diff_fr_none_one_get_content_annexinfo_call(path):
     # get_content_annexinfo() is expensive.  If fr=None, we should
     # only need to call it once.
     with patch.object(AnnexRepo, "get_content_annexinfo") as gca:
-        res = ds.diff(fr=None, to="HEAD", annex="all", result_renderer=None)
+        res = ds.diff(fr=None, to="HEAD", annex="all", result_renderer='disabled')
         eq_(gca.call_count, 1)

--- a/datalad/core/local/tests/test_results.py
+++ b/datalad/core/local/tests/test_results.py
@@ -16,11 +16,11 @@ from datalad.tests.utils import (
     swallow_outputs,
 )
 from datalad.interface.utils import (
-    default_result_renderer,
+    generic_result_renderer,
 )
 
 
-def test_default_result_renderer():
+def test_generic_result_renderer():
     # a bunch of bad cases of results
     testcases = [
         # an empty result will surface
@@ -51,6 +51,6 @@ def test_default_result_renderer():
         ])
     for result, contenttests in testcases:
         with swallow_outputs() as cmo:
-            default_result_renderer(result)
+            generic_result_renderer(result)
             for ctest in contenttests:
                 assert_in(ctest, cmo.out)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -544,7 +544,7 @@ def test_run_remove_keeps_leading_directory(path):
 
     assert_in_results(
         ds.run("cd .> {}".format(output_rel), outputs=[output_rel],
-               result_renderer=None),
+               result_renderer='disabled'),
         action="run.remove", status="ok")
 
     assert_repo_status(ds.path)
@@ -554,7 +554,7 @@ def test_run_remove_keeps_leading_directory(path):
     repo.drop(output_rel, options=["--force"])
     assert_in_results(
         ds.run("cd .> something-else", outputs=[output_rel],
-               result_renderer=None),
+               result_renderer='disabled'),
         action="run.remove", status="ok")
     assert_repo_status(ds.path)
 

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -356,7 +356,7 @@ class CreateSiblingRia(Interface):
             # even if we have to fail, let's report all conflicting siblings
             # in subdatasets
             failed = False
-            for r in ds.siblings(result_renderer=None,
+            for r in ds.siblings(result_renderer='disabled',
                                  recursive=recursive,
                                  recursion_limit=recursion_limit):
                 log_progress(
@@ -523,7 +523,7 @@ def _create_sibling_ria(
     # determine layout locations; go for a v1 store-level layout
     repo_path, _, _ = get_layout_locations(1, base_path, ds.id)
 
-    ds_siblings = [r['name'] for r in ds.siblings(result_renderer=None)]
+    ds_siblings = [r['name'] for r in ds.siblings(result_renderer='disabled')]
     # Figure whether we are supposed to skip this very dataset
     if existing == 'skip' and (
             name in ds_siblings or (
@@ -742,7 +742,7 @@ def _create_sibling_ria(
         recursive=False,
         # Note, that this should be None if storage_sibling was not set
         publish_depends=storage_name,
-        result_renderer=None,
+        result_renderer='disabled',
         # Note, that otherwise a subsequent publish will report
         # "notneeded".
         fetch=True

--- a/datalad/distributed/tests/test_create_sibling_ghlike.py
+++ b/datalad/distributed/tests/test_create_sibling_ghlike.py
@@ -47,7 +47,7 @@ def test_invalid_call(path):
 
     # conflicting sibling name
     ds.siblings('add', name='gin', url='http://example.com',
-                result_renderer=None)
+                result_renderer='disabled')
     res = ds.create_sibling_gin(
         'bogus', name='gin', credential='some', on_failure='ignore',
         dry_run=True)
@@ -137,7 +137,7 @@ def check4real(testcmd, testdir, credential, api, delete_endpoint):
             name='ghlike-sibling',
         )
         # now do it again
-        ds.siblings('remove', name='ghlike-sibling', result_renderer=None)
+        ds.siblings('remove', name='ghlike-sibling', result_renderer='disabled')
         res = testcmd(
             reponame, dataset=ds, api=api, credential=credential,
             on_failure='ignore')

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -107,12 +107,12 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     eq_(len(res), 1)
 
     # remotes exist, but only in super
-    siblings = ds.siblings(result_renderer=None)
+    siblings = ds.siblings(result_renderer='disabled')
     eq_({'datastore', 'datastore-storage', 'here'},
         {s['name'] for s in siblings})
-    sub_siblings = subds.siblings(result_renderer=None)
+    sub_siblings = subds.siblings(result_renderer='disabled')
     eq_({'here'}, {s['name'] for s in sub_siblings})
-    sub2_siblings = subds2.siblings(result_renderer=None)
+    sub2_siblings = subds2.siblings(result_renderer='disabled')
     eq_({'here'}, {s['name'] for s in sub2_siblings})
 
     # check bare repo:
@@ -166,14 +166,14 @@ def _test_create_store(host, base_path, ds_path, clone_path):
     assert_result_count(res, 1, path=str(subds2.pathobj), status='ok', action="create-sibling-ria")
 
     # remotes now exist in super and sub
-    siblings = ds.siblings(result_renderer=None)
+    siblings = ds.siblings(result_renderer='disabled')
     eq_({'datastore', 'datastore-storage', 'here'},
         {s['name'] for s in siblings})
-    sub_siblings = subds.siblings(result_renderer=None)
+    sub_siblings = subds.siblings(result_renderer='disabled')
     eq_({'datastore', 'datastore-storage', 'here'},
         {s['name'] for s in sub_siblings})
     # but no special remote in plain git subdataset:
-    sub2_siblings = subds2.siblings(result_renderer=None)
+    sub2_siblings = subds2.siblings(result_renderer='disabled')
     eq_({'datastore', 'here'},
         {s['name'] for s in sub2_siblings})
 
@@ -327,7 +327,7 @@ def test_storage_only(base_path, ds_path):
     eq_(len(res), 1)
 
     # the storage sibling uses the main name, not -storage
-    siblings = ds.siblings(result_renderer=None)
+    siblings = ds.siblings(result_renderer='disabled')
     eq_({'datastore', 'here'},
         {s['name'] for s in siblings})
 
@@ -353,14 +353,14 @@ def test_no_storage(store1, store2, ds_path):
                                 new_store_ok=True)
     assert_result_count(res, 1, status='ok', action='create-sibling-ria')
     eq_({'datastore1', 'here'},
-        {s['name'] for s in ds.siblings(result_renderer=None)})
+        {s['name'] for s in ds.siblings(result_renderer='disabled')})
 
     # deprecated way of disabling storage still works
     res = ds.create_sibling_ria(store2_url, "datastore2",
                                 disable_storage__=True, new_store_ok=True)
     assert_result_count(res, 1, status='ok', action='create-sibling-ria')
     eq_({'datastore2', 'datastore1', 'here'},
-        {s['name'] for s in ds.siblings(result_renderer=None)})
+        {s['name'] for s in ds.siblings(result_renderer='disabled')})
 
     # smoke test that we can push to it
     res = ds.push(to='datastore1')

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -343,7 +343,7 @@ def _create_dataset_sibling(
         annex_group=annex_group,
         annex_groupwanted=annex_groupwanted,
         inherit=inherit,
-        result_renderer=None,
+        result_renderer='disabled',
     )
 
     # check git version on remote end
@@ -681,7 +681,7 @@ class CreateSibling(Interface):
                             recursive=recursive,
                             recursion_limit=recursion_limit,
                             fulfilled=True,
-                            result_renderer=None)
+                            result_renderer='disabled')
                     ],
                     # save cycles, we are only looking for datasets
                     annex=None,

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -42,7 +42,7 @@ from datalad.interface.common_opts import (
 )
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import (
-    default_result_renderer,
+    generic_result_renderer,
     eval_results,
 )
 from datalad.support.annexrepo import AnnexRepo
@@ -332,7 +332,7 @@ class Siblings(Interface):
             )
             return
         if res['status'] != 'ok' or not res.get('action', '').endswith('-sibling') :
-            default_result_renderer(res)
+            generic_result_renderer(res)
             return
         path = op.relpath(res['path'],
                        res['refds']) if res.get('refds', None) else res['path']

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -705,7 +705,7 @@ def test_get_relays_command_errors(path):
     ds.save()
     ds.drop("foo", check=False)
     assert_result_count(
-        ds.get("foo", on_failure="ignore", result_renderer=None),
+        ds.get("foo", on_failure="ignore", result_renderer='disabled'),
         1, action="get", type="file", status="error")
 
 

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -81,7 +81,7 @@ def test_siblings(origin, repo_path, local_clone_path):
         url=httpurl1,
         publish_depends=['r1', 'r2'],
         on_failure='ignore',
-        result_renderer=None)
+        result_renderer='disabled')
     assert_status('error', res)
     eq_(res[0]['message'],
         ('unknown sibling(s) specified as publication dependency: %s',
@@ -93,7 +93,7 @@ def test_siblings(origin, repo_path, local_clone_path):
                    dataset=source, name="test-remote",
                    url=httpurl1,
                    result_xfm='paths',
-                   result_renderer=None)
+                   result_renderer='disabled')
 
     eq_(res, [source.path])
     assert_in("test-remote", source.repo.get_remotes())
@@ -103,18 +103,18 @@ def test_siblings(origin, repo_path, local_clone_path):
     # reconfiguring doesn't change anything
     siblings('configure', dataset=source, name="test-remote",
              url=httpurl1,
-             result_renderer=None)
+             result_renderer='disabled')
     assert_in("test-remote", source.repo.get_remotes())
     eq_(httpurl1,
         source.repo.get_remote_url("test-remote"))
     # re-adding doesn't work
     res = siblings('add', dataset=source, name="test-remote",
                    url=httpurl1, on_failure='ignore',
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_status('error', res)
     # only after removal
     res = siblings('remove', dataset=source, name="test-remote",
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_status('ok', res)
     assert_not_in("test-remote", source.repo.get_remotes())
     # remove again (with result renderer to smoke-test a renderer
@@ -124,7 +124,7 @@ def test_siblings(origin, repo_path, local_clone_path):
 
     res = siblings('add', dataset=source, name="test-remote",
                    url=httpurl1, on_failure='ignore',
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_status('ok', res)
 
     # add another remove with a publication dependency
@@ -138,7 +138,7 @@ def test_siblings(origin, repo_path, local_clone_path):
                    publish_depends='test-remote',
                    # just for smoke testing
                    publish_by_default=DEFAULT_BRANCH,
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_status('ok', res)
     # config replaced with new setup
     #source.config.reload(force=True)
@@ -149,7 +149,7 @@ def test_siblings(origin, repo_path, local_clone_path):
     # and being in the dataset directory
     with chpwd(source.path):
         res = siblings('add', url=httpurl2,
-                       result_renderer=None)
+                       result_renderer='disabled')
     assert_result_count(
         res, 1,
         name="remote2.example.com", type='sibling')
@@ -159,7 +159,7 @@ def test_siblings(origin, repo_path, local_clone_path):
     res = siblings('configure',
                    dataset=source, name="test-remote",
                    url=httpurl1 + "/elsewhere",
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_status('ok', res)
     eq_(httpurl1 + "/elsewhere",
         source.repo.get_remote_url("test-remote"))
@@ -189,7 +189,7 @@ def test_siblings(origin, repo_path, local_clone_path):
                    dataset=source, name="test-remote",
                    url=httpurl1 + "/elsewhere",
                    pushurl=sshurl,
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_status('ok', res)
     eq_(httpurl1 + "/elsewhere",
         source.repo.get_remote_url("test-remote"))
@@ -227,7 +227,7 @@ def test_siblings(origin, repo_path, local_clone_path):
             # we need to disable annex queries, as it will try to access
             # the fake URL configured above
             get_annex_info=False,
-            result_renderer=None):
+            result_renderer='disabled'):
         repo = GitRepo(r['path'], create=False)
         assert_in("test-remote-2", repo.get_remotes())
         url = repo.get_remote_url("test-remote-2")
@@ -261,7 +261,7 @@ def test_siblings(origin, repo_path, local_clone_path):
             # we need to disable annex queries, as it will try to access
             # the fake URL configured above
             get_annex_info=False,
-            result_renderer=None):
+            result_renderer='disabled'):
         repo = GitRepo(r['path'], create=False)
         assert_in("test-remote-3", repo.get_remotes())
         url = repo.get_remote_url("test-remote-3")
@@ -284,7 +284,7 @@ def test_here(path):
     res = ds.siblings(
         'query',
         on_failure='ignore',
-        result_renderer=None)
+        result_renderer='disabled')
     assert_status('ok', res)
     assert_result_count(res, 1)
     assert_result_count(res, 1, name='here')
@@ -299,7 +299,7 @@ def test_here(path):
         'query',
         name='notthere',
         on_failure='ignore',
-        result_renderer=None)
+        result_renderer='disabled')
     assert_status('error', res)
 
     # set a description
@@ -308,7 +308,7 @@ def test_here(path):
         name='here',
         description='very special',
         on_failure='ignore',
-        result_renderer=None)
+        result_renderer='disabled')
     assert_status('ok', res)
     assert_result_count(res, 1)
     assert_result_count(res, 1, name='here')
@@ -336,14 +336,14 @@ def test_no_annex(path):
         name='here',
         description='very special',
         on_failure='ignore',
-        result_renderer=None)
+        result_renderer='disabled')
     assert_status('impossible', res)
 
     res = ds.siblings(
         'enable',
         name='doesnotmatter',
         on_failure='ignore',
-        result_renderer=None)
+        result_renderer='disabled')
     assert_in_results(
         res, status='impossible',
         message='cannot enable sibling of non-annex dataset')
@@ -413,7 +413,7 @@ def test_sibling_enable_sameas(repo, clone_path):
     # does not work without a name
     res = ds_cloned.siblings(
         action="enable",
-        result_renderer=None,
+        result_renderer='disabled',
         on_failure='ignore',
     )
     assert_in_results(
@@ -422,7 +422,7 @@ def test_sibling_enable_sameas(repo, clone_path):
     res = ds_cloned.siblings(
         action="enable",
         name='wrong',
-        result_renderer=None,
+        result_renderer='disabled',
         on_failure='ignore',
     )
     assert_in_results(
@@ -443,16 +443,16 @@ def test_sibling_inherit(basedir):
     # In superdataset, set up remote "source" that has git-annex group "grp".
     ds_super = Dataset(opj(basedir, "super")).create()
     ds_super.siblings(action="add", name="source", url=ds_source.path,
-                      annex_group="grp", result_renderer=None)
+                      annex_group="grp", result_renderer='disabled')
 
     ds_clone = ds_super.clone(
         source=ds_source.path, path="clone")
     # In a subdataset, adding a "source" sibling with inherit=True pulls in
     # that configuration.
     ds_clone.siblings(action="add", name="source", url=ds_source.path,
-                      inherit=True, result_renderer=None)
+                      inherit=True, result_renderer='disabled')
     res = ds_clone.siblings(action="query", name="source",
-                            result_renderer=None)
+                            result_renderer='disabled')
     eq_(res[0]["annex-group"], "grp")
 
 
@@ -465,7 +465,7 @@ def test_sibling_inherit_no_super_remote(basedir):
     # Adding a sibling with inherit=True doesn't crash when the superdataset
     # doesn't have a remote `name`.
     ds_clone.siblings(action="add", name="donotexist", inherit=True,
-                      url=ds_source.path, result_renderer=None)
+                      url=ds_source.path, result_renderer='disabled')
 
 
 @with_tempfile(mkdir=True)
@@ -477,11 +477,11 @@ def test_sibling_path_is_posix(basedir, otherpath):
         action="add",
         name="donotexist",
         url=otherpath,
-        result_renderer=None)
+        result_renderer='disabled')
     res = ds_source.siblings(
         action="query",
         name="donotexist",
-        result_renderer=None,
+        result_renderer='disabled',
         return_type='item-or-list')
     # path URL should come out POSIX as if `git clone` had configured it for origin
     # https://github.com/datalad/datalad/issues/3972
@@ -529,7 +529,7 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
         name=DEFAULT_REMOTE,
         as_common_datasrc='mike',
         on_failure='ignore',
-        result_renderer=None,
+        result_renderer='disabled',
     )
     assert_in_results(
         res,
@@ -544,7 +544,7 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
         'configure',
         name=DEFAULT_REMOTE,
         as_common_datasrc='mike2',
-        result_renderer=None,
+        result_renderer='disabled',
     )
     assert_status('ok', res)
     # same thing should be possible by adding a fresh remote
@@ -553,7 +553,7 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
         name='fresh',
         url=url,
         as_common_datasrc='fresh-sr',
-        result_renderer=None,
+        result_renderer='disabled',
     )
     assert_status('ok', res)
 
@@ -574,7 +574,7 @@ def test_specialremote(dspath, remotepath):
     ds.repo.call_annex(
         ['initremote', 'myremote', 'type=directory',
          f'directory={remotepath}', 'encryption=none'])
-    res = ds.siblings('query', result_renderer=None)
+    res = ds.siblings('query', result_renderer='disabled')
     assert_in_results(
         res,
         **{'name': 'myremote',

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -762,14 +762,16 @@ class Interface(object):
             # that are tailored towards the the Python API
             kwargs['return_type'] = 'generator'
             kwargs['result_xfm'] = None
-            # allow commands to override the default, unless something other than
-            # default is requested
+            # allow commands to override the default, unless something other
+            # than the default 'tailored' is requested
             kwargs['result_renderer'] = \
-                args.common_output_format if args.common_output_format != 'tailored' \
-                else getattr(cls, 'result_renderer', 'default')
-            if '{' in args.common_output_format:
+                args.common_result_renderer \
+                if args.common_result_renderer != 'tailored' \
+                else getattr(cls, 'result_renderer', 'generic')
+            if '{' in args.common_result_renderer:
                 # stupid hack, could and should become more powerful
-                kwargs['result_renderer'] = DefaultOutputRenderer(args.common_output_format)
+                kwargs['result_renderer'] = DefaultOutputRenderer(
+                    args.common_result_renderer)
 
             if args.common_on_failure:
                 kwargs['on_failure'] = args.common_on_failure

--- a/datalad/interface/clean.py
+++ b/datalad/interface/clean.py
@@ -183,14 +183,14 @@ class Clean(Interface):
         # Don't render things like 'status' for clean-info messages -
         # seems rather meaningless.
 
-        from datalad.interface.utils import default_result_renderer
+        from datalad.interface.utils import generic_result_renderer
         import datalad.support.ansi_colors as ac
         from datalad.utils import Path
         from os import getcwd
 
         if res['action'] == 'clean':
             # default renderer is just fine
-            return default_result_renderer(res)
+            return generic_result_renderer(res)
         elif res['action'] != 'clean [dry-run]':
             # Result didn't come from within `clean`.
             # Should be handled elsewhere.
@@ -222,7 +222,7 @@ class Clean(Interface):
 
         else:
             # Any other status than 'ok' is reported the default way.
-            return default_result_renderer(res)
+            return generic_result_renderer(res)
 
     @staticmethod
     def custom_result_summary_renderer(results):

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -325,8 +325,23 @@ eval_params = dict(
         given.""",
         constraints=EnsureChoice(*list(known_result_xfms.keys())) | EnsureCallable() | EnsureNone()),
     result_renderer=Parameter(
-        doc="""format of return value rendering on stdout""",
-        constraints=EnsureChoice('default', 'json', 'json_pp', 'tailored') | EnsureNone()),
+        doc="""select rendering mode command results.
+        'tailored' enables a command-specific rendering style that is typically
+        tailored to human consumption, if there is one for a specific
+        command, or otherwise falls back on the the 'generic' result renderer;
+        'generic' renders each result in one line  with key info like action,
+        status, path, and an optional message);
+        'json' a complete JSON line serialization of the full result record;
+        'json_pp' like 'json', but pretty-printed spanning multiple lines;
+        'disabled' turns off result rendering entirely;
+        '<template>' reports any value(s) of any result properties in any
+        format indicated by the template (e.g. '{path}', compare with JSON
+        output for all key-value choices). The template syntax follows the
+        Python "format() language". It is possible to report individual
+        dictionary values, e.g. '{metadata[name]}'. If a 2nd-level key contains
+        a colon, e.g. 'music:Genre', ':' must be substituted by '#' in the
+        template, like so: '{metadata[music#Genre]}'.""",
+        default='tailored'),
     on_failure=Parameter(
         doc="""behavior to perform on failure: 'ignore' any failure is reported,
         but does not cause an exception; 'continue' if any failure occurs an

--- a/datalad/interface/rerun.py
+++ b/datalad/interface/rerun.py
@@ -697,7 +697,7 @@ def diff_revision(dataset, revision="HEAD"):
     diff = dataset.diff(recursive=True,
                         fr=fr, to=revision,
                         result_filter=changed,
-                        return_type='generator', result_renderer=None)
+                        return_type='generator', result_renderer='disabled')
     for r in diff:
         yield r
 

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -470,7 +470,7 @@ class RunProcedure(Interface):
     @staticmethod
     def custom_result_renderer(res, **kwargs):
         from datalad.ui import ui
-        from datalad.interface.utils import default_result_renderer
+        from datalad.interface.utils import generic_result_renderer
 
         if res['status'] != 'ok':
             # logging complained about this already
@@ -478,7 +478,7 @@ class RunProcedure(Interface):
 
         if 'procedure' not in res.get('action', ''):
             # it's not our business
-            default_result_renderer(res)
+            generic_result_renderer(res)
             return
 
         if kwargs.get('discover', None):
@@ -508,4 +508,4 @@ class RunProcedure(Interface):
             ))
 
         else:
-            default_result_renderer(res)
+            generic_result_renderer(res)

--- a/datalad/interface/tests/test_base.py
+++ b/datalad/interface/tests/test_base.py
@@ -49,7 +49,7 @@ def _args(**kwargs):
         # tests.
         **updated(
             dict(
-                common_output_format="default"
+                common_result_renderer="generic"
             ),
             kwargs
         )
@@ -102,7 +102,7 @@ def test_call_from_parser_default_args():
             eq_(kwargs['common_report_status'], None)
             eq_(kwargs['common_report_type'], None)
             # and even those we didn't pass
-            eq_(kwargs['common_output_format'], "default")
+            eq_(kwargs['common_result_renderer'], "generic")
             # with dissolution of _OLD_STYLE_COMMANDS yoh yet to find
             # a real interface which had return_type (defined in
             # eval_defaults and eval_params) but no @eval_results

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -17,6 +17,8 @@ from os.path import (
     exists,
     join as opj,
 )
+import re
+
 from datalad.tests.utils import (
     assert_dict_equal,
     assert_equal,
@@ -262,8 +264,8 @@ def test_eval_results_plus_build_doc():
     assert_in("It's a number", doc1)
 
     # docstring shows correct override values of defaults in eval_params
-    assert_in("Default: 'tailored'", doc1)
-    assert_in("Default: 'item-or-list'", doc1)
+    assert_re_in("Default:\\s+'tailored'", doc1, match=False)
+    assert_re_in("Default:\\s+'item-or-list'", doc1, match=False)
 
     # docstring also contains eval_result's parameters:
     assert_in("result_filter", doc1)

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -32,7 +32,7 @@ from datalad.log import log_progress, with_result_progress
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.interface.utils import (
-    default_result_renderer,
+    generic_result_renderer,
     render_action_summary,
 )
 from datalad.interface.results import annexjson2result, get_status_dict
@@ -1572,7 +1572,7 @@ filename_format='{filenameformat}'"""
         refds = res.get("addurls.refds")
         if refds:
             res = dict(res, refds=refds)
-        default_result_renderer(res)
+        generic_result_renderer(res)
 
     custom_result_summary_renderer_pass_summary = True
 

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -16,7 +16,7 @@ import re
 import os
 
 from datalad.interface.base import Interface
-from datalad.interface.utils import default_result_renderer
+from datalad.interface.utils import generic_result_renderer
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
 from datalad.interface.results import get_status_dict
@@ -289,7 +289,7 @@ class Subdatasets(Interface):
 
     @staticmethod
     def custom_result_renderer(res, **kwargs):
-        default_result_renderer(res)
+        generic_result_renderer(res)
 
 
 # internal helper that needs all switches, simply to avoid going through

--- a/datalad/local/tests/test_addurls.py
+++ b/datalad/local/tests/test_addurls.py
@@ -354,7 +354,7 @@ def test_addurls_nonannex_repo(path):
     ds = Dataset(path).create(force=True, annex=False)
     with assert_raises(IncompleteResultsError) as raised:
         ds.addurls("dummy_arg0", "dummy_arg1", "dummy_arg2",
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_in("not an annex repo", str(raised.exception))
 
 
@@ -364,30 +364,30 @@ def test_addurls_unknown_placeholder(path):
     # Close but wrong URL placeholder
     with assert_raises(IncompleteResultsError) as exc:
         ds.addurls("in.csv", "{link}", "{abcd}", dry_run=True,
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_in("linky", str(exc.exception))
     # Close but wrong file name placeholder
     with assert_raises(IncompleteResultsError) as exc:
         ds.addurls("in.csv", "{linky}", "{abc}", dry_run=True,
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_in("abcd", str(exc.exception))
     # Out-of-bounds index.
     with assert_raises(IncompleteResultsError) as exc:
         ds.addurls("in.csv", "{linky}", "{3}", dry_run=True,
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_in("index", str(exc.exception))
 
     # Suggestions also work for automatic file name placeholders
     with assert_raises(IncompleteResultsError) as exc:
         ds.addurls("in.csv", "{linky}", "{_url_hostnam}", dry_run=True,
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_in("_url_hostname", str(exc.exception))
     # ... though if you whiff on the beginning prefix, we don't suggest
     # anything because we decide to generate those fields based on detecting
     # the prefix.
     with assert_raises(IncompleteResultsError) as exc:
         ds.addurls("in.csv", "{linky}", "{_uurl_hostnam}", dry_run=True,
-                   result_renderer=None)
+                   result_renderer='disabled')
     assert_not_in("_url_hostname", str(exc.exception))
 
 
@@ -408,7 +408,7 @@ def test_addurls_dry_run(path):
         ds.addurls(json_file,
                    "{url}",
                    "{subdir}//{_url_filename_root}",
-                   dry_run=True, result_renderer=None)
+                   dry_run=True, result_renderer='disabled')
 
         for dir_ in ["foo", "bar"]:
             assert_in("Would create a subdataset at {}".format(dir_),
@@ -486,7 +486,7 @@ class TestAddurls(object):
         json_file = op.relpath(self.json_file, ds.path)
 
         ds.addurls(json_file, "{url}", "{name}",
-                   exclude_autometa="(md5sum|size)", result_renderer=None)
+                   exclude_autometa="(md5sum|size)", result_renderer='disabled')
         ok_startswith(ds.repo.format_commit('%b', DEFAULT_BRANCH), f"url_file='{json_file}'")
 
         filenames = ["a", "b", "c"]
@@ -511,7 +511,7 @@ class TestAddurls(object):
         # Add to already existing links, overwriting.
         with swallow_logs(new_level=logging.DEBUG) as cml:
             ds.addurls(self.json_file, "{url}", "{name}",
-                       ifexists="overwrite", result_renderer=None)
+                       ifexists="overwrite", result_renderer='disabled')
             for fname in filenames:
                 assert_in("Removing {}".format(os.path.join(path, fname)),
                           cml.out)
@@ -519,12 +519,12 @@ class TestAddurls(object):
         # Add to already existing links, skipping.
         assert_in_results(
             ds.addurls(self.json_file, "{url}", "{name}", ifexists="skip",
-                       result_renderer=None),
+                       result_renderer='disabled'),
             action="addurls",
             status="notneeded")
 
         # Add to already existing links works, as long content is the same.
-        ds.addurls(self.json_file, "{url}", "{name}", result_renderer=None)
+        ds.addurls(self.json_file, "{url}", "{name}", result_renderer='disabled')
 
         # But it fails if something has changed.
         ds.unlock("a")
@@ -535,7 +535,7 @@ class TestAddurls(object):
         assert_raises(IncompleteResultsError,
                       ds.addurls,
                       self.json_file, "{url}", "{name}",
-                      result_renderer=None)
+                      result_renderer='disabled')
 
     @with_tempfile(mkdir=True)
     def test_addurls_unbound_dataset(self, path):
@@ -545,7 +545,7 @@ class TestAddurls(object):
             with chpwd(subdir):
                 shutil.copy(self.json_file, "in.json")
                 addurls(dataset_arg, url_file, "{url}", fname_format,
-                        result_renderer=None)
+                        result_renderer='disabled')
                 # Files specified in the CSV file are always relative to the
                 # dataset.
                 for fname in ["a", "b", "c"]:
@@ -568,14 +568,14 @@ class TestAddurls(object):
     def test_addurls_create_newdataset(self, path):
         dspath = os.path.join(path, "ds")
         addurls(dspath, self.json_file, "{url}", "{name}",
-                cfg_proc=["yoda"], result_renderer=None)
+                cfg_proc=["yoda"], result_renderer='disabled')
         for fname in ["a", "b", "c", "code"]:
             ok_exists(os.path.join(dspath, fname))
 
     @with_tempfile
     def test_addurls_from_list(self, path):
         ds = Dataset(path).create()
-        ds.addurls(self.data, "{url}", "{name}", result_renderer=None)
+        ds.addurls(self.data, "{url}", "{name}", result_renderer='disabled')
         for fname in ["a", "b", "c"]:
             ok_exists(op.join(path, fname))
 
@@ -626,7 +626,7 @@ class TestAddurls(object):
         # We don't try to recreate existing subdatasets.
         with swallow_logs(new_level=logging.DEBUG) as cml:
             ds.addurls(self.json_file, "{url}", "{subdir}-nosave//{name}",
-                       result_renderer=None)
+                       result_renderer='disabled')
             assert_in("Not creating subdataset at existing path", cml.out)
 
     @with_tempfile(mkdir=True)
@@ -635,11 +635,11 @@ class TestAddurls(object):
 
         with assert_raises(IncompleteResultsError) as raised:
             ds.addurls(self.json_file, "{url}", "{subdir}",
-                       result_renderer=None)
+                       result_renderer='disabled')
         assert_in("collided", str(raised.exception))
 
         ds.addurls(self.json_file, "{url}", "{subdir}-{_repindex}",
-                   result_renderer=None)
+                   result_renderer='disabled')
 
         for fname in ["foo-0", "bar-0", "foo-1"]:
             ok_exists(op.join(ds.path, fname))
@@ -708,7 +708,7 @@ class TestAddurls(object):
     def test_addurls_url_parts(self, path):
         ds = Dataset(path).create(force=True)
         ds.addurls(self.json_file, "{url}", "{_url0}/{_url_basename}",
-                   result_renderer=None)
+                   result_renderer='disabled')
 
         for fname in ["a.dat", "b.dat", "c.dat"]:
             ok_exists(op.join(ds.path, "udir", fname))
@@ -717,7 +717,7 @@ class TestAddurls(object):
     def test_addurls_url_filename(self, path):
         ds = Dataset(path).create(force=True)
         ds.addurls(self.json_file, "{url}", "{_url0}/{_url_filename}",
-                   result_renderer=None)
+                   result_renderer='disabled')
         for fname in ["a.dat", "b.dat", "c.dat"]:
             ok_exists(op.join(ds.path, "udir", fname))
 
@@ -729,21 +729,21 @@ class TestAddurls(object):
                       self.json_file,
                       "{url}/nofilename/",
                       "{_url0}/{_url_filename}",
-                      result_renderer=None)
+                      result_renderer='disabled')
 
     @with_tempfile(mkdir=True)
     def test_addurls_url_special_key_fail(self, path):
         ds = Dataset(path).create(force=True)
 
         res1 = ds.addurls(self.json_file, "{url}", "{_url4}/{_url_filename}",
-                          on_failure="ignore", result_renderer=None)
+                          on_failure="ignore", result_renderer='disabled')
         assert_in("Special key", res1[0]["message"])
 
         data = self.data.copy()[:1]
         data[0]["url"] = urlparse(data[0]["url"]).netloc
         with patch("sys.stdin", new=StringIO(json.dumps(data))):
             res2 = ds.addurls("-", "{url}", "{_url_basename}",
-                              on_failure="ignore", result_renderer=None)
+                              on_failure="ignore", result_renderer='disabled')
         assert_in("Special key", res2[0]["message"])
 
     @with_tempfile(mkdir=True)
@@ -760,14 +760,14 @@ class TestAddurls(object):
         with patch.object(ds.repo, 'set_metadata_', set_meta):
             with assert_raises(IncompleteResultsError):
                 ds.addurls(self.json_file, "{url}", "{name}",
-                           result_renderer=None)
+                           result_renderer='disabled')
 
     @with_tempfile(mkdir=True)
     def test_addurls_dropped_urls(self, path):
         ds = Dataset(path).create(force=True)
         with swallow_logs(new_level=logging.WARNING) as cml:
             ds.addurls(self.json_file, "", "{subdir}//{name}",
-                       result_renderer=None)
+                       result_renderer='disabled')
             assert_re_in(r".*Dropped [0-9]+ row\(s\) that had an empty URL",
                          str(cml.out))
 
@@ -783,7 +783,7 @@ class TestAddurls(object):
         with patch("datalad.local.addurls.get_versioned_url", version_fn):
             with swallow_logs(new_level=logging.WARNING) as cml:
                 ds.addurls(self.json_file, "{url}", "{name}",
-                           version_urls=True, result_renderer=None)
+                           version_urls=True, result_renderer='disabled')
                 assert_in("b.dat", str(cml.out))
 
         names = ["a", "c"]
@@ -801,7 +801,7 @@ class TestAddurls(object):
         ds.addurls(
             self.json_file, "{url}",
             "{subdir}//adir/{subdir}-again//other-ds//bdir/{name}",
-            jobs=3, result_renderer=None)
+            jobs=3, result_renderer='disabled')
         eq_(set(ds.subdatasets(recursive=True, result_xfm="relpaths")),
             {"foo",
              "bar",
@@ -819,7 +819,7 @@ class TestAddurls(object):
         for in_type in au.INPUT_TYPES:
             with assert_raises(IncompleteResultsError) as exc:
                 ds.addurls(in_file, "{url}", "{name}", input_type=in_type,
-                           result_renderer=None)
+                           result_renderer='disabled')
             assert_in("Failed to read", str(exc.exception))
 
     @with_tree({"in.csv": "url,name,subdir",
@@ -830,7 +830,7 @@ class TestAddurls(object):
         for fname in ["in.csv", "in.tsv", "in.json"]:
             with swallow_logs(new_level=logging.WARNING) as cml:
                 assert_in_results(
-                    ds.addurls(fname, "{url}", "{name}", result_renderer=None),
+                    ds.addurls(fname, "{url}", "{name}", result_renderer='disabled'),
                     action="addurls",
                     status="notneeded")
                 cml.assert_logged("No rows", regex=False)
@@ -840,7 +840,7 @@ class TestAddurls(object):
         ds = Dataset(path).create(force=True)
         with patch("sys.stdin", new=StringIO(input_text)):
             ds.addurls("-", "{url}", "{name}", input_type=input_type,
-                       result_renderer=None)
+                       result_renderer='disabled')
         for fname in ["a", "b", "c"]:
             ok_exists(op.join(ds.path, fname))
 
@@ -885,7 +885,7 @@ class TestAddurls(object):
         # make some files go to git, so we could test that we do not blow
         # while trying to drop what is in git not annex
         res = ds.addurls(self.json_file, '{url}', '{name}', drop_after=True,
-                         result_renderer=None)
+                         result_renderer='disabled')
 
         assert_result_count(res, 3, action='addurl', status='ok')  # a, b, c  even if a goes to git
         assert_result_count(res, 2, action='drop', status='ok')  # b, c
@@ -901,7 +901,7 @@ class TestAddurls(object):
             with assert_raises(IncompleteResultsError):
                 ds.addurls(self.json_file, "{url}", "{name}",
                            key=fmt, exclude_autometa="*",
-                           result_renderer=None)
+                           result_renderer='disabled')
 
     @with_tempfile(mkdir=True)
     def check_addurls_from_key(self, key_arg, expected_backend, fake_dates,
@@ -911,7 +911,7 @@ class TestAddurls(object):
             raise SkipTest("Adjusted branch functionality requires "
                            "more recent `git annex examinekey`")
         ds.addurls(self.json_file, "{url}", "{name}", exclude_autometa="*",
-                   key=key_arg, result_renderer=None)
+                   key=key_arg, result_renderer='disabled')
         repo = ds.repo
         repo_path = ds.repo.pathobj
         paths = [repo_path / x for x in "ac"]
@@ -922,7 +922,7 @@ class TestAddurls(object):
             eq_(pstat["backend"], expected_backend)
             assert_false(pstat["has_content"])
 
-        get_res = ds.get(paths, result_renderer=None, on_failure="ignore")
+        get_res = ds.get(paths, result_renderer='disabled', on_failure="ignore")
         assert_result_count(get_res, 2, action="get", status="ok")
 
     def test_addurls_from_key(self):
@@ -948,7 +948,7 @@ class TestAddurls(object):
                 break
         with patch("sys.stdin", new=StringIO(json.dumps(data))):
             ds.addurls("-", "{url}", "{name}", exclude_autometa="*",
-                       key="MD5-s{size}--{md5sum}", result_renderer=None)
+                       key="MD5-s{size}--{md5sum}", result_renderer='disabled')
 
         repo = ds.repo
         repo_path = ds.repo.pathobj

--- a/datalad/local/tests/test_copy_file.py
+++ b/datalad/local/tests/test_copy_file.py
@@ -250,7 +250,7 @@ def test_copy_file_into_dshierarchy(srcdir, destdir):
     # nested datasets
     eq_(*[
         sorted(
-            r for r in d.status(result_xfm='relpaths', result_renderer=None)
+            r for r in d.status(result_xfm='relpaths', result_renderer='disabled')
             # filter out subdataset entry in dest_ds
             if r not in ('lvl2', '.gitmodules'))
         for d in (src_ds, dest_ds)
@@ -303,7 +303,7 @@ def test_copy_file_specs_from(srcdir, destdir):
                  (r_srcabs, r_srcdestabs_str)):
         eq_(*[
             sorted(
-                r for r in d.status(result_xfm='relpaths', result_renderer=None))
+                r for r in d.status(result_xfm='relpaths', result_renderer='disabled'))
             for d in (a, b)
         ])
 

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -695,7 +695,7 @@ def _update_ds_agginfo(refds_path, ds_path, subds_paths, incremental, agginfo_db
             # TODO evaluate whether this should be exposed as a switch
             # to run an explicit force-drop prior to calling remove()
             check=False,
-            result_renderer=None, return_type=list)
+            result_renderer='disabled', return_type=list)
         if not objs2add and not refds_path == ds_path:
             # this is not the base dataset, make sure to save removal in the
             # parentds -- not needed when objects get added, as removal itself

--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -56,7 +56,7 @@ def duecredit_dataset(dataset):
         with swallow_logs(logging.ERROR) as cml:
             res = dataset.metadata(
                 reporton='datasets',  # Interested only in the dataset record
-                result_renderer=None,  # No need
+                result_renderer='disabled',  # No need
                 return_type='item-or-list'  # Expecting a single record
             )
     except Exception as exc:


### PR DESCRIPTION
The full story is in #6038

Concretely, this:

- documents the 'disabled' renderer mode
- strip supported for the undocumented datalad.api.result-renderer
  config setting
- homogeneous documentation for `--output-format` and `result_renderer`
- rename `default[_result_renderer]` to `generic[_result_renderer` to
  resolve the multi-level ambiguity of "default" for a renderer that,
  ironically, is not the default. Shims for legacy code are in place,
  and will likely never be removed
- replace internal usage of `output_format` with a consistent
  `result_renderer` for homogeneity. Command line API is kept unchanged
  though -- might be worth a follow-up discussion in a separate issue/PR
- discontinue the undocumented use of `result_renderer=None` and replaces
  it with `result_renderer='disabled'`

Fixes #6038