### PR TITLE
TST: redistribute windows tests across workers to harmonize runtime

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -105,6 +105,7 @@ environment:
           datalad.cmdline
           datalad.customremotes
           datalad.distribution
+          datalad.distributed
           datalad.downloaders
           datalad.interface
       # TODO: datalad.metadata (this is completely non-functional on Windows,
@@ -115,7 +116,6 @@ environment:
       # ~50min
       DTS: >
           datalad.local
-          datalad.distributed
           datalad.support
           datalad.tests
           datalad.ui

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -108,6 +108,7 @@ environment:
           datalad.distributed
           datalad.downloaders
           datalad.interface
+          datalad.tests
       # TODO: datalad.metadata (this is completely non-functional on Windows,
       #       either tests only, or actual code too)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
@@ -117,7 +118,6 @@ environment:
       DTS: >
           datalad.local
           datalad.support
-          datalad.tests
           datalad.ui
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PY: 39-x64


### PR DESCRIPTION
This is an attempt to fix #6193, but we will have to take a look at the actual runtimes with this change