### PR TITLE
MNT: Replace appdirs with platformdirs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ since we use it to provide backports of recent fixed external modules we depend 
 
 ```sh
 apt-get install -y -q git git-annex-standalone
-apt-get install -y -q patool python3-scrapy python3-{appdirs,argcomplete,git,humanize,keyring,lxml,msgpack,progressbar,requests,setuptools}
+apt-get install -y -q patool python3-scrapy python3-{argcomplete,git,humanize,keyring,lxml,msgpack,progressbar,requests,setuptools}
 ```
 
 and additionally, for development we suggest to use tox and new

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -38,7 +38,7 @@ from ..utils import (
     get_suggestions_msg,
 )
 
-from appdirs import AppDirs
+from platformdirs import AppDirs
 from os.path import join as opj
 
 dirs = AppDirs("datalad", "datalad.org")

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -119,7 +119,7 @@ url_re = https?://crcns\.org/.*
 authentication_type = none
 """}},
    '.git': { "HEAD" : ""}})
-@patch.multiple("appdirs.AppDirs", site_config_dir=None, user_config_dir=None)
+@patch.multiple("platformdirs.AppDirs", site_config_dir=None, user_config_dir=None)
 def test_Providers_from_config__files(sysdir, userdir, dsdir):
     """Test configuration file precedence
 
@@ -143,14 +143,14 @@ def test_Providers_from_config__files(sysdir, userdir, dsdir):
 
         # Test that the system defaults take precedence over the dataset
         # defaults (we're still within the dsdir)
-        with patch.multiple("appdirs.AppDirs", site_config_dir=sysdir, user_config_dir=None):
+        with patch.multiple("platformdirs.AppDirs", site_config_dir=sysdir, user_config_dir=None):
             providers = Providers.from_config_files(reload=True)
             provider = providers.get_provider('https://crcns.org/data....')
             assert_equal(provider.name, 'syscrcns')
 
         # Test that the user defaults take precedence over the system
         # defaults
-        with patch.multiple("appdirs.AppDirs", site_config_dir=sysdir, user_config_dir=userdir):
+        with patch.multiple("platformdirs.AppDirs", site_config_dir=sysdir, user_config_dir=userdir):
             providers = Providers.from_config_files(reload=True)
             provider = providers.get_provider('https://crcns.org/data....')
             assert_equal(provider.name, 'usercrcns')
@@ -158,7 +158,7 @@ def test_Providers_from_config__files(sysdir, userdir, dsdir):
 
 @with_tempfile(mkdir=True)
 def test_providers_enter_new(path):
-    with patch.multiple("appdirs.AppDirs", site_config_dir=None,
+    with patch.multiple("platformdirs.AppDirs", site_config_dir=None,
                         user_config_dir=path):
         providers_dir = op.join(path, "providers")
         providers = Providers.from_config_files(reload=True)

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -12,7 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
-from appdirs import AppDirs
+from platformdirs import AppDirs
 from os import environ
 from os.path import join as opj, expanduser
 from datalad.support.constraints import EnsureBool

--- a/datalad/interface/run_procedure.py
+++ b/datalad/interface/run_procedure.py
@@ -216,10 +216,10 @@ class RunProcedure(Interface):
     Directories identified by the configuration settings
 
     - 'datalad.locations.user-procedures' (determined by
-      appdirs.user_config_dir; defaults to '$HOME/.config/datalad/procedures'
+      platformdirs.user_config_dir; defaults to '$HOME/.config/datalad/procedures'
       on GNU/Linux systems)
     - 'datalad.locations.system-procedures' (determined by
-      appdirs.site_config_dir; defaults to '/etc/xdg/datalad/procedures' on
+      platformdirs.site_config_dir; defaults to '/etc/xdg/datalad/procedures' on
       GNU/Linux systems)
     - 'datalad.locations.dataset-procedures'
 

--- a/datalad/support/cookies.py
+++ b/datalad/support/cookies.py
@@ -11,7 +11,7 @@
 import atexit
 import logging
 import shelve
-import appdirs
+import platformdirs
 import os.path
 
 from .network import get_tld
@@ -46,7 +46,7 @@ class CookiesDB(object):
             filename = self._filename
             cookies_dir = os.path.dirname(filename)
         else:
-            cookies_dir = os.path.join(appdirs.user_config_dir(), 'datalad')  # FIXME prolly shouldn't hardcode 'datalad'
+            cookies_dir = os.path.join(platformdirs.user_config_dir(), 'datalad')  # FIXME prolly shouldn't hardcode 'datalad'
             filename = os.path.join(cookies_dir, 'cookies')
 
         # TODO: guarantee restricted permissions

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -161,7 +161,7 @@ class ExternalVersions(object):
     }
     _INTERESTING = (
         'annexremote',
-        'appdirs',
+        'platformdirs',
         'boto',
         'exifread',
         'git',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from _datalad_build_support.setup import (
 
 requires = {
     'core': [
-        'appdirs',
+        'platformdirs',
         'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',


### PR DESCRIPTION
The original appdirs repository is unmaintained. This change replaces it
with a currently maintained fork of the project. Closes #6164, and for now replaces #6166
