### PR TITLE
RF: de-wrapt

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -10,6 +10,7 @@
 """
 
 import logging
+from functools import wraps
 from os.path import (
     curdir,
     exists,
@@ -18,7 +19,6 @@ from os.path import (
     pardir,
 )
 from weakref import WeakValueDictionary
-import wrapt
 
 from datalad import cfg
 from datalad.config import ConfigManager
@@ -447,11 +447,12 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
 
     The decorator has no effect on the actual function decorated with it.
     """
+
     if not name:
         name = f.__name__
 
-    @wrapt.decorator
-    def apply_func(wrapped, instance, args, kwargs):
+    @wraps(f)
+    def apply_func(instance, *args, **kwargs):
         # Wrapper function to assign arguments of the bound function to
         # original function.
         #
@@ -459,7 +460,6 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
         # ----
         # This wrapper is NOT returned by the decorator, but only used to bind
         # the function `f` to the Dataset class.
-
         kwargs = kwargs.copy()
         from datalad.utils import getargspec
         orig_pos = getargspec(f).args
@@ -484,7 +484,12 @@ def datasetmethod(f, name=None, dataset_argname='dataset'):
                 kwargs[orig_pos[i+1]] = args[i]
         return f(**kwargs)
 
-    setattr(Dataset, name, apply_func(f))
+    setattr(Dataset, name, apply_func)
+    # set the ad-hoc attribute so that @build_doc could also bind built doc
+    # to the dataset method
+    if getattr(f, '_dataset_method', None):
+        raise RuntimeError(f"_dataset_method of {f} is already set to {f._dataset_method}")
+    setattr(f, '_dataset_method', apply_func)
     return f
 
 

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -525,6 +525,9 @@ def build_doc(cls, **kwargs):
         add_args=add_args
     )
 
+    if hasattr(cls.__call__, '_dataset_method'):
+        cls.__call__._dataset_method.__doc__ = cls.__call__.__doc__
+
     # return original
     return cls
 

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -176,7 +176,6 @@ class ExternalVersions(object):
         'cmd:7z',
         'requests',
         'scrapy',
-        'wrapt',
     )
 
     def __init__(self):

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -11,6 +11,8 @@
 
 """
 
+from functools import wraps
+import inspect
 import os
 import os.path as op
 import shutil
@@ -49,6 +51,7 @@ from datalad.utils import (
     file_basename,
     find_files,
     generate_chunks,
+    getargspec,
     get_dataset_root,
     get_open_files,
     get_path_prefix,
@@ -122,9 +125,6 @@ from datalad import cfg as dl_cfg
 
 
 def test_better_wraps():
-    from functools import wraps
-    from datalad.utils import getargspec
-
     def wraps_decorator(func):
         @wraps(func)
         def  _wrap_wraps_decorator(*args, **kwargs):
@@ -148,9 +148,67 @@ def test_better_wraps():
         return "function2"
 
     eq_("function1", function1(1, 2, 3))
-    eq_(getargspec(function1)[0], [])
+    # getargspec shim now can handle @wraps'ed functions just fine
+    eq_(getargspec(function1)[0], ['a', 'b', 'c'])
     eq_("function2", function2(1, 2, 3))
     eq_(getargspec(function2)[0], ['a', 'b', 'c'])
+
+
+def test_getargspec():
+
+    def eq_argspec(f, expected, has_kwonlyargs=False):
+        """A helper to centralize testing of getargspec on original and wrapped function
+
+        has_kwonlyargs is to instruct if function has kwonly args so we do not try to compare
+        to inspect.get*spec functions, which would barf ValueError if attempted to run on a
+        function with kwonlys. And also we pass it as include_kwonlyargs to our getargspec
+        """
+        # so we know that our expected is correct
+        if not has_kwonlyargs:
+            # if False - we test function with kwonlys - inspect.getargspec would barf
+            eq_(inspect.getargspec(f), expected)
+            # and getfullargspec[:4] wouldn't provide a full picture
+            eq_(inspect.getfullargspec(f)[:4], expected)
+        else:
+            assert_raises(ValueError, inspect.getargspec, f)
+            inspect.getfullargspec(f)  # doesn't barf
+        eq_(getargspec(f, include_kwonlyargs=has_kwonlyargs), expected)
+
+        # and lets try on a wrapped one -- only ours can do the right thing
+        def decorator(f):
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                return f(*args, **kwargs)
+            return wrapper
+        fw = decorator(f)
+        if has_kwonlyargs:
+            # We barf ValueError similarly to inspect.getargspec, unless explicitly requested
+            # to include kwonlyargs
+            assert_raises(ValueError, getargspec, fw)
+        eq_(getargspec(fw, include_kwonlyargs=has_kwonlyargs), expected)
+
+    def f0():
+        pass
+
+    yield eq_argspec, f0, ([], None, None, None)
+
+    def f1(a1, kw1=None, kw0=1):
+        pass
+
+    yield eq_argspec, f1, (['a1', 'kw1', 'kw0'], None, None, (None, 1))
+
+    # Having *a already makes keyword args to be kwonlyargs, in that
+    # inspect.get*spec would barf
+    def f1_args(a1, *a, kw1=None, kw0=1, **kw):
+        pass
+
+    yield eq_argspec, f1_args, (['a1', 'kw1', 'kw0'], 'a', 'kw', (None, 1)), True
+
+    def f1_star(a1, *, kw1=None, kw0=1):
+        pass
+
+    assert_raises(ValueError, getargspec, f1_star)
+    yield eq_argspec, f1_star, (['a1', 'kw1', 'kw0'], None, None, (None, 1)), True
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1149,15 +1149,14 @@ def collect_method_callstats(func):
       - .repo is expensive since does all kinds of checks.
       - .config is expensive transitively since it calls .repo each time
 
-
     TODO:
-    - fancy one could look through the stack for the same id(self) to see if
-      that location is already in memo.  That would hint to the cases where object
-      is not passed into underlying functions, causing them to redo the same work
-      over and over again
-    - ATM might flood with all "1 lines" calls which are not that informative.
-      The underlying possibly suboptimal use might be coming from their callers.
-      It might or not relate to the previous TODO
+      - fancy one could look through the stack for the same id(self) to see if
+        that location is already in memo.  That would hint to the cases where object
+        is not passed into underlying functions, causing them to redo the same work
+        over and over again
+      - ATM might flood with all "1 lines" calls which are not that informative.
+        The underlying possibly suboptimal use might be coming from their callers.
+        It might or not relate to the previous TODO
     """
     from collections import defaultdict
     import traceback

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -26,7 +26,6 @@ import gzip
 import stat
 import string
 import warnings
-import wrapt
 
 import os.path as op
 
@@ -1062,20 +1061,12 @@ def saved_generator(gen):
 #
 # Decorators
 #
-def better_wraps(to_be_wrapped):
-    """Decorator to replace `functools.wraps`
 
-    This is based on `wrapt` instead of `functools` and in opposition to `wraps`
-    preserves the correct signature of the decorated function.
-    It is written with the intention to replace the use of `wraps` without any
-    need to rewrite the actual decorators.
-    """
-
-    @wrapt.decorator(adapter=to_be_wrapped)
-    def intermediator(to_be_wrapper, instance, args, kwargs):
-        return to_be_wrapper(*args, **kwargs)
-
-    return intermediator
+# Originally better_wraps was created to provide `wrapt`-based, instead of
+# `functools.wraps` implementation to preserve the correct signature of the
+# decorated function. By using inspect.signature in our getargspec, which
+# works fine on `functools.wraps`ed functions, we mediated this necessity.
+better_wraps = wraps
 
 
 # Borrowed from pandas

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,4 @@
 # Theoretically we don't want -e here but ATM pip would puke if just .[full] is provided
 # Since we use requirements.txt ATM only for development IMHO it is ok but
 # we need to figure out/complaint to pip folks
-# For now, until https://github.com/GrahamDumpleton/wrapt/issues/98 resolved
-# we should use fresh version allowing to disable extensions
-wrapt>=1.10.11
 -e .[devel]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ requires = {
         'fasteners>=0.14',
         'patool>=1.7',
         'tqdm',
-        'wrapt',
         'annexremote',
     ],
     'downloaders': [


### PR DESCRIPTION
A quick chat with @mih inspired me to look into it.... in a nutshell (more to come if feasible):

- use `inspect.signature` instead of `inspect.getargspec` since that one manages to get args of `functools.wraps`ed functions. Source of information: https://stackoverflow.com/questions/147816/preserving-signatures-of-decorated-functions#comment68410839_147878

- ~~remaining gotcha (TEMPorarily disabled that test ) -- not yet "binding" `__doc__` to `Dataset.method` -- `@build_doc` assigns `__doc__` to `__call__` later than `@datasetmethod` is invoked. So I guess `wrapt` does some magic for `__doc__` to be always be queried for the `wrapt`ed functions.~~ -- I think I came up with a good enough workaround

- reworked `getargspec` is based on the one in #6176 but redone on top - will conflict. If we go with this -- this one should take over ;-)

oh well -- let's see if anything else breaks ;-)