### PR TITLE
API mode indicator and library-mode enabling switch

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -25,10 +25,6 @@ import os
 
 # this is not to be modified. for querying use get_apimode()
 __api = 'python'
-# this is not to be modified. see enable/in_librarymode()
-# by default, we are in application-mode, simply because most of
-# datalad was originally implemented with this scenario assumption
-__runtime_mode = 'application'
 
 
 def get_apimode():
@@ -83,6 +79,8 @@ def enable_librarymode():
     """
     global __runtime_mode
     __runtime_mode = 'library'
+    # export into the environment for child processes to inherit
+    os.environ['DATALAD_RUNTIME_LIBRARYMODE'] = '1'
 
 
 # For reproducible demos/tests
@@ -112,6 +110,13 @@ from .config import ConfigManager
 cfg = ConfigManager()
 
 # must come after config manager
+# this is not to be modified. see enable/in_librarymode()
+# by default, we are in application-mode, simply because most of
+# datalad was originally implemented with this scenario assumption
+__runtime_mode = 'library' \
+    if cfg.getbool('datalad.runtime', 'librarymode', False) \
+    else 'application'
+
 from .log import lgr
 from datalad.support.exceptions import CapturedException
 from datalad.utils import (

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -23,6 +23,28 @@ import atexit
 import os
 
 
+# this is not to be modified. for querying use get_apimode()
+__api = 'python'
+
+
+def get_apimode():
+    """Returns the API mode label for the current session.
+
+    The API mode label indicates whether DataLad is running in "normal"
+    mode in a Python session, or whether it is used via the command line
+    interface.
+
+    This function is a utility for optimizing behavior and messaging to the
+    particular API (Python vs command line) in use in a given process.
+
+    Returns
+    {'python', 'cmdline'}
+      The API mode is 'python' by default, unless the main command line
+      entrypoint set it to 'cmdline'.
+    """
+    return __api
+
+
 # For reproducible demos/tests
 _seed = os.environ.get('DATALAD_SEED', None)
 if _seed is not None:

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -25,6 +25,10 @@ import os
 
 # this is not to be modified. for querying use get_apimode()
 __api = 'python'
+# this is not to be modified. see enable/in_librarymode()
+# by default, we are in application-mode, simply because most of
+# datalad was originally implemented with this scenario assumption
+__runtime_mode = 'application'
 
 
 def get_apimode():
@@ -43,6 +47,42 @@ def get_apimode():
       entrypoint set it to 'cmdline'.
     """
     return __api
+
+
+def in_librarymode():
+    """Returns whether DataLad is requested to run in "library mode"
+
+    In this mode DataLad aims to behave without the assumption that it is
+    itself the front-end of a process and in full control over messaging
+    and parameters.
+
+    Returns
+    -------
+    bool
+    """
+    return __runtime_mode == 'library'
+
+
+def enable_librarymode():
+    """Request DataLad to operate in library mode.
+
+    This function should be executed immediately after importing the `datalad`
+    package, when DataLad is not used as an application, or in interactive
+    scenarios, but as a utility library inside other applications. Enabling
+    this mode will turn off some convenience feature that are irrelevant in
+    such use cases (with performance benefits), and alters it messaging
+    behavior to better interoperate with 3rd-party front-ends.
+
+    Library mode can only be enabled once. Switching it on and off within
+    the runtime of a process is not supported.
+
+    Example::
+
+        >>> import datalad
+        >>> datalad.enable_librarymode()
+    """
+    global __runtime_mode
+    __runtime_mode = 'library'
 
 
 # For reproducible demos/tests

--- a/datalad/api.py
+++ b/datalad/api.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Python DataLad API exposing user-oriented commands (also available via CLI)"""
 
+import datalad
 from datalad.coreapi import *
 
 
@@ -35,7 +36,8 @@ def _command_summary():
     return "\n".join(get_cmd_summaries(grp_short_descriptions, groups))
 
 
-__doc__ += "\n\n{}".format(_command_summary())
+if not datalad.in_librarymode():
+    __doc__ += "\n\n{}".format(_command_summary())
 
 
 def _generate_extension_api():

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -276,6 +276,12 @@ def parser_add_common_options(parser, version=None):
         code. A failure is any result with status 'impossible' or 'error'.
         [Default: '%(default)s']""")
     parser.add_argument(
+        '--library-mode', dest='common_library_mode', action='store_true',
+        help="""Enable operation as a utility library (rather than a front-end
+        application). This may improve performance, because convenience
+        functionality will be disabled, and will alter the error reporting to
+        be better suited for internal use.""")
+    parser.add_argument(
         '--cmd', dest='_', action='store_true',
         help="""syntactical helper that can be used to end the list of global
         command line options before the subcommand label. Options taking

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -276,12 +276,6 @@ def parser_add_common_options(parser, version=None):
         code. A failure is any result with status 'impossible' or 'error'.
         [Default: '%(default)s']""")
     parser.add_argument(
-        '--library-mode', dest='common_library_mode', action='store_true',
-        help="""Enable operation as a utility library (rather than a front-end
-        application). This may improve performance, because convenience
-        functionality will be disabled, and will alter the error reporting to
-        be better suited for internal use.""")
-    parser.add_argument(
         '--cmd', dest='_', action='store_true',
         help="""syntactical helper that can be used to end the list of global
         command line options before the subcommand label. Options taking

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -151,6 +151,8 @@ def setup_parser(
 
 def main(args=None):
     lgr.log(5, "Starting main(%r)", args)
+    # record that we came in via the cmdline
+    datalad.__api = 'cmdline'
     args = args or sys.argv
     if on_msys_tainted_paths:
         # Possibly present DataLadRIs were stripped of a leading /

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -168,8 +168,6 @@ def main(args=None):
     # parse cmd args
     lgr.debug("Parsing known args among %s", repr(args))
     cmdlineargs, unparsed_args = parser.parse_known_args(args[1:])
-    if cmdlineargs.common_library_mode:
-        datalad.enable_librarymode()
     has_func = hasattr(cmdlineargs, 'func') and cmdlineargs.func is not None
     if unparsed_args:
         if has_func and cmdlineargs.func.__self__.__name__ != 'Export':
@@ -192,6 +190,8 @@ def main(args=None):
 
     # enable overrides
     datalad.cfg.reload(force=True)
+    if 'datalad.runtime.librarymode' in datalad.cfg:
+        datalad.enable_librarymode()
 
     if cmdlineargs.change_path is not None:
         from .common_args import change_path as change_path_opt

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -168,6 +168,8 @@ def main(args=None):
     # parse cmd args
     lgr.debug("Parsing known args among %s", repr(args))
     cmdlineargs, unparsed_args = parser.parse_known_args(args[1:])
+    if cmdlineargs.common_library_mode:
+        datalad.enable_librarymode()
     has_func = hasattr(cmdlineargs, 'func') and cmdlineargs.func is not None
     if unparsed_args:
         if has_func and cmdlineargs.func.__self__.__name__ != 'Export':
@@ -263,6 +265,8 @@ def main(args=None):
         ce = CapturedException(exc)
         lgr.error("Failed to render results due to %s", ce)
         sys.exit(1)
+    # all good, not strictly needed, but makes internal testing easier
+    sys.exit(0)
 
 
 lgr.log(5, "Done importing cmdline.main")

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -396,7 +396,9 @@ def test_librarymode():
         # to execute. It has no particular role here, other than
         # to make the code pass the location where library mode
         # should be turned on via the cmdline API
-        run_main(['--library-mode', 'clean', '--dry-run'])
+        run_main(['-c', 'datalad.runtime.librarymode=yes', 'clean', '--dry-run'])
         ok_(datalad.in_librarymode())
     finally:
+        # restore pre-test behavior
         datalad.__runtime_mode = was_mode
+        datalad.cfg.overrides.pop('datalad.runtime.librarymode')

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -70,21 +70,28 @@ def run_main(args, exit_code=0, expect_stderr=False):
     stdout, stderr  strings
        Output produced
     """
-    with patch('sys.stderr', new_callable=StringIO) as cmerr:
-        with patch('sys.stdout', new_callable=StringIO) as cmout:
-            with assert_raises(SystemExit) as cm:
-                main(["datalad"] + list(args))
-            assert_equal(cm.exception.code, exit_code)
-            stdout = cmout.getvalue()
-            stderr = cmerr.getvalue()
-            if expect_stderr is False:
-                assert_equal(stderr, "")
-            elif expect_stderr is True:
-                # do nothing -- just return
-                pass
-            else:
-                # must be a string
-                assert_equal(stderr, expect_stderr)
+    was_mode = datalad.__api
+    try:
+        with patch('sys.stderr', new_callable=StringIO) as cmerr:
+            with patch('sys.stdout', new_callable=StringIO) as cmout:
+                with assert_raises(SystemExit) as cm:
+                    main(["datalad"] + list(args))
+                eq_('cmdline', datalad.get_apimode())
+                assert_equal(cm.exception.code, exit_code)
+                stdout = cmout.getvalue()
+                stderr = cmerr.getvalue()
+                if expect_stderr is False:
+                    assert_equal(stderr, "")
+                elif expect_stderr is True:
+                    # do nothing -- just return
+                    pass
+                else:
+                    # must be a string
+                    assert_equal(stderr, expect_stderr)
+    finally:
+        # restore what we had
+        datalad.__api = was_mode
+
     return stdout, stderr
 
 

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -45,6 +45,7 @@ from datalad.tests.utils import (
     assert_re_in,
     eq_,
     in_,
+    ok_,
     ok_startswith,
     on_windows,
     slow,
@@ -386,3 +387,16 @@ def test_commanderror_jsonmsgs(src, exp):
             protocol=StdOutErrCapture)
     if ds.repo.git_annex_version >= "8.20201129":
         in_('use `git-annex export`', cme.exception.stderr)
+
+
+def test_librarymode():
+    was_mode = datalad.__runtime_mode
+    try:
+        # clean --dry-run is just a no-op command that is cheap
+        # to execute. It has no particular role here, other than
+        # to make the code pass the location where library mode
+        # should be turned on via the cmdline API
+        run_main(['--library-mode', 'clean', '--dry-run'])
+        ok_(datalad.in_librarymode())
+    finally:
+        datalad.__runtime_mode = was_mode

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -30,6 +30,7 @@ import warnings
 
 from ..ui import ui
 
+import datalad
 from datalad.interface.common_opts import eval_params
 from datalad.interface.common_opts import eval_defaults
 from datalad.support.constraints import (
@@ -484,6 +485,9 @@ def build_doc(cls, **kwargs):
     cls: Interface
       class defining a datalad command
     """
+    if datalad.in_librarymode():
+        lgr.debug("Not assembling DataLad API docs in libary-mode")
+        return cls
 
     # Note, that this is a class decorator, which is executed only once when the
     # class is imported. It builds the docstring for the class' __call__ method

--- a/datalad/support/tests/test_sshrun.py
+++ b/datalad/support/tests/test_sshrun.py
@@ -77,8 +77,9 @@ def test_ssh_option():
     # back an empty value, assume that isn't configured, and skip the test.
     with patch.dict('os.environ', {"LC_DATALAD_HACK": 'hackbert'}):
         with swallow_outputs() as cmo:
-            main(["datalad", "sshrun", "-oSendEnv=LC_DATALAD_HACK",
-                  "datalad-test", "echo $LC_DATALAD_HACK"])
+            with assert_raises(SystemExit):
+                main(["datalad", "sshrun", "-oSendEnv=LC_DATALAD_HACK",
+                      "datalad-test", "echo $LC_DATALAD_HACK"])
             out = cmo.out.strip()
             if not out:
                 raise SkipTest(

--- a/docs/source/design/application_vs_library_mode.rst
+++ b/docs/source/design/application_vs_library_mode.rst
@@ -1,0 +1,52 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_design_application_vs_libary_mode:
+
+***************************************
+Application-type vs. library-type usage
+***************************************
+
+.. topic:: Specification scope and status
+
+   This specification describes the current implementation.
+
+Historically, DataLad was implemented with the assumption of application-type
+usage, i.e., a person using DataLad through any of its APIs. Consequently,
+(error) messaging was primarily targeting humans, and usage advice focused on
+interactive use. With the increasing utilization of DataLad as an
+infrastructural component it was necessary to address use cases of library-type
+or internal usage more explicitly.
+
+DataLad continues to behave like a stand-alone application by default.
+
+For internal use, Python and command-line APIs provide dedicated mode switches.
+
+The command line entry point offers a ``--library-mode`` switch that enables
+the mode very early in the process runtime, and for the complete lifetime of the
+process. Similarly, the Python API offers a function ``enable_libarymode()``
+that should be called immediately after importing the ``datalad`` package
+for maximum impact.
+
+.. code-block:: python
+
+   >>> import datalad
+   >>> datalad.enable_libarymode()
+
+Moreover, with ``datalad.in_librarymode()`` a query utility is provided that
+can be used throughout the code base for adjusting behavior according to the
+usage scenario.
+
+Switching back and forth between modes during the runtime of a process is not
+supported.
+
+Care must be taken to configure child-processes of the main DataLad
+process/session appropriately, for example internal Dataset procedure calls, in
+order to inherit the mode of the parent process.
+
+
+Library-mode implications
+=========================
+
+Once the mode distinction has actual behavioral consequences, such consequences
+should be summarized here.

--- a/docs/source/design/application_vs_library_mode.rst
+++ b/docs/source/design/application_vs_library_mode.rst
@@ -48,5 +48,6 @@ order to inherit the mode of the parent process.
 Library-mode implications
 =========================
 
-Once the mode distinction has actual behavioral consequences, such consequences
-should be summarized here.
+No Python API docs
+  Generation of comprehensive doc-strings for all API commands is skipped. This
+  speeds up ``import datalad.api`` by about 30%.

--- a/docs/source/design/application_vs_library_mode.rst
+++ b/docs/source/design/application_vs_library_mode.rst
@@ -22,16 +22,22 @@ DataLad continues to behave like a stand-alone application by default.
 
 For internal use, Python and command-line APIs provide dedicated mode switches.
 
-The command line entry point offers a ``--library-mode`` switch that enables
-the mode very early in the process runtime, and for the complete lifetime of the
-process. Similarly, the Python API offers a function ``enable_libarymode()``
-that should be called immediately after importing the ``datalad`` package
-for maximum impact.
+Library mode can be enabled by setting the boolean configuration setting
+``datalad.runtime.librarymode`` **before the start of the DataLad process**.
+From the command line, this can be done with the option
+``-c datalad.runtime.librarymode=yes``, or any other means for setting
+configuration. In an already running Python process, library mode can be
+enabled by calling ``datalad.enable_libarymode()``. This should be done
+immediately after importing the ``datalad`` package for maximum impact.
 
 .. code-block:: python
 
    >>> import datalad
    >>> datalad.enable_libarymode()
+
+In a Python session, library mode **cannot** be enabled reliably by just setting
+the configuration flag **after** the ``datalad`` package was already imported.
+The ``enable_librarymode()`` function must be used.
 
 Moreover, with ``datalad.in_librarymode()`` a query utility is provided that
 can be used throughout the code base for adjusting behavior according to the
@@ -40,9 +46,9 @@ usage scenario.
 Switching back and forth between modes during the runtime of a process is not
 supported.
 
-Care must be taken to configure child-processes of the main DataLad
-process/session appropriately, for example internal Dataset procedure calls, in
-order to inherit the mode of the parent process.
+A library mode setting is exported into the environment of the Python process.
+By default, it will be inherited by all child-processes, such as dataset
+procedure executions.
 
 
 Library-mode implications

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -13,6 +13,7 @@ subsystems in DataLad.
 .. toctree::
    :maxdepth: 2
 
+   application_vs_library_mode
    file_url_handling
    result_records
    dataset_argument


### PR DESCRIPTION
This PR lays the foundation to introduce "library-mode" behavior, and to distinguish via which API datalad functionality is being accessed. These aspects are related but orthogonal.

Summary:

- Added `datalad.get_apimode()` to query for the effective API in use
- Added `datalad.enable_librarymode()` to put DataLad in lib-mode
- Added `datalad.in_librarymode()` to test for active lib-mode
- Added design document on this

This is the foundation to further tailor messaging, logging behavior, etc. None of which is planned for this PR.

Additional changes:

- Unit tests for the mode queries (limited to deviation from the default)
- Disabled Python API doc generation in lib-mode (shaves off 150ms process startup time on my machine)

- Fixes #6081