### PR TITLE
RM: (re)move get_func_kwargs_doc and some python2 compat code path

### DIFF
--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -50,7 +50,6 @@ from datalad.utils import (
     find_files,
     generate_chunks,
     get_dataset_root,
-    get_func_kwargs_doc,
     get_open_files,
     get_path_prefix,
     get_timestamp_suffix,
@@ -120,12 +119,6 @@ from .utils import (
     with_tree,
 )
 from datalad import cfg as dl_cfg
-
-
-def test_get_func_kwargs_doc():
-    def some_func(arg1, kwarg1=None, kwarg2="bu"):
-        return
-    eq_(get_func_kwargs_doc(some_func), ['arg1', 'kwarg1', 'kwarg2'])
 
 
 def test_better_wraps():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -164,25 +164,6 @@ else:
     getargspec = inspect.getargspec
 
 
-def get_func_kwargs_doc(func):
-    """ Provides args for a function
-
-    Parameters
-    ----------
-    func: str
-      name of the function from which args are being requested
-
-    Returns
-    -------
-    list
-      of the args that a function takes in
-    """
-    return getargspec(func)[0]
-
-    # TODO: format error message with descriptions of args
-    # return [repr(dict(get_docstring_split(func)[1]).get(x)) for x in getargspec(func)[0]]
-
-
 def any_re_search(regexes, value):
     """Return if any of regexes (list or str) searches successfully for value"""
     for regex in ensure_tuple_or_list(regexes):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -154,14 +154,14 @@ lgr.debug(
 #
 
 # `getargspec` has been deprecated in Python 3.
-if hasattr(inspect, "getfullargspec"):
-    ArgSpecFake = collections.namedtuple(
-        "ArgSpecFake", ["args", "varargs", "keywords", "defaults"])
+ArgSpecFake = collections.namedtuple(
+    "ArgSpecFake", ["args", "varargs", "keywords", "defaults"])
 
-    def getargspec(func):
-        return ArgSpecFake(*inspect.getfullargspec(func)[:4])
-else:
-    getargspec = inspect.getargspec
+
+def getargspec(func):
+    """Minimal compat shim for getargspec deprecated in python 3.
+    """
+    return ArgSpecFake(*inspect.getfullargspec(func)[:4])
 
 
 def any_re_search(regexes, value):


### PR DESCRIPTION
There might be more but largely orthogonal so decided to submit this short quick PR.

It is a companion to https://github.com/datalad/datalad-crawler/pull/113 which I marked for the release and just merged... https://pypi.org/project/datalad-crawler/ has 0.9.3 now

I didn't check other extensions if they use this elderly function -- will see with this PR