### PR TITLE
Last step before {Git|Annex}Repo.add() removal

### DIFF
--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -216,7 +216,7 @@ def test_diff(path, norepo):
         ds.diff(path='new', result_renderer='disabled'), 1,
         action='diff', path=op.join(ds.path, 'new'), state='modified')
     # stage changes
-    ds.repo.add('.', git=True)
+    ds.repo._save_add('.', git=True)
     # no change in diff, staged is not committed
     assert_result_count(_dirty_results(ds.diff(result_renderer='disabled')), 1)
     ds.save()
@@ -246,7 +246,7 @@ def test_diff(path, norepo):
     assert_result_count(
         ds.diff(path='deep', result_renderer='disabled'), 1,
         state='untracked', path=op.join(ds.path, 'deep'))
-    ds.repo.add(op.join('deep', 'down2'), git=True)
+    ds.repo._save_add(op.join('deep', 'down2'), git=True)
     # now the remaining file is the only untracked one
     assert_result_count(
         ds.diff(result_renderer='disabled'), 1, state='untracked',

--- a/datalad/customremotes/tests/test_archives.py
+++ b/datalad/customremotes/tests/test_archives.py
@@ -77,10 +77,8 @@ def test_basic_scenario(d, d2):
     assert annex.is_special_annex_remote(ARCHIVES_SPECIAL_REMOTE)
     # We want two maximally obscure names, which are also different
     assert(fn_extracted != fn_in_archive_obscure)
-    annex.add(fn_archive)
-    annex.commit(msg="Added tarball")
-    annex.add(fn_extracted)
-    annex.commit(msg="Added the load file")
+    annex.save("Added tarball", [fn_archive])
+    annex.save("Added the load file", [fn_extracted])
 
     # Operations with archive remote URL
     # this is not using this class for its actual purpose

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -40,8 +40,7 @@ from ..base import (
 @with_tree(tree={'file.dat': ''})
 def test_get_contentlocation(tdir):
     repo = AnnexRepo(tdir, create=True, init=True)
-    repo.add('file.dat')
-    repo.commit('added file.dat')
+    repo.save('added file.dat', ['file.dat'])
 
     # TODO contentlocation would come with eval_availability=True
     key = repo.get_file_annexinfo('file.dat')['key']

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -96,8 +96,7 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
     fn = opj(path, "file%d.dat" % random.randint(1, 1000))
     with open(fn, 'w') as f:
         f.write(fn)
-    repo.add(fn, git=True)
-    repo.commit(msg="Added %s" % fn)
+    repo.save("Added %s" % fn, paths=[fn], git=True)
 
     yield path
 

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -88,8 +88,7 @@ from ..dataset import Dataset
 @with_tempfile
 def _test_guess_dot_git(annex, path, url, tdir):
     repo = (AnnexRepo if annex else GitRepo)(path, create=True)
-    repo.add('file.txt', git=not annex)
-    repo.commit()
+    repo.save(paths=['file.txt'], git=not annex)
 
     # we need to prepare to be served via http, otherwise it must fail
     with swallow_logs() as cml:
@@ -291,8 +290,7 @@ def test_install_dataladri(src, topurl, path):
     # make plain git repo
     ds_path = opj(src, 'ds')
     gr = GitRepo(ds_path, create=True)
-    gr.add('test.txt')
-    gr.commit('demo')
+    gr.save('demo', paths=['test.txt'])
     Runner(cwd=gr.path).run(['git', 'update-server-info'])
     # now install it somewhere else
     with patch('datalad.consts.DATASETS_TOPURL', topurl), \

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -104,7 +104,7 @@ def test_dirty(path):
     # we don't want to auto-add untracked files by saving (anymore)
     assert_raises(AssertionError, _check_auto_save, ds, orig_state)
     # tainted: staged
-    ds.repo.add('something', git=True)
+    ds.repo._save_add('something', git=True)
     orig_state = _check_auto_save(ds, orig_state)
     # tainted: submodule
     # not added to super on purpose!

--- a/datalad/local/tests/test_check_dates.py
+++ b/datalad/local/tests/test_check_dates.py
@@ -65,8 +65,7 @@ def test_check_dates(path):
     repo = os.path.join(path, "repo")
     with set_date(ref_ts + 5000):
         ar = AnnexRepo(repo)
-        ar.add(".")
-        ar.commit()
+        ar.save(paths=["."])
 
     # The standard renderer outputs json.
     with swallow_outputs() as cmo:

--- a/datalad/local/tests/test_rerun.py
+++ b/datalad/local/tests/test_rerun.py
@@ -536,8 +536,7 @@ def test_new_or_modified(path):
 
     with open(op.join(path, "to_add"), "w") as f:
         f.write("content5")
-    ds.repo.add(["to_add"])
-    ds.repo.commit("add one, remove another")
+    ds.repo.save("add one, remove another", ["to_add"])
 
     eq_(get_new_or_modified(ds, "HEAD"),
         ["to_add"])
@@ -797,7 +796,7 @@ def test_rerun_explicit(path):
     # But checking out a new HEAD can fail when there are modifications.
     ds.repo.checkout(DEFAULT_BRANCH)
     ok_(ds.repo.dirty)
-    ds.repo.add(["to_modify"], git=True)
+    ds.repo._save_add(["to_modify"], git=True)
     ds.save()
     assert_false(ds.repo.dirty)
     with open(op.join(ds.path, "to_modify"), "a") as ofh:

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -727,7 +727,12 @@ def _update_ds_agginfo(refds_path, ds_path, subds_paths, incremental, agginfo_db
 
     if objs2add:
         # they are added standard way, depending on the repo type
-        ds.repo.add([op.join(agg_base_path, p) for p in objs2add])
+        # list() to consume the generator
+        # TODO redo to avoid any staging and use save() directly
+        list(
+            ds.repo._save_add_(
+                {op.join(agg_base_path, p): {} for p in objs2add})
+        )
         # queue for save, and mark as staged
         to_save.extend(
             [dict(path=op.join(agg_base_path, p), type='file', staged=True)
@@ -737,7 +742,11 @@ def _update_ds_agginfo(refds_path, ds_path, subds_paths, incremental, agginfo_db
         return
 
     _store_agginfo_db(ds, ds_agginfos)
-    ds.repo.add(agginfo_fpath, git=True)
+    # list() to consume the generator
+    # TODO redo to avoid any staging and use save() directly
+    list(
+        ds.repo._save_add_({agginfo_fpath: {}}, git=True)
+    )
     # queue for save, and mark as staged
     to_save.append(
         dict(path=agginfo_fpath, type='file', staged=True))

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -230,8 +230,7 @@ def test_ignore_nondatasets(path):
         r = cls(subm_path, create=True)
         with open(opj(subm_path, 'test'), 'w') as f:
             f.write('test')
-        r.add('test')
-        r.commit('some')
+        r.save('some', ['test'])
         assert_true(Dataset(subm_path).is_installed())
         assert_equal(meta, _kill_time(ds.metadata(reporton='datasets', on_failure='ignore')))
         # making it a submodule has no effect either

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -349,7 +349,10 @@ class AnnexRepo(GitRepo, RepoInterface):
                 self.set_gitattributes(
                     [('*', {'annex.backend': backend})],
                     git_attributes_file)
-                self.add(git_attributes_file, git=True)
+                # list to consume the generator
+                # TODO evaluate whether the `commit=False` possibility is
+                # needed/used and replace all this with a plain save()
+                list(self._save_add_({git_attributes_file: {}}, git=True))
                 if commit:
                     self.commit(
                         "Set default backend for all files to be %s" % backend,
@@ -3348,7 +3351,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         self._mark_content_availability(info)
         return info
 
-    def _save_add(self, files, git=None, git_opts=None):
+    def _save_add_(self, files, git=None, git_opts=None):
         """Simple helper to add files in save()"""
         from datalad.interface.results import get_status_dict
         # alter default behavior of git-annex by considering dotfiles
@@ -3370,7 +3373,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 p: props for p, props in files.items()
                 if props.get('type', None) == 'symlink'}
             if symlinks_toadd:
-                for r in GitRepo._save_add(
+                for r in GitRepo._save_add_(
                         self,
                         symlinks_toadd,
                         git_opts=git_opts):
@@ -3387,7 +3390,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             expected_additions = {p: self.get_file_size(p) for p in files}
 
         if git is True:
-            yield from GitRepo._save_add(self, files, git_opts=git_opts)
+            yield from GitRepo._save_add_(self, files, git_opts=git_opts)
         else:
             for r in self._call_annex_records(
                     ['add'] + options,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1577,8 +1577,13 @@ class AnnexRepo(GitRepo, RepoInterface):
         ))
 
     def add_(self, files, git=None, backend=None, options=None, jobs=None,
-            git_options=None, annex_options=None, update=False):
+             git_options=None, annex_options=None, update=False):
         """Like `add`, but returns a generator"""
+        warnings.warn(
+            "AnnexRepo.add() and AnnexRepo.add_() were deprecated with "
+            "DataLad 0.16. They will be removed in a subsequent release. "
+            "Use AnnexRepo.save() or AnnexRepo.call_annex(['add',...]) "
+            "instead.", DeprecationWarning)
         if update and not git:
             raise InsufficientArgumentsError("option 'update' requires 'git', too")
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1208,6 +1208,11 @@ class GitRepo(CoreGitRepo):
 
     def add_(self, files, git=True, git_options=None, update=False):
         """Like `add`, but returns a generator"""
+        warnings.warn(
+            "GitRepo.add() and GitRepo.add_() were deprecated with "
+            "DataLad 0.16. They will be removed in a subsequent release. "
+            "Use GitRepo.save() or GitRepo.call_git(['add',...]) instead.",
+            DeprecationWarning)
         # TODO: git_options is used as options for the git-add here,
         # instead of options to the git executable => rename for consistency
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1532,6 +1532,7 @@ def test_get_urls_none(path):
     eq_(ar.get_urls("afile"), [])
 
 
+@skip_if(cond=not hasattr(AnnexRepo, 'add'))
 @with_tempfile(mkdir=True)
 def test_annex_add_no_dotfiles(path):
     ar = AnnexRepo(path, create=True)
@@ -1546,7 +1547,7 @@ def test_annex_add_no_dotfiles(path):
     # make sure the repo is considered dirty now
     assert_true(ar.dirty)  # TODO: has been more detailed assertion (untracked file)
     # now add to git, and it should work
-    ar._save_add('.', git=True)
+    ar.add('.', git=True)
     # all in index
     assert_true(ar.dirty)
     # TODO: has been more specific:

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -211,7 +211,7 @@ def test_GitRepo_bare(path, empty_dir, non_empty_dir, empty_dot_git, non_bare,
 )
 def test_init_fail_under_known_subdir(path):
     repo = GitRepo(path, create=True)
-    repo.add(op.join('subds', 'file_name'))
+    repo._save_add(op.join('subds', 'file_name'))
     # Should fail even if we do not commit but only add to index:
     with assert_raises(PathKnownToRepositoryError) as cme:
         GitRepo(op.join(path, 'subds'), create=True)
@@ -247,9 +247,9 @@ def test_GitRepo_add(src, path):
     filename = get_most_obscure_supported_name()
     with open(op.join(path, filename), 'w') as f:
         f.write("File to add to git")
-    added = gr.add(filename)
+    added = gr._save_add(filename)
 
-    eq_(added, {'success': True, 'file': filename})
+    assert_in_results(added, status='ok', path=Path(path, filename))
     assert_in(filename, gr.get_indexed_files(),
               "%s not successfully added to %s" % (filename, path))
     # uncommitted:
@@ -260,9 +260,9 @@ def test_GitRepo_add(src, path):
         f.write("Another file to add to git")
 
     # include committing:
-    added2 = gr.add(filename)
+    added2 = gr._save_add(filename)
     gr.commit(msg="Add two files.")
-    eq_(added2, {'success': True, 'file': filename})
+    assert_in_results(added2, status='ok', path=Path(path, filename))
 
     assert_in(filename, gr.get_indexed_files(),
               "%s not successfully added to %s" % (filename, path))
@@ -282,8 +282,7 @@ def test_GitRepo_add(src, path):
 def test_GitRepo_remove(path):
 
     gr = GitRepo(path, create=True)
-    gr.add('*')
-    gr.commit("committing all the files")
+    gr.save("committing all the files", ['*'])
 
     eq_(gr.remove('file'), ['file'])
     eq_(set(gr.remove('d', r=True, f=True)), {'d/f1', 'd/f2'})
@@ -300,8 +299,7 @@ def test_GitRepo_commit(path):
     with open(op.join(path, filename), 'w') as f:
         f.write("File to add to git")
 
-    gr.add(filename)
-    gr.commit("Testing GitRepo.commit().")
+    gr.save("Testing GitRepo.commit().", [filename])
     assert_repo_status(gr)
     eq_("Testing GitRepo.commit().",
         gr.format_commit("%B").strip())
@@ -309,7 +307,7 @@ def test_GitRepo_commit(path):
     with open(op.join(path, filename), 'w') as f:
         f.write("changed content")
 
-    gr.add(filename)
+    gr._save_add(filename)
     gr.commit("commit with options", options=to_options(dry_run=True))
     # wasn't actually committed:
     ok_(gr.dirty)
@@ -324,7 +322,7 @@ def test_GitRepo_commit(path):
     last_sha = gr.get_hexsha()
     with open(op.join(path, filename), 'w') as f:
         f.write("changed again")
-    gr.add(filename)
+    gr.call_git(['add', filename])
     gr.commit("amend message", options=to_options(amend=True))
     assert_repo_status(gr)
     assert_equal(gr.format_commit("%B").strip(), "amend message")
@@ -356,7 +354,7 @@ def test_GitRepo_get_indexed_files(path):
     for filename in ('some1.txt', 'some2.dat'):
         with open(op.join(path, filename), 'w') as f:
             f.write(filename)
-        gr.add(filename)
+        gr.call_git(['add', filename])
     gr.commit('Some files')
 
     idx_list = gr.get_indexed_files()
@@ -523,11 +521,10 @@ def test_GitRepo_get_remote_url(path):
 @with_tempfile
 @with_tempfile
 def test_GitRepo_fetch(orig_path, clone_path):
-
     origin = GitRepo(orig_path)
     with open(op.join(orig_path, 'some.txt'), 'w') as f:
         f.write("New text file.")
-    origin.add('some.txt')
+    origin.call_git(['add', 'some.txt'])
     origin.commit("new file added.")
 
     clone = GitRepo.clone(orig_path, clone_path)
@@ -536,8 +533,7 @@ def test_GitRepo_fetch(orig_path, clone_path):
     origin.checkout("new_branch", ['-b'])
     with open(op.join(orig_path, filename), 'w') as f:
         f.write("New file.")
-    origin.add(filename)
-    origin.commit("new file added.")
+    origin.save("new file added.", [filename])
 
     fetched = clone.fetch(remote=DEFAULT_REMOTE)
     # test FetchInfo list returned by fetch
@@ -577,7 +573,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
     remote_repo = GitRepo(remote_path)
     with open(op.join(remote_path, 'some.txt'), 'w') as f:
         f.write("New text file.")
-    remote_repo.add('some.txt')
+    remote_repo.call_git(['add', 'some.txt'])
     remote_repo.commit("new file added.")
 
     url = _path2localsshurl(remote_path)
@@ -621,8 +617,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     repo.checkout("ssh-test", ['-b'])
     with open(op.join(repo.path, "ssh_testfile.dat"), "w") as f:
         f.write("whatever")
-    repo.add("ssh_testfile.dat")
-    repo.commit("ssh_testfile.dat added.")
+    repo.save("ssh_testfile.dat added.", ["ssh_testfile.dat"])
 
     # file is not known to the remote yet:
     assert_not_in("ssh_testfile.dat", remote_repo.get_indexed_files())
@@ -674,8 +669,7 @@ def test_GitRepo_push_n_checkout(orig_path, clone_path):
 
     with open(op.join(clone_path, filename), 'w') as f:
         f.write("New file.")
-    clone.add(filename)
-    clone.commit("new file added.")
+    clone.save("new file added.", [filename])
     # TODO: need checkout first:
     clone.push(DEFAULT_REMOTE, '+{}:new-branch'.format(DEFAULT_BRANCH))
     origin.checkout('new-branch')
@@ -697,24 +691,20 @@ def test_GitRepo_remote_update(path1, path2, path3):
     # Setting up remote 'git2'
     with open(op.join(path2, 'masterfile'), 'w') as f:
         f.write("git2 in master")
-    git2.add('masterfile')
-    git2.commit("Add something to master.")
+    git2.save("Add something to master.", ['masterfile'])
     git2.checkout('branch2', ['-b'])
     with open(op.join(path2, 'branch2file'), 'w') as f:
         f.write("git2 in branch2")
-    git2.add('branch2file')
-    git2.commit("Add something to branch2.")
+    git2.save("Add something to branch2.", ['branch2file'])
 
     # Setting up remote 'git3'
     with open(op.join(path3, 'masterfile'), 'w') as f:
         f.write("git3 in master")
-    git3.add('masterfile')
-    git3.commit("Add something to master.")
+    git3.save("Add something to master.", ['masterfile'])
     git3.checkout('branch3', ['-b'])
     with open(op.join(path3, 'branch3file'), 'w') as f:
         f.write("git3 in branch3")
-    git3.add('branch3file')
-    git3.commit("Add something to branch3.")
+    git3.save("Add something to branch3.", ['branch3file'])
 
     git1.update_remote()
 
@@ -734,7 +724,7 @@ def test_GitRepo_get_files(src_path, path):
     for filename in ('some1.txt', 'some2.dat'):
         with open(op.join(src_path, filename), 'w') as f:
             f.write(filename)
-        src.add(filename)
+        src.call_git(['add', filename])
     src.commit('Some files')
 
     gr = GitRepo.clone(src.path, path)
@@ -762,8 +752,7 @@ def test_GitRepo_get_files(src_path, path):
     filename = 'another_file.dat'
     with open(op.join(path, filename), 'w') as f:
         f.write("something")
-    gr.add(filename)
-    gr.commit("Added.")
+    gr.save("Added.", [filename])
 
     # now get the files again:
     local_files = set(gr.get_files())
@@ -811,7 +800,7 @@ def test_GitRepo_dirty(path):
         f.write('whatever')
     ok_(repo.dirty)
     # staged file
-    repo.add('file1.txt')
+    repo._save_add('file1.txt')
     ok_(repo.dirty)
     # clean again
     repo.commit("file1.txt added")
@@ -825,8 +814,7 @@ def test_GitRepo_dirty(path):
         f.write('something else')
     ok_(repo.dirty)
     # clean again
-    repo.add('file1.txt')
-    repo.commit("file1.txt modified")
+    repo.save("file1.txt modified", ['file1.txt'])
     ok_(not repo.dirty)
 
     # An empty directory doesn't count as dirty.
@@ -864,8 +852,7 @@ def test_GitRepo_get_merge_base(src):
     repo = GitRepo(src, create=True)
     with open(op.join(src, 'file.txt'), 'w') as f:
         f.write('load')
-    repo.add('*')
-    repo.commit('committing')
+    repo.save('committing', ['*'])
 
     assert_raises(ValueError, repo.get_merge_base, [])
     branch1 = repo.get_active_branch()
@@ -879,10 +866,9 @@ def test_GitRepo_get_merge_base(src):
     # it will have all the files
     # Must not do:  https://github.com/gitpython-developers/GitPython/issues/375
     # repo.git_add('.')
-    repo.add('*')
     # NOTE: fun part is that we should have at least a different commit message
     # so it results in a different checksum ;)
-    repo.commit("committing again")
+    repo.save("committing again", ['*'])
     assert(repo.get_indexed_files())  # we did commit
     assert(repo.get_merge_base(branch1) is None)
     assert(repo.get_merge_base([branch2, branch1]) is None)
@@ -901,8 +887,7 @@ def test_GitRepo_git_get_branch_commits_(src):
     repo = GitRepo(src, create=True)
     with open(op.join(src, 'file.txt'), 'w') as f:
         f.write('load')
-    repo.add('*')
-    repo.commit('committing')
+    repo.save('committing', ['*'])
 
     commits_default = list(repo.get_branch_commits_())
     commits = list(repo.get_branch_commits_(DEFAULT_BRANCH))
@@ -917,7 +902,7 @@ def test_get_tracking_branch(o_path, c_path):
     for filename in ('some1.txt', 'some2.dat'):
         with open(op.join(o_path, filename), 'w') as f:
             f.write(filename)
-        src.add(filename)
+        src.call_git(['add', filename])
     src.commit('Some files')
 
     clone = GitRepo.clone(o_path, c_path)
@@ -1048,8 +1033,7 @@ def test_optimized_cloning(path):
     repo = GitRepo(originpath, create=True)
     with open(op.join(originpath, 'test'), 'w') as f:
         f.write('some')
-    repo.add('test')
-    repo.commit('init')
+    repo.save('init', ['test'])
     assert_repo_status(originpath, annex=False)
     from glob import glob
 
@@ -1172,8 +1156,7 @@ def test_GitRepo_gitignore(path):
     sub = GitRepo(op.join(path, 'ignore-sub.me'))
     # we need to commit something, otherwise add_submodule
     # will already refuse the submodule for having no commit
-    sub.add('a_file.txt')
-    sub.commit()
+    sub.save(paths=['a_file.txt'])
 
     from ..exceptions import GitIgnoreError
 
@@ -1181,11 +1164,11 @@ def test_GitRepo_gitignore(path):
         f.write("*.me")
 
     with assert_raises(GitIgnoreError) as cme:
-        gr.add('ignore.me')
+        gr._save_add('ignore.me')
     eq_(cme.exception.paths, ['ignore.me'])
 
     with assert_raises(GitIgnoreError) as cme:
-        gr.add(['ignore.me', 'dontigno.re', op.join('ignore-sub.me', 'a_file.txt')])
+        gr._save_add(['ignore.me', 'dontigno.re', op.join('ignore-sub.me', 'a_file.txt')])
     eq_(set(cme.exception.paths), {'ignore.me', 'ignore-sub.me'})
 
     eq_(gr.get_gitattributes('.')['.'], {})  # nothing is recorded within .gitattributes
@@ -1305,8 +1288,7 @@ def test_get_tags(path):
     with patch.dict("os.environ", {"GIT_COMMITTER_DATE":
                                    "Thu, 07 Apr 2005 22:13:13 +0200"}):
         create_tree(gr.path, {'file': ""})
-        gr.add('file')
-        gr.commit(msg="msg")
+        gr.save("msg", paths=['file'])
         eq_(gr.get_tags(), [])
         eq_(gr.describe(), None)
 
@@ -1322,8 +1304,7 @@ def test_get_tags(path):
                                    "Fri, 08 Apr 2005 22:13:13 +0200"}):
 
         create_tree(gr.path, {'file': "123"})
-        gr.add('file')
-        gr.commit(msg="changed")
+        gr.save("changed", paths=['file'])
 
     with patch.dict("os.environ", {"GIT_COMMITTER_DATE":
                                    "Fri, 09 Apr 2005 22:13:13 +0200"}):
@@ -1365,7 +1346,7 @@ def test_get_commit_date(path):
     # Let's make a commit with a custom date
     DATE = "Wed Mar 14 03:47:30 2018 -0000"
     DATE_EPOCH = 1520999250
-    gr.add('1')
+    gr._save_add('1')
     gr.commit("committed", date=DATE)
     gr = GitRepo(path, create=True)
     date = gr.get_commit_date()
@@ -1384,8 +1365,7 @@ def test_get_commit_date(path):
 def test_fake_dates(path):
     gr = GitRepo(path, create=True, fake_dates=True)
 
-    gr.add("foo")
-    gr.commit("commit foo")
+    gr.save("commit foo", ['foo'])
 
     seconds_initial = gr.config.obtain("datalad.fake-dates-start")
 
@@ -1393,8 +1373,7 @@ def test_fake_dates(path):
     eq_(seconds_initial + 1, gr.get_commit_date())
 
     # The second commit by 2.
-    gr.add("bar")
-    gr.commit("commit bar")
+    gr.save("commit bar", ['bar'])
     eq_(seconds_initial + 2, gr.get_commit_date())
 
     # If we checkout another branch, its time is still based on the latest
@@ -1402,8 +1381,7 @@ def test_fake_dates(path):
     gr.checkout("other", options=["--orphan"])
     with open(op.join(path, "baz"), "w") as ofh:
         ofh.write("baz content")
-    gr.add("baz")
-    gr.commit("commit baz")
+    gr.save("commit baz", ['baz'])
     eq_(gr.get_active_branch(), "other")
     eq_(seconds_initial + 3, gr.get_commit_date())
 
@@ -1494,16 +1472,14 @@ def test_gitrepo_add_to_git_with_annex_v7(path):
     from datalad.support.annexrepo import AnnexRepo
     ar = AnnexRepo(path, create=True, version=7)
     gr = GitRepo(path)
-    gr.add("foo")
-    gr.commit(msg="c1")
+    gr.save("c1", paths=['foo'])
     assert_false(ar.is_under_annex("foo"))
 
 
 @with_tree({"foo": "foo", "bar": "bar"})
 def test_gitrepo_call_git_methods(path):
     gr = GitRepo(path)
-    gr.add(["foo", "bar"])
-    gr.commit(msg="foobar")
+    gr.save("foobar", paths=["foo", "bar"])
     gr.call_git(["mv"], files=["foo", "foo.txt"])
     ok_(op.exists(op.join(gr.path, 'foo.txt')))
 

--- a/datalad/support/tests/test_repodates.py
+++ b/datalad/support/tests/test_repodates.py
@@ -40,7 +40,6 @@ def test_check_dates(path):
 
         ar.save("add foo", ["foo"])
         foo_commit = ar.get_hexsha()
-        ar.commit("add foo")
         ar.tag("foo-tag", "tag before refdate")
         foo_tag = tag_object("foo-tag")
         # Make a lightweight tag to make sure `tag_dates` doesn't choke on it.

--- a/datalad/support/tests/test_repodates.py
+++ b/datalad/support/tests/test_repodates.py
@@ -38,8 +38,7 @@ def test_check_dates(path):
             return ar.call_git_oneline(
                 ["rev-parse", "refs/tags/{}".format(tag)], read_only=True)
 
-        ar.add("foo")
-        ar.commit("add foo")
+        ar.save("add foo", ["foo"])
         foo_commit = ar.get_hexsha()
         ar.commit("add foo")
         ar.tag("foo-tag", "tag before refdate")
@@ -47,8 +46,7 @@ def test_check_dates(path):
         # Make a lightweight tag to make sure `tag_dates` doesn't choke on it.
         ar.tag("light")
     with set_date(refdate + 1):
-        ar.add("bar")
-        ar.commit("add bar")
+        ar.save("add bar", ["bar"])
         bar_commit = ar.get_hexsha()
         ar.tag("bar-tag", "tag after refdate")
         bar_tag = tag_object("bar-tag")

--- a/datalad/support/tests/test_repodates.py
+++ b/datalad/support/tests/test_repodates.py
@@ -56,7 +56,10 @@ def test_check_dates(path):
 
     results = {}
     for which in ["older", "newer"]:
-        result = check_dates(ar, refdate, which=which)["objects"]
+        # Note: Use --all so that we can pick up foo_commit even when using an
+        # adjusted branch (which the last save call have rebased).
+        result = check_dates(
+            ar, refdate, revs=["--all"], which=which)["objects"]
         ok_(result)
         if which == "newer":
             assert_in(bar_commit, result)

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -153,8 +153,7 @@ def check_compress_file(ext, annex, path, name):
         # key
         from datalad.support.annexrepo import AnnexRepo
         repo = AnnexRepo(path, init=True)
-        repo.add(_filename)
-        repo.commit(files=[_filename], msg="commit")
+        repo.save("commit", paths=[_filename])
 
     dir_extracted = name + "_extracted"
     try:

--- a/datalad/tests/test_tests_utils.py
+++ b/datalad/tests/test_tests_utils.py
@@ -674,9 +674,8 @@ def test_ignore_nose_capturing_stdout():
 def test_ok_file_under_git_symlinks(path):
     # Test that works correctly under symlinked path
     orepo = GitRepo(path)
-    orepo.add('ingit')
-    orepo.commit('msg')
-    orepo.add('staged')
+    orepo.save('msg', ['ingit'])
+    orepo._save_add('staged')
     lpath = path + "-symlink"  # will also be removed AFAIK by our tempfile handling
     Path(lpath).symlink_to(Path(path))
     ok_symlink(lpath)

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -903,7 +903,7 @@ def test_get_dataset_root(path):
         os.makedirs(subdir)
         with open(fname, 'w') as f:
             f.write('some')
-        repo.add(fname)
+        repo._save_add(fname)
         # we can find this repo
         eq_(get_dataset_root(os.curdir), os.curdir)
         # and we get the type of path that we fed in

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -365,9 +365,12 @@ def put_file_under_git(path, filename=None, content=None, annexed=False):
     if annexed:
         if not isinstance(repo, AnnexRepo):
             repo = AnnexRepo(repo.path)
-        repo.add(file_repo_path)
+        repo._save_add(file_repo_path)
     else:
-        repo.add(file_repo_path, git=True)
+        if isinstance(repo, AnnexRepo):
+            repo._save_add(file_repo_path, git=True)
+        else:
+            repo._save_add(file_repo_path)
     repo.commit(_datalad_msg=True)
     ok_file_under_git(repo.path, file_repo_path, annexed)
     return repo

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1850,7 +1850,7 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
             },
         }
     )
-    ds.repo.add(['file_added', opj('subdir', 'file_added')])
+    ds.repo._save_add(['file_added', opj('subdir', 'file_added')])
     # untracked subdatasets
     create(opj(ds.path, 'subds_untracked'))
     create(opj(ds.path, 'subdir', 'subds_untracked'))

--- a/datalad/tests/utils_testrepos.py
+++ b/datalad/tests/utils_testrepos.py
@@ -71,11 +71,14 @@ class TestRepo(object, metaclass=ABCMeta):
         if add:
             if annex:
                 if isinstance(self.repo, AnnexRepo):
-                    self.repo.add(name)
+                    self.repo._save_add(name)
                 else:
                     raise ValueError("Can't annex add to a non-annex repo.")
             else:
-                self.repo.add(name, git=True)
+                if isinstance(self.repo, AnnexRepo):
+                    self.repo._save_add(name, git=True)
+                else:
+                    self.repo._save_add(name)
 
     def create(self):
         if self._created:


### PR DESCRIPTION
This brings back https://github.com/datalad/datalad/pull/4872, a year after it stalled -- sigh...

It established the foundation to move the obsolete `add()` methods of the `Repo` classes to `-deprecated`.

- [x] The last commit in this series is to be dropped, and to be replaced by a regular deprecation of these methods.

- https://github.com/datalad/datalad-metalad/issues/64
- https://github.com/datalad/datalad-crawler/issues/83

are known TODOs that have not been resolved within the last year.