### PR TITLE
ENH/RF: Interface-s - add *  to explicitly separate posargs from kwargs

### DIFF
--- a/benchmarks/plugins/addurls.py
+++ b/benchmarks/plugins/addurls.py
@@ -57,7 +57,8 @@ class addurls1(SuprocBenchmarks):
     def time_addurls(self, exclude_autometa):
         lgr.warning("CSV: " + self.listfile.read_text())
         ret = dl.addurls(
-            self.ds, str(self.listfile), '{url}', '{filename}',
+            str(self.listfile), '{url}', '{filename}',
+            dataset=self.ds,
             exclude_autometa=exclude_autometa
         )
         assert not any(r['status'] == 'error' for r in ret)

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -244,6 +244,7 @@ class Clone(Interface):
     def __call__(
             source,
             path=None,
+            *,
             dataset=None,
             description=None,
             reckless=None,

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -244,11 +244,12 @@ class Clone(Interface):
     def __call__(
             source,
             path=None,
+            git_clone_opts=None,
             *,
             dataset=None,
             description=None,
             reckless=None,
-            git_clone_opts=None):
+        ):
         # did we explicitly get a dataset to install into?
         # if we got a dataset, path will be resolved against it.
         # Otherwise path will be resolved first.

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -182,6 +182,7 @@ class Push(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             to=None,
             since=None,

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -193,6 +193,7 @@ class Create(Interface):
     def __call__(
             path=None,
             initopts=None,
+            *,
             force=False,
             description=None,
             dataset=None,

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -120,6 +120,7 @@ class Diff(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             fr='HEAD',
             to=None,
             dataset=None,

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -268,6 +268,7 @@ class Run(Interface):
     @eval_results
     def __call__(
             cmd=None,
+            *,
             dataset=None,
             inputs=None,
             outputs=None,

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -165,7 +165,9 @@ class Save(Interface):
     @staticmethod
     @datasetmethod(name='save')
     @eval_results
-    def __call__(path=None, message=None, dataset=None,
+    def __call__(path=None,
+                 *,
+                 message=None, dataset=None,
                  version_tag=None,
                  recursive=False, recursion_limit=None,
                  updated=False,

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -360,6 +360,7 @@ class Status(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             annex=None,
             untracked='normal',

--- a/datalad/distributed/create_sibling_gin.py
+++ b/datalad/distributed/create_sibling_gin.py
@@ -113,6 +113,7 @@ class CreateSiblingGin(Interface):
     @eval_results
     def __call__(
             reponame,
+            *,
             dataset=None,
             recursive=False,
             recursion_limit=None,

--- a/datalad/distributed/create_sibling_gitea.py
+++ b/datalad/distributed/create_sibling_gitea.py
@@ -106,6 +106,7 @@ class CreateSiblingGitea(Interface):
     @eval_results
     def __call__(
             reponame,
+            *,
             dataset=None,
             recursive=False,
             recursion_limit=None,

--- a/datalad/distributed/create_sibling_github.py
+++ b/datalad/distributed/create_sibling_github.py
@@ -217,6 +217,7 @@ class CreateSiblingGithub(Interface):
     @eval_results
     def __call__(
             reponame,
+            *,
             dataset=None,
             recursive=False,
             recursion_limit=None,

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -209,6 +209,7 @@ class CreateSiblingGitlab(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             site=None,
             project=None,
             layout=None,

--- a/datalad/distributed/create_sibling_gogs.py
+++ b/datalad/distributed/create_sibling_gogs.py
@@ -75,6 +75,7 @@ class CreateSiblingGogs(Interface):
     @eval_results
     def __call__(
             reponame,
+            *,
             # possibly retrieve a default from config
             api=None,
             dataset=None,

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -259,7 +259,8 @@ class CreateSiblingRia(Interface):
     @datasetmethod(name='create_sibling_ria')
     @eval_results
     def __call__(url,
-                 name,
+                 name=None,
+                 *,  # note that `name` is required but not posarg in CLI
                  dataset=None,
                  storage_name=None,
                  alias=None,

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -259,7 +259,7 @@ class CreateSiblingRia(Interface):
     @datasetmethod(name='create_sibling_ria')
     @eval_results
     def __call__(url,
-                 name=None,
+                 name,
                  *,  # note that `name` is required but not posarg in CLI
                  dataset=None,
                  storage_name=None,

--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -167,6 +167,7 @@ class Drop(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             what='filecontent',
             reckless=None,
             dataset=None,

--- a/datalad/distributed/export_archive_ora.py
+++ b/datalad/distributed/export_archive_ora.py
@@ -120,6 +120,7 @@ class ExportArchiveORA(Interface):
     def __call__(
             target,
             opts=None,
+            *,  # opts is positional but optional in CLI
             dataset=None,
             remote=None,
             annex_wanted=None,

--- a/datalad/distributed/export_to_figshare.py
+++ b/datalad/distributed/export_to_figshare.py
@@ -248,7 +248,10 @@ class ExportToFigshare(Interface):
     @datasetmethod(name='export_to_figshare')
     @eval_results
     # TODO*: yet another former plugin with dataset first -- do we need that???
-    def __call__(dataset, filename=None, missing_content='error', no_annex=False,
+    def __call__(filename=None,
+                 *,
+                 dataset=None,
+                 missing_content='error', no_annex=False,
                  # TODO: support working with projects and articles within them
                  # project_id=None,
                  article_id=None):
@@ -283,7 +286,7 @@ class ExportToFigshare(Interface):
         )
         archive_out = next(
             export_archive(
-                dataset,
+                dataset=dataset,
                 filename=filename,
                 archivetype='zip',
                 missing_content=missing_content,

--- a/datalad/distributed/export_to_figshare.py
+++ b/datalad/distributed/export_to_figshare.py
@@ -247,6 +247,7 @@ class ExportToFigshare(Interface):
     @staticmethod
     @datasetmethod(name='export_to_figshare')
     @eval_results
+    # TODO*: yet another former plugin with dataset first -- do we need that???
     def __call__(dataset, filename=None, missing_content='error', no_annex=False,
                  # TODO: support working with projects and articles within them
                  # project_id=None,

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -557,7 +557,9 @@ class CreateSibling(Interface):
     @staticmethod
     @datasetmethod(name='create_sibling')
     @eval_results
-    def __call__(sshurl, name=None, target_dir=None,
+    def __call__(sshurl,
+                 *,
+                 name=None, target_dir=None,
                  target_url=None, target_pushurl=None,
                  dataset=None,
                  recursive=False,

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -153,7 +153,7 @@ class CreateTestDataset(Interface):
     )
 
     @staticmethod
-    def __call__(path=None, spec=None, seed=None):
+    def __call__(path=None, *, spec=None, seed=None):
         levels = _parse_spec(spec)
 
         if seed is not None:

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -46,6 +46,7 @@ from datalad.utils import (
     getpwd,
     optional_args,
     get_dataset_root,
+    get_sig_param_names,
     # TODO remove after a while, when external consumers have adjusted
     # to use get_dataset_root()
     get_dataset_root as rev_get_dataset_root,
@@ -466,18 +467,8 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
         # due to use of functools.wraps and inability of of getarspec to get
         # those, we use .signature.
         # More information in de-wrapt PR https://github.com/datalad/datalad/pull/6190
-        f_sign = inspect.signature(f)
-        P = inspect.Parameter
-        f_args = [
-            p_name
-            for p_name, p in f_sign.parameters.items()
-            if p.kind in (P.POSITIONAL_ONLY, P.POSITIONAL_OR_KEYWORD)
-        ]
-        f_kwonlyargs = {
-            p_name: p
-            for p_name, p in f_sign.parameters.items()
-            if p.kind == P.KEYWORD_ONLY
-        }
+        from datalad.utils import get_sig_param_names
+        f_args, f_kwonlyargs = get_sig_param_names(f, ['pos_any', 'kw_only'])
 
         # If bound function is used with wrong signature (especially by
         # explicitly passing a dataset), let's raise a proper exception instead

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -469,13 +469,13 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
         # explicitly passing a dataset, let's raise a proper exception instead
         # of a 'list index out of range', that is not very telling to the user.
         if len(args) >= len(f_args):
-            raise TypeError("{0}() takes at most {1} arguments ({2} given):"
-                            " {3}".format(name, len(f_args), len(args),
-                                          ['self'] + [a for a in f_args
-                                                      if a != dataset_argname]))
+            non_dataset_args = ['self'] + [a for a in f_args if a != dataset_argname]
+            raise TypeError(
+                f"{name}() takes at most {len(f_args)} arguments ({len(args)} given): "
+                f"{non_dataset_args}")
         if dataset_argname in kwargs:
-            raise TypeError("{}() got an unexpected keyword argument {}"
-                            "".format(name, dataset_argname))
+            raise TypeError(
+                f"{name}() got an unexpected keyword argument {dataset_argname}")
         kwargs[dataset_argname] = instance
         ds_index = f_args.index(dataset_argname)
         for i in range(0, len(args)):

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -468,7 +468,7 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
         # those, we use .signature.
         # More information in de-wrapt PR https://github.com/datalad/datalad/pull/6190
         from datalad.utils import get_sig_param_names
-        f_args, f_kwonlyargs = get_sig_param_names(f, ['pos_any', 'kw_only'])
+        f_args, f_kwonlyargs = get_sig_param_names(f, ('pos_any', 'kw_only'))
 
         # If bound function is used with wrong signature (especially by
         # explicitly passing a dataset), let's raise a proper exception instead

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -830,6 +830,7 @@ class Get(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             source=None,
             dataset=None,
             recursive=False,

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -175,6 +175,7 @@ class Install(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             source=None,
             dataset=None,
             get_data=False,

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -206,6 +206,7 @@ class Siblings(Interface):
     @eval_results
     def __call__(
             action='query',
+            *,
             dataset=None,
             name=None,
             url=None,

--- a/datalad/distribution/tests/test_dataset_binding.py
+++ b/datalad/distribution/tests/test_dataset_binding.py
@@ -58,3 +58,38 @@ def test_decorator():
         return some
 
     eq_(ds.new_name('whatever'), 'whatever')
+
+
+def test_decorator_star():
+    @datasetmethod
+    def func(a, b, *, dataset=None, some_more=True):
+
+        return {'a': a, 'b': b, 'dataset': dataset, 'some_more': some_more}
+
+    ds = Dataset(opj('some', 'where'))
+
+    orig = func(1, 2, dataset=ds, some_more=False)
+    eq_(orig['a'], 1)
+    eq_(orig['b'], 2)
+    eq_(orig['dataset'], ds)
+    eq_(orig['some_more'], False)
+
+    # general call
+    bound = ds.func(1, 2, some_more=False)
+    eq_(orig, bound)
+
+    # use default value
+    bound = ds.func(1, 2)
+    orig['some_more'] = True
+    eq_(orig, bound)
+
+    # too few arguments:
+    assert_raises(TypeError, ds.func, 1)
+
+    # too much arguments, by using original call with bound function,
+    # raises proper TypeError:
+    assert_raises(TypeError, ds.func, 1, 2, ds)
+
+    # keyword argument 'dataset' is invalidated in Dataset-bound function:
+    # raises proper TypeError:
+    assert_raises(TypeError, ds.func, 1, 2, dataset='whatever')

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -132,7 +132,12 @@ def test_invalid_args(path):
     assert_raises(ValueError, install, 'ssh://mars/Zoidberg', source='Zoidberg')
     # make fake dataset
     ds = create(path)
-    assert_raises(IncompleteResultsError, install, '/higherup.', 'Zoidberg', dataset=ds)
+    # explicit 'source' as a kwarg
+    assert_raises(IncompleteResultsError, install, '/higherup.', source='Zoidberg', dataset=ds)
+    # or obscure form for multiple installation "things"
+    assert_raises(IncompleteResultsError, install, ['/higherup.', 'Zoidberg'], dataset=ds)
+    # and if just given without keyword arg for source -- standard Python exception
+    assert_raises(TypeError, install, '/higherup.', 'Zoidberg', dataset=ds)
 
 
 # This test caused a mysterious segvault in gh-1350. I reimplementation of

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -84,6 +84,7 @@ class Uninstall(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             recursive=False,
             check=True,

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -214,6 +214,7 @@ class Update(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             sibling=None,
             merge=False,
             how=None,

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -352,8 +352,7 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None,
     """
     from datalad.utils import getargspec
     # get the signature
-    ndefaults = 0
-    args, varargs, varkw, defaults = getargspec(func)
+    args, varargs, varkw, defaults = getargspec(func, include_kwonlyargs=True)
     defaults = defaults or tuple()
     if add_args:
         add_argnames = sorted(add_args.keys())
@@ -662,7 +661,7 @@ class Interface(object):
         from datalad.utils import getargspec
         # get the signature
         ndefaults = 0
-        args, varargs, varkw, defaults = getargspec(cls.__call__)
+        args, varargs, varkw, defaults = getargspec(cls.__call__, include_kwonlyargs=True)
         if defaults is not None:
             ndefaults = len(defaults)
         default_offset = ndefaults - len(args)
@@ -753,10 +752,10 @@ class Interface(object):
     def call_from_parser(cls, args):
         # XXX needs safety check for name collisions
         from datalad.utils import getargspec
-        argspec = getargspec(cls.__call__)
-        if argspec[2] is None:
+        argspec = getargspec(cls.__call__, include_kwonlyargs=True)
+        if argspec.keywords is None:
             # no **kwargs in the call receiver, pull argnames from signature
-            argnames = getargspec(cls.__call__)[0]
+            argnames = argspec.args
         else:
             # common options
             # XXX define or better get from elsewhere
@@ -854,7 +853,7 @@ def get_allargs_as_kwargs(call, args, kwargs):
     dict
     """
     from datalad.utils import getargspec
-    argspec = getargspec(call)
+    argspec = getargspec(call, include_kwonlyargs=True)
     defaults = argspec.defaults
     nargs = len(argspec.args)
     defaults = defaults or []  # ensure it is a list and not None

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -56,7 +56,7 @@ class Test(Interface):
     )
 
     @staticmethod
-    def __call__(module=None, verbose=False, nocapture=False, pdb=False, stop=False):
+    def __call__(module=None, *, verbose=False, nocapture=False, pdb=False, stop=False):
         if not module:
             from pkg_resources import iter_entry_points
             module = ['datalad']

--- a/datalad/local/add_archive_content.py
+++ b/datalad/local/add_archive_content.py
@@ -222,6 +222,7 @@ class AddArchiveContent(Interface):
     @eval_results
     def __call__(
             archive,
+            *,
             dataset=None,
             annex=None,
             add_archive_leading_dir=False,

--- a/datalad/local/add_archive_content.py
+++ b/datalad/local/add_archive_content.py
@@ -213,6 +213,7 @@ class AddArchiveContent(Interface):
 
         # TODO: interaction with archives cache whenever we make it persistent across runs
         archive=Parameter(
+            args=("archive",),
             doc="archive file or a key (if %s specified)" % _KEY_OPT,
             constraints=EnsureStr()),
     )

--- a/datalad/local/add_readme.py
+++ b/datalad/local/add_readme.py
@@ -60,6 +60,7 @@ class AddReadme(Interface):
     @staticmethod
     @datasetmethod(name='add_readme')
     @eval_results
+    # TODO*: harmonize for adding *,
     def __call__(dataset, filename='README.md', existing='skip'):
         from os.path import lexists
         from os.path import join as opj

--- a/datalad/local/add_readme.py
+++ b/datalad/local/add_readme.py
@@ -60,8 +60,10 @@ class AddReadme(Interface):
     @staticmethod
     @datasetmethod(name='add_readme')
     @eval_results
-    # TODO*: harmonize for adding *,
-    def __call__(dataset, filename='README.md', existing='skip'):
+    def __call__(filename='README.md',
+                 *,
+                 dataset=None,
+                 existing='skip'):
         from os.path import lexists
         from os.path import join as opj
         from io import open

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -1306,8 +1306,9 @@ class Addurls(Interface):
     @staticmethod
     @datasetmethod(name='addurls')
     @eval_results
-    # TODO*: harmonize to match CLI -- move dataset
-    def __call__(dataset, urlfile, urlformat, filenameformat,
+    def __call__(urlfile, urlformat, filenameformat,
+                 *,
+                 dataset=None,
                  input_type="ext", exclude_autometa=None, meta=None, key=None,
                  message=None, dry_run=False, fast=False, ifexists=None,
                  missing_value=None, save=True, version_urls=False,

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -1306,6 +1306,7 @@ class Addurls(Interface):
     @staticmethod
     @datasetmethod(name='addurls')
     @eval_results
+    # TODO*: harmonize to match CLI -- move dataset
     def __call__(dataset, urlfile, urlformat, filenameformat,
                  input_type="ext", exclude_autometa=None, meta=None, key=None,
                  message=None, dry_run=False, fast=False, ifexists=None,

--- a/datalad/local/check_dates.py
+++ b/datalad/local/check_dates.py
@@ -144,6 +144,7 @@ class CheckDates(Interface):
     @staticmethod
     @eval_results
     def __call__(paths,
+                 *,
                  reference_date="@1514764800",
                  revs=None,
                  annex="all",

--- a/datalad/local/clean.py
+++ b/datalad/local/clean.py
@@ -104,7 +104,8 @@ class Clean(Interface):
     @staticmethod
     @datasetmethod(name='clean')
     @eval_results
-    def __call__(dataset=None, what=None, dry_run=False,
+    def __call__(*,
+                 dataset=None, what=None, dry_run=False,
                  recursive=False, recursion_limit=None):
 
         ds = require_dataset(dataset,

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -166,6 +166,7 @@ class CopyFile(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             recursive=False,
             target_dir=None,

--- a/datalad/local/download_url.py
+++ b/datalad/local/download_url.py
@@ -69,6 +69,7 @@ class DownloadURL(Interface):
                 ", ".join(map(repr, sorted(Provider.DOWNLOADERS)))),
             constraints=EnsureStr(),  # TODO: EnsureURL
             metavar='url',
+            args=('urls',),
             nargs='+'),
         dataset=Parameter(
             args=("-d", "--dataset"),

--- a/datalad/local/download_url.py
+++ b/datalad/local/download_url.py
@@ -123,7 +123,9 @@ class DownloadURL(Interface):
     @staticmethod
     @datasetmethod(name="download_url")
     @eval_results
-    def __call__(urls, dataset=None, path=None, overwrite=False,
+    def __call__(urls,
+                 *,
+                 dataset=None, path=None, overwrite=False,
                  archive=False, save=True, message=None):
         from ..downloaders.http import HTTPDownloader
         from ..downloaders.providers import Providers

--- a/datalad/local/export_archive.py
+++ b/datalad/local/export_archive.py
@@ -71,8 +71,11 @@ class ExportArchive(Interface):
     @staticmethod
     @datasetmethod(name='export_archive')
     @eval_results
-    # TODO*: harmonize - move dataset after posarg filename and add *,
-    def __call__(dataset, filename=None, archivetype='tar', compression='gz',
+    def __call__(filename=None,
+                 *,
+                 dataset=None,
+                 archivetype='tar',
+                 compression='gz',
                  missing_content='error'):
         import os
         import tarfile

--- a/datalad/local/export_archive.py
+++ b/datalad/local/export_archive.py
@@ -71,6 +71,7 @@ class ExportArchive(Interface):
     @staticmethod
     @datasetmethod(name='export_archive')
     @eval_results
+    # TODO*: harmonize - move dataset after posarg filename and add *,
     def __call__(dataset, filename=None, archivetype='tar', compression='gz',
                  missing_content='error'):
         import os

--- a/datalad/local/no_annex.py
+++ b/datalad/local/no_annex.py
@@ -73,6 +73,7 @@ class NoAnnex(Interface):
     @staticmethod
     @datasetmethod(name='no_annex')
     @eval_results
+    # TODO*: make dataset, pattern into kwargs after *,?
     def __call__(dataset, pattern, ref_dir='.', makedirs=False):
         # could be extended to accept actual largefile expressions
         from os.path import join as opj

--- a/datalad/local/remove.py
+++ b/datalad/local/remove.py
@@ -152,6 +152,7 @@ class Remove(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             drop='datasets',
             reckless=None,

--- a/datalad/local/rerun.py
+++ b/datalad/local/rerun.py
@@ -196,6 +196,7 @@ class Rerun(Interface):
     @eval_results
     def __call__(
             revision=None,
+            *,
             since=None,
             dataset=None,
             branch=None,

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -327,6 +327,7 @@ class RunProcedure(Interface):
     @eval_results
     def __call__(
             spec=None,
+            *,
             dataset=None,
             discover=False,
             help_proc=False):

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -217,6 +217,7 @@ class Subdatasets(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             fulfilled=None,
             recursive=False,

--- a/datalad/local/tests/test_addurls.py
+++ b/datalad/local/tests/test_addurls.py
@@ -7,7 +7,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Test addurls plugin"""
+"""Test addurls"""
 
 from copy import deepcopy
 import json
@@ -544,7 +544,8 @@ class TestAddurls(object):
             os.mkdir(subdir)
             with chpwd(subdir):
                 shutil.copy(self.json_file, "in.json")
-                addurls(dataset_arg, url_file, "{url}", fname_format,
+                addurls(url_file, "{url}", fname_format,
+                        dataset=dataset_arg,
                         result_renderer='disabled')
                 # Files specified in the CSV file are always relative to the
                 # dataset.
@@ -567,7 +568,8 @@ class TestAddurls(object):
     @with_tempfile(mkdir=True)
     def test_addurls_create_newdataset(self, path):
         dspath = os.path.join(path, "ds")
-        addurls(dspath, self.json_file, "{url}", "{name}",
+        addurls(self.json_file, "{url}", "{name}",
+                dataset=dspath,
                 cfg_proc=["yoda"], result_renderer='disabled')
         for fname in ["a", "b", "c", "code"]:
             ok_exists(os.path.join(dspath, fname))

--- a/datalad/local/tests/test_export_archive.py
+++ b/datalad/local/tests/test_export_archive.py
@@ -46,7 +46,8 @@ _dataset_template = {
 @with_tree(_dataset_template)
 def test_failure(path):
     # non-existing dataset
-    assert_raises(ValueError, export_archive, Dataset('nowhere'))
+    with assert_raises(ValueError):
+        export_archive(dataset=Dataset('nowhere'))
 
 
 @with_tree(_dataset_template)

--- a/datalad/local/unlock.py
+++ b/datalad/local/unlock.py
@@ -84,6 +84,7 @@ class Unlock(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             recursive=False,
             recursion_limit=None):

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -382,7 +382,7 @@ class WTF(Interface):
     @staticmethod
     @datasetmethod(name='wtf')
     @eval_results
-    def __call__(dataset=None, sensitive=None, sections=None, flavor="full", decor=None, clipboard=None):
+    def __call__(*, dataset=None, sensitive=None, sections=None, flavor="full", decor=None, clipboard=None):
         from datalad.distribution.dataset import require_dataset
         from datalad.support.exceptions import NoDatasetFound
         from datalad.interface.results import get_status_dict

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -899,6 +899,7 @@ class AggregateMetaData(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             recursive=False,
             recursion_limit=None,

--- a/datalad/metadata/extract_metadata.py
+++ b/datalad/metadata/extract_metadata.py
@@ -70,6 +70,7 @@ class ExtractMetadata(Interface):
     @staticmethod
     @datasetmethod(name='extract_metadata')
     @eval_results
+    # TODO*: types is option and files (path!) is posarg -- harmonize
     def __call__(types, files=None, dataset=None):
         dataset = require_dataset(dataset or curdir,
                                   purpose="extract metadata",

--- a/datalad/metadata/extract_metadata.py
+++ b/datalad/metadata/extract_metadata.py
@@ -70,7 +70,9 @@ class ExtractMetadata(Interface):
     @staticmethod
     @datasetmethod(name='extract_metadata')
     @eval_results
-    # TODO*: types is option and files (path!) is posarg -- harmonize
+    # Note: types is a required option and files (path!) is posarg --
+    # This is not consistent with the other uses, but since it is being redone in metalad
+    # anyways -- kept as is.without adding * following current design docs.
     def __call__(types, files=None, dataset=None):
         dataset = require_dataset(dataset or curdir,
                                   purpose="extract metadata",

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -879,6 +879,7 @@ class Metadata(Interface):
     @eval_results
     def __call__(
             path=None,
+            *,
             dataset=None,
             get_aggregates=False,
             reporton='all',

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -1307,6 +1307,7 @@ class Search(Interface):
     @datasetmethod(name='search')
     @eval_results
     def __call__(query=None,
+                 *,
                  dataset=None,
                  force_reindex=False,
                  max_nresults=None,

--- a/datalad/support/param.py
+++ b/datalad/support/param.py
@@ -27,7 +27,12 @@ class Parameter(object):
     # Known keyword arguments which we want to allow to pass over into
     # argparser.add_argument . Mentioned explicitly, since otherwise
     # are not verified while working in Python-only API
-    _KNOWN_ARGS = getargspec(argparse.Action.__init__)[0] + ['action']
+    # include_kwonlyargs=True is future-proofing since ATM in 3.9 there is no
+    # *, in Action.__init__ but could be added later, and semantically it
+    # makes sense to include those among _KNOWN_ARGS
+    _KNOWN_ARGS = getargspec(
+        argparse.Action.__init__, include_kwonlyargs=True
+    ).args + ['action']
 
     def __init__(self, constraints=None, doc=None, args=None, **kwargs):
         """Add constraints (validator) specifications and a docstring for

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -76,7 +76,9 @@ class SSHRun(Interface):
     )
 
     @staticmethod
-    def __call__(login, cmd, port=None, ipv4=False, ipv6=False, options=None,
+    def __call__(login, cmd,
+                 *,
+                 port=None, ipv4=False, ipv6=False, options=None,
                  no_stdin=False):
         lgr.debug("sshrun invoked: login=%r, cmd=%r, port=%r, options=%r, "
                   "ipv4=%r, ipv6=%r, no_stdin=%r",

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -9,7 +9,7 @@
 '''Unit tests for Python API functionality.'''
 
 import re
-from datalad.utils import getargspec
+from datalad.utils import get_sig_param_names
 
 from datalad.tests.utils import assert_true, assert_false
 from datalad.tests.utils import SkipTest
@@ -36,7 +36,7 @@ def test_basic_setup():
 
 def _test_consistent_order_of_args(intf, spec_posargs):
     f = getattr(intf, '__call__')
-    args, varargs, varkw, defaults = getargspec(f, include_kwonlyargs=True)
+    args, = get_sig_param_names(f, ['pos_any'])
     # now verify that those spec_posargs are first among args
     if not spec_posargs:
         raise SkipTest("no positional args") # print intf, "skipped"

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -68,6 +68,12 @@ def _test_consistent_order_of_args(intf, spec_posargs):
     else:
         # and if no kw_only -- only those which are known to be positional
         eq_(set(args[:len(spec_posargs)]), spec_posargs)
+        if spec_posargs:
+            # and really -- we should not even get here if there are some spec_posargs --
+            # new interfaces should use * to separate pos args from kwargs per our now
+            # accepted design doc:
+            # http://docs.datalad.org/en/latest/design/pos_vs_kw_parameters.html
+            assert False
 
 
 def test_consistent_order_of_args():

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -42,12 +42,8 @@ def _test_consistent_order_of_args(intf, spec_posargs):
         raise SkipTest("no positional args") # print intf, "skipped"
 #    else:
 #        print intf, spec_posargs
-    if intf.__name__ == 'Save':
-        # it makes sense there to have most common argument first
-        # -- the message. But we don't enforce it on cmdline so it is
-        # optional
-        spec_posargs.add('message')
-    elif intf.__name__ in (
+    # TODO*: all those ideally are RFed to follow the CLI-matching args-kwargs separation with *
+    if intf.__name__ in (
             'AddReadme',
             'Addurls',
             # Clone gained a git_clone_opts REMAINDER option. This is

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -36,7 +36,7 @@ def test_basic_setup():
 
 def _test_consistent_order_of_args(intf, spec_posargs):
     f = getattr(intf, '__call__')
-    args, varargs, varkw, defaults = getargspec(f)
+    args, varargs, varkw, defaults = getargspec(f, include_kwonlyargs=True)
     # now verify that those spec_posargs are first among args
     if not spec_posargs:
         raise SkipTest("no positional args") # print intf, "skipped"

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -36,7 +36,7 @@ def test_basic_setup():
 
 def _test_consistent_order_of_args(intf, spec_posargs):
     f = getattr(intf, '__call__')
-    args, kw_only = get_sig_param_names(f, ['pos_any', 'kw_only'])
+    args, kw_only = get_sig_param_names(f, ('pos_any', 'kw_only'))
     # now verify that those spec_posargs are first among args
     # TODO*: The last odd one left from "plugins" era. Decided to leave alone
     if intf.__name__ in ('ExtractMetadata',):

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -38,16 +38,8 @@ def _test_consistent_order_of_args(intf, spec_posargs):
     f = getattr(intf, '__call__')
     args, kw_only = get_sig_param_names(f, ['pos_any', 'kw_only'])
     # now verify that those spec_posargs are first among args
-    # TODO*: all those ideally are RFed to follow the CLI-matching args-kwargs separation with *
-    if intf.__name__ in (
-            'AddReadme',
-            'ExportArchive',
-            'ExportToFigshare',
-            'ExtractMetadata'):
-        if intf.__name__ not in ['ExtractMetadata']:
-            # ex-plugins had 'dataset' as the first positional argument
-            # and ExtractMetadata has 'types' as the first positional arg
-            eq_(args[0], 'dataset')
+    # TODO*: The last odd one left from "plugins" era. Decided to leave alone
+    if intf.__name__ in ('ExtractMetadata',):
         return
 
     # if we had used * to instruct to have keyword only args, then all

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -36,12 +36,8 @@ def test_basic_setup():
 
 def _test_consistent_order_of_args(intf, spec_posargs):
     f = getattr(intf, '__call__')
-    args, = get_sig_param_names(f, ['pos_any'])
+    args, kw_only = get_sig_param_names(f, ['pos_any', 'kw_only'])
     # now verify that those spec_posargs are first among args
-    if not spec_posargs:
-        raise SkipTest("no positional args") # print intf, "skipped"
-#    else:
-#        print intf, spec_posargs
     # TODO*: all those ideally are RFed to follow the CLI-matching args-kwargs separation with *
     if intf.__name__ in (
             'AddReadme',
@@ -60,7 +56,18 @@ def _test_consistent_order_of_args(intf, spec_posargs):
         eq_(spec_posargs, spec_posargs)
         return
 
-    eq_(set(args[:len(spec_posargs)]), spec_posargs)
+    # if we had used * to instruct to have keyword only args, then all
+    # args should actually be matched entirely
+    if kw_only:
+        # "special cases/exclusions"
+        if intf.__name__ == 'CreateSiblingRia':
+            # -s|--name is a mandatory option (for uniformity), so allowed to be used as posarg #2
+            eq_(set(args), spec_posargs.union({'name'}))
+        else:
+            eq_(set(args), spec_posargs)
+    else:
+        # and if no kw_only -- only those which are known to be positional
+        eq_(set(args[:len(spec_posargs)]), spec_posargs)
 
 
 def test_consistent_order_of_args():

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -41,7 +41,6 @@ def _test_consistent_order_of_args(intf, spec_posargs):
     # TODO*: all those ideally are RFed to follow the CLI-matching args-kwargs separation with *
     if intf.__name__ in (
             'AddReadme',
-            'Addurls',
             'ExportArchive',
             'ExportToFigshare',
             'ExtractMetadata'):

--- a/datalad/tests/test_api.py
+++ b/datalad/tests/test_api.py
@@ -42,18 +42,13 @@ def _test_consistent_order_of_args(intf, spec_posargs):
     if intf.__name__ in (
             'AddReadme',
             'Addurls',
-            # Clone gained a git_clone_opts REMAINDER option. This is
-            # positional on the command line, but positioning it at the front
-            # of the signature could break existing python callers.
-            'Clone',
             'ExportArchive',
             'ExportToFigshare',
             'ExtractMetadata'):
-        if intf.__name__ not in ['Clone', 'ExtractMetadata']:
+        if intf.__name__ not in ['ExtractMetadata']:
             # ex-plugins had 'dataset' as the first positional argument
             # and ExtractMetadata has 'types' as the first positional arg
             eq_(args[0], 'dataset')
-        eq_(spec_posargs, spec_posargs)
         return
 
     # if we had used * to instruct to have keyword only args, then all

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -217,10 +217,10 @@ def test_get_sig_param_names():
         pass  # pragma: no cover
 
     # note: `a1` could be used either positionally or via keyword, so is listed in kw_any
-    assert_equal(get_sig_param_names(f, ['kw_only', 'kw_any']), (['kw2'], ['a1', 'kw1', 'kw2']))
-    assert_equal(get_sig_param_names(f, ['any']), (['a1', 'kw1', 'kw2'],))
-    assert_equal(get_sig_param_names(f, []), ())
-    assert_raises(ValueError, get_sig_param_names, f, ['mumba'])
+    assert_equal(get_sig_param_names(f, ('kw_only', 'kw_any')), (['kw2'], ['a1', 'kw1', 'kw2']))
+    assert_equal(get_sig_param_names(f, ('any',)), (['a1', 'kw1', 'kw2'],))
+    assert_equal(get_sig_param_names(f, tuple()), ())
+    assert_raises(ValueError, get_sig_param_names, f, ('mumba',))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -55,6 +55,7 @@ from datalad.utils import (
     get_dataset_root,
     get_open_files,
     get_path_prefix,
+    get_sig_param_names,
     get_timestamp_suffix,
     get_trace,
     getpwd, chpwd,
@@ -209,6 +210,17 @@ def test_getargspec():
 
     assert_raises(ValueError, getargspec, f1_star)
     yield eq_argspec, f1_star, (['a1', 'kw1', 'kw0'], None, None, (None, 1)), True
+
+
+def test_get_sig_param_names():
+    def f(a1, kw1=None, *args, kw2=None, **kwargs):
+        pass  # pragma: no cover
+
+    # note: `a1` could be used either positionally or via keyword, so is listed in kw_any
+    assert_equal(get_sig_param_names(f, ['kw_only', 'kw_any']), (['kw2'], ['a1', 'kw1', 'kw2']))
+    assert_equal(get_sig_param_names(f, ['any']), (['a1', 'kw1', 'kw2'],))
+    assert_equal(get_sig_param_names(f, []), ())
+    assert_raises(ValueError, get_sig_param_names, f, ['mumba'])
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -212,6 +212,59 @@ def getargspec(func, *, include_kwonlyargs=False):
     return ArgSpecFake(*args4)
 
 
+# Definitions to be (re)used in the next function
+_SIG_P = inspect.Parameter
+_SIG_KIND_SELECTORS = {
+    'pos_only': {_SIG_P.POSITIONAL_ONLY,},
+    'pos_any': {_SIG_P.POSITIONAL_ONLY, _SIG_P.POSITIONAL_OR_KEYWORD},
+    'kw_any': {_SIG_P.POSITIONAL_OR_KEYWORD, _SIG_P.KEYWORD_ONLY},
+    'kw_only': {_SIG_P.KEYWORD_ONLY,},
+}
+_SIG_KIND_SELECTORS['any'] = set().union(*_SIG_KIND_SELECTORS.values())
+
+
+def get_sig_param_names(f, kinds: list) -> tuple:
+    """A helper to selectively return parameters from inspect.signature.
+
+    inspect.signature is the ultimate way for introspecting callables.  But
+    its interface is not so convenient for a quick selection of parameters
+    (AKA arguments) of desired type or combinations of such.  This helper
+    should make it easier to retrieve desired collections of parameters.
+
+    Since often it is desired to get information about multiple specific types
+    of parameters, `kinds` is a list, so in a single invocation of `signature`
+    and looping through the results we can obtain all information.
+
+    Parameters
+    ----------
+    f: callable
+    kinds: list with values from {'pos_any', 'pos_only', 'kw_any', 'kw_only', 'any'}
+      Is a list of what kinds of args to return in result (tuple). Each element
+      should be one of: 'any_pos' - positional or keyword which could be used
+      positionally. 'kw_only' - keyword only (cannot be used positionally) arguments,
+      'any_kw` - any keyword (could be a positional which could be used as a keyword),
+      `any` -- any type from the above.
+
+    Returns
+    -------
+    tuple:
+      Each element is a list of parameters (names only) of that "kind".
+    """
+    selectors = []
+    for kind in kinds:
+        if kind not in _SIG_KIND_SELECTORS:
+            raise ValueError(f"Unknown 'kind' {kind}. Known are: {', '.join(_SIG_KIND_SELECTORS)}")
+        selectors.append(_SIG_KIND_SELECTORS[kind])
+
+    out = [[] for _ in kinds]
+    for p_name, p in inspect.signature(f).parameters.items():
+        for i, selector in enumerate(selectors):
+            if p.kind in selector:
+                out[i].append(p_name)
+
+    return tuple(out)
+
+
 def any_re_search(regexes, value):
     """Return if any of regexes (list or str) searches successfully for value"""
     for regex in ensure_tuple_or_list(regexes):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -157,6 +157,8 @@ ArgSpecFake = collections.namedtuple(
     "ArgSpecFake", ["args", "varargs", "keywords", "defaults"])
 
 
+# adding cache here somehow does break it -- even 'datalad wtf' does not run
+# @lru_cache()  # signatures stay the same, why to "redo"? brings it into ns from mks
 def getargspec(func, *, include_kwonlyargs=False):
     """Compat shim for getargspec deprecated in python 3.
 
@@ -223,7 +225,8 @@ _SIG_KIND_SELECTORS = {
 _SIG_KIND_SELECTORS['any'] = set().union(*_SIG_KIND_SELECTORS.values())
 
 
-def get_sig_param_names(f, kinds: list) -> tuple:
+@lru_cache()  # signatures stay the same, why to "redo"? brings it into ns from mks
+def get_sig_param_names(f, kinds: tuple) -> tuple:
     """A helper to selectively return parameters from inspect.signature.
 
     inspect.signature is the ultimate way for introspecting callables.  But
@@ -238,7 +241,7 @@ def get_sig_param_names(f, kinds: list) -> tuple:
     Parameters
     ----------
     f: callable
-    kinds: list with values from {'pos_any', 'pos_only', 'kw_any', 'kw_only', 'any'}
+    kinds: tuple with values from {'pos_any', 'pos_only', 'kw_any', 'kw_only', 'any'}
       Is a list of what kinds of args to return in result (tuple). Each element
       should be one of: 'any_pos' - positional or keyword which could be used
       positionally. 'kw_only' - keyword only (cannot be used positionally) arguments,


### PR DESCRIPTION
- Sits on top of tiny https://github.com/datalad/datalad/pull/6175 which I thought would be relevant but apparently not really.  Can rebase
- inspired by #5517 when I thought to RF `cmd` into `--cmd` and thus possibly opening the way for ppl to shoot themselves in the foot whenever later I would decide to add `path` pos arg (in CLI etc)
- adding explicit `*` separation would mimic how CLI is specified - you can't specify `--options` as positional arguments.
- may be would give another reason to harmonize interfaces of older interfaces (moved from plugins) -- in most of the cases it is just move of `dataset` from the 0th arg into its due `kwarg` position.
- [x] make sure tests pass
- [x] decide to either issue a DeprecationWarning if an Interface without `*` is encountered: decided not to bother. Now we have some test which sould fail in such case of having some specargs but no kwonly args
- [x] decide what to do if anything about those `TODO*` marked interfaces
  - [x] RFed signature of `clone` to place optional last (REMAINER) posarg to be a kwarg right before `*`
  - [x] RFed signature of `addurls` to have `dataset` as a kwarg as all other interfaces do!
  - [x] RFed other elderlies: add_readme, export_to_figshare, export_archive to also have `dataset` as a kwarg. Rationale: if they are used, most likely via CLI anyways. There it should not matter. Uniformity is good to have
  - [-] Left alone `extract_metadata`  ....
- [x] pay attention to change in the test for `save` where we did allow `message` to be used as posarg (I think - bad idea). But may be do allow for posarg use?  decided against -- no reason to make it different from `git commit -m ...`.
- [ ] (after there is an agreement) Add perspective CHANGELOG.md record to describe this change and breaking changes (if any left).