### PR TITLE
INFRA: Modernize readthedocs configuration

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,11 +1,26 @@
-formats:
-    - epub
-    - pdf
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-requirements_file: requirements.txt
+# Required
+version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+
+formats: all
+
+# Optionally declare the Python requirements required to build your docs
 python:
-   version: 2
-
-python:
-   setup_py_install: true
+   install:
+   - requirements: requirements-devel.txt
+   - method: setuptools
+   - path: .


### PR DESCRIPTION
This is an attempt to fix the readthedocs build failure. I've modernized our readthedocs.yml file into a modern version 2 one. The previous one was the culprit leading to the wrong requirements being installed - I hope this one may fix it.
I will kill all CIs in this PR.