### PR TITLE
NF: Teach clone and install to name siblings other names than origin

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -22,6 +22,7 @@ from datalad.interface.results import get_status_dict
 from datalad.interface.common_opts import (
     location_description,
     reckless_opt,
+    origin_opt,
 )
 from datalad.log import log_progress
 from datalad.support.gitrepo import (
@@ -223,6 +224,7 @@ class Clone(Interface):
             similar to :command:`git clone`"""),
         description=location_description,
         reckless=reckless_opt,
+        origin=origin_opt,
     )
 
     @staticmethod
@@ -232,6 +234,7 @@ class Clone(Interface):
             source,
             path=None,
             dataset=None,
+            origin=None,
             description=None,
             reckless=None):
         # did we explicitly get a dataset to install into?
@@ -321,6 +324,7 @@ class Clone(Interface):
         for r in clone_dataset(
                 [source],
                 destination_dataset,
+                origin,
                 reckless,
                 description,
                 result_props,
@@ -456,6 +460,7 @@ def _map_urls(cfg, urls):
 def clone_dataset(
         srcs,
         destds,
+        origin=None,
         reckless=None,
         description=None,
         result_props=None,
@@ -472,6 +477,8 @@ def clone_dataset(
       Any suitable clone source specifications (paths, URLs)
     destds : Dataset
       Dataset instance for the clone destination
+    origin : str
+      Sibling name to use for clone source. Is passed as --origin to git clone.
     reckless : {None, 'auto', 'ephemeral', 'shared-...'}, optional
       Mode switch to put cloned dataset into unsafe/throw-away configurations, i.e.
       sacrifice data safety for performance or resource footprint. When None
@@ -591,6 +598,8 @@ def clone_dataset(
 
         if cand.get('version', None):
             clone_opts['branch'] = cand['version']
+        if origin is not None:
+            clone_opts['origin'] = origin
         try:
             # TODO for now GitRepo.clone() cannot handle Path instances, and PY35
             # doesn't make it happen seamlessly

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -21,6 +21,7 @@ from datalad.api import (
     clone,
     create,
     remove,
+    siblings,
 )
 from datalad.utils import (
     chpwd,
@@ -169,7 +170,8 @@ def test_clone_datasets_root(tdir):
 
 @with_testrepos('.*basic.*', flavors=['local-url', 'network', 'local'])
 @with_tempfile(mkdir=True)
-def test_clone_simple_local(src, path):
+@with_tempfile(mkdir=True)
+def test_clone_simple_local(src, path, path2):
     origin = Dataset(path)
 
     # now install it somewhere else
@@ -209,6 +211,13 @@ def test_clone_simple_local(src, path):
     if isinstance(origin.repo, AnnexRepo):
         eq_(uuid_before, ds.repo.uuid)
 
+    # install it with a custom sibling name
+    res = clone(src, path2, origin='custom',
+                result_xfm=None, return_type='list')
+    assert_status('ok', res)
+    assert_in('custom',
+              [s['name'] for s in siblings(dataset=path2,
+                                           result_renderer='disabled')])
 
 
 # AssertionError: unexpected content of state "deleted": [WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/datalad_temp_gzegy3hf/testrepo--basic--r1/test-annex.dat')] != []

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -20,6 +20,7 @@ from datalad.interface.common_opts import (
     location_description,
     jobs_opt,
     reckless_opt,
+    origin_opt,
 )
 from datalad.interface.results import (
     get_status_dict,
@@ -161,6 +162,7 @@ class Install(Interface):
         recursion_limit=recursion_limit,
         reckless=reckless_opt,
         jobs=jobs_opt,
+        origin=origin_opt,
     )
 
     @staticmethod
@@ -175,7 +177,8 @@ class Install(Interface):
             recursive=False,
             recursion_limit=None,
             reckless=None,
-            jobs="auto"):
+            jobs="auto",
+            origin=None):
 
         # normalize path argument to be equal when called from cmdline and
         # python and nothing was passed into `path`
@@ -361,7 +364,8 @@ class Install(Interface):
             result_xfm=None,
             return_type='generator',
             result_filter=None,
-            on_failure='ignore')
+            on_failure='ignore',
+            origin=origin)
         # helper
         as_ds = YieldDatasets()
         destination_dataset = None

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -289,6 +289,14 @@ reporton_opt = Parameter(
     doc="""choose on what type result to report on: 'datasets',
     'files', 'all' (both datasets and files), or 'none' (no report).""",
     constraints=EnsureChoice('all', 'datasets', 'files', 'none'))
+
+origin_opt = Parameter(
+    args=("-o", "--origin",),
+    metavar='ORIGIN',
+    doc="""Sibling name for the source location the dataset is cloned
+    from. Defaults to 'origin', or the Git (version >2.30) configuration
+    value of clone.defaultRemoteName""",
+    constraints=EnsureStr() | EnsureNone())
 # define parameters to be used by eval_results to tune behavior
 # Note: This is done outside eval_results in order to be available when building
 # docstrings for the decorated functions


### PR DESCRIPTION
This is an attempt to implement #5320: Giving ``clone`` and `install` the ability to custom name the sibling it was cloned from. It is implemented as a new common ``-o``/``--origin`` parameter, and uses Git's own ``-o``/``--origin`` parameter under the hood.
I stayed consistent with Gits naming scheme, and referenced the configuration ``clone.defaultRemoteName`` (Git version 2.30 and up) in the parameter docstring as well.

Fixes #5320