### PR TITLE
Do not fail dropping an uninitialized AnnexRepo 

### DIFF
--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -495,7 +495,8 @@ def _fatal_pre_drop_checks(ds, repo, paths, what, reckless, is_annex):
         # this annex is about to die, test if it is still considered
         # not-dead. if so, complain to avoid generation of zombies
         # (annexed that are floating around, but are actually dead).
-        remotes_that_know_this_annex = [
+        # if repo.uuid is None, git annex init never ran, and we can skip this
+        remotes_that_know_this_annex = None if repo.uuid is None else [
             r
             for r in _detect_nondead_annex_at_remotes(repo, repo.uuid)
             # filter out "here"

--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -558,10 +558,10 @@ def _fatal_pre_drop_checks(ds, repo, paths, what, reckless, is_annex):
 
 
 def _pre_drop_checks(ds, repo, paths, what, reckless, is_annex):
-    if not is_annex and paths and not reckless == 'kill':
+    if not is_annex and reckless not in ('datasets', 'kill'):
         # we cannot drop content in non-annex repos, issue same
         # 'notneeded' as for git-file in annex repo
-        for p in paths:
+        for p in paths or [ds.path]:
             yield dict(
                 action='drop',
                 path=str(p),

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -529,6 +529,8 @@ def test_uninstall_without_super(path):
 @with_tempfile
 def test_drop_from_git(path):
     ds = Dataset(path).create(annex=False)
+    res = ds.drop()
+    assert_in_results(res, action='drop', status='notneeded')
     (ds.pathobj / 'file').write_text('some')
     ds.save()
     assert_status('notneeded', ds.drop('file'))

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -24,6 +24,7 @@ from datalad.support.exceptions import (
     IncompleteResultsError,
     NoDatasetFound,
 )
+from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils import (
     DEFAULT_BRANCH,
     DEFAULT_REMOTE,
@@ -535,3 +536,15 @@ def test_drop_from_git(path):
     ds.save()
     assert_status('notneeded', ds.drop('file'))
     assert_status('notneeded', ds.drop(what='allkeys'))
+
+
+# https://github.com/datalad/datalad/issues/6180
+@with_tempfile
+@with_tempfile
+def test_drop_uninit_annexrepo(origpath, path):
+    Dataset(origpath).create()
+    # just git-clone to bypass `git annex init`
+    GitRepo.clone(origpath, path)
+    ds = Dataset(path)
+    assert_status('ok', ds.drop(what='datasets'))
+    nok_(ds.is_installed())


### PR DESCRIPTION
Previously it would fail trying to determine whether the local
annex is known to remotes, but before `init` there is no local
annex.

With this change I am catching this condition and avoid the entire
investigation.

The potentially bigger issue (whether or not such a dataset should
carry an `AnnexRepo` instance, rather than `GitRepo`) is related
to #6103 and must be discussed separately.

Fixes #6180