### PR TITLE
Make outcome of `create-sibling-gin` readily usable for a `push` data transfer

### DIFF
--- a/datalad/distributed/create_sibling_gin.py
+++ b/datalad/distributed/create_sibling_gin.py
@@ -13,12 +13,17 @@ import logging
 
 from datalad.distributed.create_sibling_ghlike import _create_sibling
 from datalad.distributed.create_sibling_gogs import _GOGS
-from datalad.distribution.dataset import datasetmethod
+from datalad.distribution.dataset import (
+    datasetmethod,
+    Dataset,
+)
 from datalad.interface.base import (
     Interface,
     build_doc,
 )
 from datalad.interface.utils import eval_results
+from datalad.support.annexrepo import AnnexRepo
+
 
 lgr = logging.getLogger('datalad.distributed.create_sibling_gin')
 
@@ -118,16 +123,31 @@ class CreateSiblingGin(Interface):
             private=False,
             dry_run=False):
 
-        yield from _create_sibling(
-            platform=_GIN(api, credential, require_token=not dry_run),
-            reponame=reponame,
-            dataset=dataset,
-            recursive=recursive,
-            recursion_limit=recursion_limit,
-            name=name,
-            existing=existing,
-            access_protocol=access_protocol,
-            publish_depends=publish_depends,
-            private=private,
-            dry_run=dry_run,
-        )
+        for res in _create_sibling(
+                platform=_GIN(api, credential, require_token=not dry_run),
+                reponame=reponame,
+                dataset=dataset,
+                recursive=recursive,
+                recursion_limit=recursion_limit,
+                name=name,
+                existing=existing,
+                access_protocol=access_protocol,
+                publish_depends=publish_depends,
+                private=private,
+                dry_run=dry_run):
+            if res.get('action') == 'configure-sibling' \
+                    and res.get('annex-ignore') in ('true', True):
+                # when we see that git-annex had disabled access to GIN
+                # we will revert it for any dataset with an annex.
+                # git-annex's conclusion might solely be based on the
+                # fact that it tested prior the first push (failed to
+                # obtain a git-annex branch with a UUID) and concluded
+                # that there can never be an annex.
+                # however, we know for sure that GIN can do it, so we
+                # force this to enable correct subsequent data transfer
+                ds = Dataset(res['path'])
+                if isinstance(ds.repo, AnnexRepo):
+                    ds.config.set(f'remote.{name}.annex-ignore', 'false',
+                                  where='local')
+                    res['annex-ignore'] = 'false'
+            yield res

--- a/datalad/distributed/tests/test_create_sibling_gin.py
+++ b/datalad/distributed/tests/test_create_sibling_gin.py
@@ -10,11 +10,25 @@
 
 from datalad.api import create_sibling_gin
 from datalad.tests.utils import (
+    assert_in_results,
     skip_if_no_network,
     with_tempfile,
 )
 
 from .test_create_sibling_ghlike import check4real
+
+
+def check_push(ds):
+    # create a file and push it to GIN to see of the
+    # access is set up properly
+    (ds.pathobj / 'file').write_text('some')
+    ds.save()
+    assert_in_results(
+        ds.push(to='gin', result_renderer='disabled'),
+        action='copy',
+        status='ok',
+        path=str(ds.pathobj / 'file')
+    )
 
 
 @skip_if_no_network
@@ -25,5 +39,11 @@ def test_gin(path):
         path,
         'gin',
         'https://gin.g-node.org',
+        # when testing locally, you might want to use your
+        # own GIN account to not have to fiddle with the key
+        # setup
+        #'api/v1/repos/mih/{reponame}',
         'api/v1/repos/dataladtester/{reponame}',
+        access_protocol='https-ssh',
+        moretests=check_push,
     )


### PR DESCRIPTION
This change corrects and overrules a premature conclusion by git-annex on the non-availability of an annex at the GIN platform -- which is merely an effect of happening prior any branch availability on GIN.

I decided to not pursue the alternative approach from https://github.com/datalad/datalad/issues/6204#issuecomment-971869080 which could potentially be more expensive with no clear advantage.

Fixes datalad/datalad#6209