### PR TITLE
Bump sphinx requirement to bypass readthedocs defaults

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ requires.update({
         # used for converting README.md -> .rst for long_description
         'pypandoc',
         # Documentation
-        'sphinx>=1.7.8, !=4.0.0',
+        'sphinx>=2, !=4.0.0',
         'sphinx-rtd-theme',
     ],
     'devel-utils': [


### PR DESCRIPTION
which lead to a broken build with a recent docutils update.
Story in https://github.com/datalad/datalad/issues/6122

Fixes datalad/datalad#6122
