### PR TITLE
MNT: Harmonize sibling parameter to -s/--sibling-name

### DIFF
--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -111,7 +111,7 @@ class CreateSiblingGitlab(Interface):
         Name of the default GitLab site (see --site)
     "datalad.gitlab-SITENAME-siblingname"
         Name of the sibling configured for the local dataset that points
-        to the GitLab instance SITENAME (see --name)
+        to the GitLab instance SITENAME (see --sibling-name)
     "datalad.gitlab-SITENAME-layout"
         Project layout used at the GitLab instance SITENAME (see --layout)
     "datalad.gitlab-SITENAME-access"
@@ -165,7 +165,7 @@ class CreateSiblingGitlab(Interface):
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         name=Parameter(
-            args=('-s', '--name',),
+            args=('-s', '--sibling-name',),
             metavar='NAME',
             doc="""name to represent the GitLab sibling remote in the local
             dataset installation. If not specified a name is looked up in the

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -163,8 +163,9 @@ class CreateSiblingRia(Interface):
             for creation of the repository sibling in the RIA store.""",
             constraints=EnsureStr() | EnsureNone()),
         name=Parameter(
-            args=('-s', '--name',),
+            args=('-s', '--sibling-name', '--name'),
             metavar='NAME',
+            dest='name',
             doc="""Name of the sibling.
             With `recursive`, the same name will be used to label all
             the subdatasets' siblings.""",

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -452,7 +452,7 @@ class CreateSibling(Interface):
                 URL and path on the server.""",
             constraints=EnsureStr()),
         name=Parameter(
-            args=('-s', '--name',),
+            args=('-s', '--sibling-name',),
             metavar='NAME',
             doc="""sibling name to create for this publication target.
                 If `recursive` is set, the same name will be used to label all

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -140,7 +140,7 @@ class Siblings(Interface):
             based on the input and/or the current working directory""",
             constraints=EnsureDataset() | EnsureNone()),
         name=Parameter(
-            args=('-s', '--name',),
+            args=('-s', '--sibling-name',),
             metavar='NAME',
             doc="""name of the sibling. For addition with path "URLs" and
             sibling removal this option is mandatory, otherwise the hostname

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -89,7 +89,7 @@ def test_update_simple(origin, src_path, dst_path):
     # deprecation message doesn't ruin things
     assert_status('notneeded', source.update(fetch_all=True))
     # but error if unknown sibling is given
-    assert_status('impossible', source.update(sibling='funky', on_failure='ignore'))
+    assert_status('impossible', source.update(name='funky', on_failure='ignore'))
 
     # get a clone to update later on:
     dest = install(dst_path, source=src_path, recursive=True)
@@ -263,7 +263,7 @@ def test_update_fetch_all(path):
 
     # merge a certain remote:
     assert_result_count(
-        ds.update(sibling='sibling_1', merge=True),
+        ds.update(name='sibling_1', merge=True),
         1, action='update', status='ok', type='dataset')
 
     # changes from sibling_2 still not present:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -129,14 +129,20 @@ class Update(Interface):
             operation.""",
             nargs="*",
             constraints=EnsureStr() | EnsureNone()),
-        sibling=Parameter(
-            args=("-s", "--sibling",),
+        name=Parameter(
+            args=("-s", "--sibling-name",),
             doc="""name of the sibling to update from. When unspecified,
             updates from all siblings are fetched. If there is more than one
             sibling and changes will be brought into the working tree (as
             requested via [CMD: --merge, --how, or --how-subds CMD][PY:
             `merge`, `how`, or `how_subds` PY]), a sibling will be chosen based
             on the configured remote for the current branch.""",
+            constraints=EnsureStr() | EnsureNone()),
+        sibling=Parameter(
+            args=("--sibling",),
+            doc="""DEPRECATED, will be removed in a future release.
+            Please use  the renamed parameter [CMD: -s/--sibling-name CMD][PY:
+            name PY] instead""",
             constraints=EnsureStr() | EnsureNone()),
         dataset=Parameter(
             args=("-d", "--dataset"),
@@ -215,6 +221,7 @@ class Update(Interface):
     def __call__(
             path=None,
             sibling=None,
+            name=None,
             merge=False,
             how=None,
             how_subds=None,
@@ -226,6 +233,13 @@ class Update(Interface):
             reobtain_data=False):
         if fetch_all is not None:
             lgr.warning('update(fetch_all=...) called. Option has no effect, and will be removed')
+        if sibling is not None:
+            import warnings
+            warnings.warn("The --sibling parameter has been renamed to -s/"
+                          "--sibling-name.",
+                          DeprecationWarning)
+        else:
+            sibling = name
         if path and not recursive:
             lgr.warning('path constraints for subdataset updates ignored, '
                         'because `recursive` option was not given')


### PR DESCRIPTION
This PR implements the suggestion in #3832 and the proposed design document in #6214 by harmonizing the ``name`` parameter for dataset siblings to be ``-s``/``--sibling-name``. Let's see what breaks with this.