### PR TITLE
TST: Switch to Visual Studio 2022 for Appveyor Windows setup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,7 +78,7 @@ environment:
     - ID: WinP39core
       # ~35 min
       DTS: datalad.core datalad.runner
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       # Python version specification is non-standard on windows
       PY: 39-x64
       # TODO: use datalad/git-annex (github release packages) but
@@ -111,7 +111,7 @@ environment:
           datalad.tests
       # TODO: datalad.metadata (this is completely non-functional on Windows,
       #       either tests only, or actual code too)
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       PY: 39-x64
     - ID: WinP39a2
       # ~50min
@@ -119,7 +119,7 @@ environment:
           datalad.local
           datalad.support
           datalad.ui
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       PY: 39-x64
 
     - ID: MacP38a1

--- a/tools/ci/appveyor_install_git-annex.bat
+++ b/tools/ci/appveyor_install_git-annex.bat
@@ -1,5 +1,5 @@
 REM Install git-annex
-appveyor DownloadFile https://datasets.datalad.org/datalad/packages/windows/git-annex-installer_8.20201127+git11-g3be9dc6e1_x64.exe -FileName C:\DLTMP\git-annex-installer.exe
+appveyor DownloadFile https://datasets.datalad.org/datalad/packages/windows/git-annex-installer_8.20211117_x64.exe -FileName C:\DLTMP\git-annex-installer.exe
 REM 7z is preinstalled in all images
 REM Extract directly into system Git installation
 7z x -aoa -o"C:\\Program Files\Git" C:\DLTMP\git-annex-installer.exe


### PR DESCRIPTION
This is the latest build worker image available, and comes with Git
version 2.33.1, which could be useful in switching test setups to
not overwrite USERPROFILE environment variables (cc #6160)

Just a test PR to check whether everything works out of the box.