### PR TITLE
Fix special remote messaging

### DIFF
--- a/datalad/customremotes/__init__.py
+++ b/datalad/customremotes/__init__.py
@@ -12,12 +12,22 @@
 
 __docformat__ = 'restructuredtext'
 
-__all__ = ['SpecialRemote']
+__all__ = ['RemoteError, SpecialRemote']
 
 from annexremote import (
     ProtocolError,
     SpecialRemote as _SpecialRemote,
+    RemoteError as _RemoteError,
 )
+
+
+class RemoteError(_RemoteError):
+    # technically the message is optional, but any such case is immediately a
+    # UX issue ("reason unknown"), hence let's not allow for it
+    def __init__(self, msg):
+        # prevent multiline messages, they would be swallowed
+        # or kill the protocol
+        super().__init__(msg.replace('\n', '\\n'))
 
 
 class SpecialRemote(_SpecialRemote):

--- a/datalad/customremotes/__init__.py
+++ b/datalad/customremotes/__init__.py
@@ -11,3 +11,33 @@
 """
 
 __docformat__ = 'restructuredtext'
+
+__all__ = ['SpecialRemote']
+
+from annexremote import (
+    ProtocolError,
+    SpecialRemote as _SpecialRemote,
+)
+
+
+class SpecialRemote(_SpecialRemote):
+    """Common base class for all of DataLad's special remote implementations"""
+
+    def message(self, msg, type='debug'):
+        handler = dict(
+            debug=self.annex.debug,
+            info=self.annex.info,
+            error=self.annex.error,
+        ).get(type, self.annex.debug)
+
+        # ensure that no multiline messages are sent, they would cause a
+        # protocol error
+        msg = msg.replace('\n', '\\n')
+
+        try:
+            handler(msg)
+        except ProtocolError:
+            # INFO not supported by annex version.
+            # If we can't have an actual info message, at least have a
+            # debug message.
+            self.annex.debug(msg)

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -410,17 +410,18 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 apath = self.cache[akey_path].get_extracted_file(afile)
                 link_file_load(apath, file)
                 if not was_extracted and self.cache[akey_path].is_extracted:
-                    self.annex.info(
+                    self.message(
                         "%s special remote is using an extraction cache "
                         "under %s. Remove it with DataLad's 'clean' "
                         "command to save disk space." %
                         (ARCHIVES_SPECIAL_REMOTE,
-                         self.cache[akey_path].path)
+                         self.cache[akey_path].path),
+                        type='info',
                     )
                 return
             except Exception as exc:
                 ce = CapturedException(exc)
-                self.annex.debug(
+                self.message(
                     "Failed to fetch {akey} containing {key}: {msg}".format(
                         akey=akey,
                         key=key,
@@ -453,10 +454,11 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         from datalad.support.annexrepo import AnnexJsonProtocol
 
         akey_size = self.repo.get_size_from_key(akey)
-        self.annex.info(
+        self.message(
             "To obtain some keys we need to fetch an archive "
             "of size %s"
-            % (naturalsize(akey_size) if akey_size else "unknown")
+            % (naturalsize(akey_size) if akey_size else "unknown"),
+            type='info',
         )
 
         try:
@@ -465,7 +467,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 protocol=AnnexJsonProtocol,
             )
         except Exception:
-            self.annex.debug(f'Failed to fetch archive with key {akey}')
+            self.message(f'Failed to fetch archive with key {akey}')
             raise
 
 

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -18,10 +18,7 @@ from collections import OrderedDict
 from operator import itemgetter
 from urllib.parse import urlparse
 
-from annexremote import (
-    RemoteError,
-    UnsupportedRequest,
-)
+from annexremote import UnsupportedRequest
 
 from datalad.cmdline.helpers import get_repo_instance
 from datalad.consts import ARCHIVES_SPECIAL_REMOTE
@@ -38,6 +35,7 @@ from datalad.utils import (
     unlink,
 )
 
+from datalad.customremotes import RemoteError
 from .base import AnnexCustomRemote
 
 lgr = logging.getLogger('datalad.customremotes.archive')
@@ -329,7 +327,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 return True
         # it is unclear to MIH why this must be UNKNOWN rather than FALSE
         # but this is how I found it
-        raise RemoteError()
+        raise RemoteError('Key not present')
 
     def remove(self, key):
         raise UnsupportedRequest('This special remote cannot remove content')

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -20,9 +20,9 @@ lgr = logging.getLogger('datalad.customremotes')
 
 from annexremote import (
     RemoteError,
-    SpecialRemote,
     UnsupportedRequest,
 )
+from datalad.customremotes import SpecialRemote
 
 from datalad.ui import ui
 

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -13,15 +13,14 @@ __docformat__ = 'restructuredtext'
 import logging
 from urllib.parse import urlparse
 
-from annexremote import RemoteError
-
 from datalad.downloaders.providers import Providers
 from datalad.support.exceptions import (
     CapturedException,
     TargetFileAbsent,
 )
 
-from .base import AnnexCustomRemote
+from datalad.customremotes import RemoteError
+from datalad.customremotes.base import AnnexCustomRemote
 
 lgr = logging.getLogger('datalad.customremotes.datalad')
 

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -50,8 +50,8 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
                 return
             except Exception as exc:
                 ce = CapturedException(exc)
-                self.annex.debug("Failed to download url %s for key %s: %s"
-                                 % (url, key, ce))
+                self.message("Failed to download url %s for key %s: %s"
+                             % (url, key, ce))
         raise RemoteError(
             f"Failed to download from any of {len(urls)} locations")
 
@@ -64,7 +64,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
             return [props]
         except Exception as exc:
             ce = CapturedException(exc)
-            self.annex.debug("Failed to check url %s: %s" % (url, ce))
+            self.message("Failed to check url %s: %s" % (url, ce))
             return False
 
     def checkpresent(self, key):
@@ -80,7 +80,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
                 # N/A, probably check the connection etc
             except TargetFileAbsent as exc:
                 ce = CapturedException(exc)
-                self.annex.debug(
+                self.message(
                     "Target url %s file seems to be missing: %s" % (url, ce))
                 if not resp:
                     # if it is already marked as UNKNOWN -- let it stay that
@@ -89,7 +89,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
                     return False
             except Exception as exc:
                 ce = CapturedException(exc)
-                self.annex.debug(
+                self.message(
                     "Failed to check status of url %s: %s" % (url, ce))
         if resp is None:
             raise RemoteError(f'Could not determine presence of key {key}')

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1,8 +1,3 @@
-from annexremote import (
-    ProtocolError,
-    RemoteError,
-)
-
 import os
 from pathlib import (
     Path,
@@ -15,7 +10,10 @@ import subprocess
 import logging
 from functools import wraps
 
-from datalad.customremotes import SpecialRemote
+from datalad.customremotes import (
+    RemoteError,
+    SpecialRemote,
+)
 from datalad.customremotes.ria_utils import (
     get_layout_locations,
     UnknownLayoutVersion,
@@ -81,9 +79,7 @@ class RemoteCommandFailedError(Exception):
 
 
 class RIARemoteError(RemoteError):
-
-    def __init__(self, msg):
-        super().__init__(msg.replace('\n', '\\n'))
+    pass
 
 
 class IOBase(object):

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1097,14 +1097,6 @@ class RIARemote(SpecialRemote):
         #       + just isinstance(LocalIO)?
         return not self.storage_host
 
-    # XXX this is pretty much obsolete, we should use self.message()
-    # which does debug messaging by default. however, I don't know if
-    # these prefixes are used for anything
-    def debug(self, msg):
-        # Annex prints just the message, so prepend with
-        # a "DEBUG" on our own.
-        self.annex.debug("ORA-DEBUG: " + msg)
-
     def _set_read_only(self, msg):
 
         if not self.force_write:
@@ -1163,7 +1155,7 @@ class RIARemote(SpecialRemote):
 
         if not self._push_io:
             if self.ria_store_pushurl:
-                self.debug("switching ORA to push-url")
+                self.message("switching ORA to push-url")
                 # Not-implemented-push-HTTP is ruled out already when reading
                 # push-url, so either local or SSH:
                 if not self.storage_host_push:

--- a/datalad/downloaders/s3.py
+++ b/datalad/downloaders/s3.py
@@ -351,8 +351,8 @@ class S3Downloader(BaseDownloader):
                 url_filepath, version_id=params.get('versionId', None)
             )
         except S3ResponseError as e:
-            raise TargetFileAbsent("S3 refused to provide the key for %s from url %s: %s"
-                                % (url_filepath, url, e))
+            raise TargetFileAbsent("S3 refused to provide the key for %s from url %s"
+                                % (url_filepath, url)) from e
         if key is None:
             raise TargetFileAbsent("No key returned for %s from url %s" % (url_filepath, url))
 

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -185,6 +185,26 @@ def format_oneline_tb(exc, tb=None, limit=None, include_str=True):
     return out
 
 
+def format_exception_with_cause(e):
+    """Helper to recursively format an exception with all underlying causes
+
+    For each exception in the chain either the str() of it is taken, or the
+    class name of the exception, with the aim to generate a simple and
+    comprehensible description that can be used in user-facing messages.
+    It is explicitly not aiming to provide a detailed/comprehensive source
+    of information for in-depth debugging.
+
+    '-caused by-' is used a separator between exceptions to be human-readable
+    while being recognizably different from potential exception payload
+    messages.
+    """
+    s = str(e) or e.__class__.__name__
+    exc_cause = getattr(e, '__cause__', None)
+    if exc_cause:
+        s += f' -caused by- {format_exception_with_cause(exc_cause)}'
+    return s
+
+
 class MissingExternalDependency(RuntimeError):
     """External dependency is missing error"""
 

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -1,7 +1,13 @@
 from unittest.mock import patch
-from nose.tools import assert_equal, assert_true
-from datalad.support.exceptions import CapturedException
-from datalad.tests.utils import assert_re_in
+from datalad.support.exceptions import (
+    format_exception_with_cause,
+    CapturedException,
+)
+from datalad.tests.utils import (
+    assert_equal,
+    assert_re_in,
+    assert_true,
+)
 from datalad import cfg
 
 
@@ -78,3 +84,28 @@ def test_CapturedException():
     # CapturedException.__repr__:
     assert_re_in(r".*test_captured_exception.py:f2:[0-9]+\]$",
                  captured_exc.__repr__())
+
+
+def makeitraise():
+    def raise_valueerror():
+        try:
+            raise_runtimeerror()
+        except Exception as e:
+            raise ValueError from e
+
+    def raise_runtimeerror():
+        raise RuntimeError("Mike")
+
+    try:
+        raise_valueerror()
+    except Exception as e:
+        raise RuntimeError from e
+
+
+def test_format_exception_with_cause():
+    try:
+        makeitraise()
+    except Exception as e:
+        assert_equal(
+            format_exception_with_cause(e),
+            'RuntimeError -caused by- ValueError -caused by- Mike')


### PR DESCRIPTION
- Prevention of multi-line messages breaking the special remote protocol
- Generalize multi-line message protection for `RemoteError` from just ORA to all special remotes
- Report on the cause for download error in the `datalad` special remote; fixes #5773 
- Introduce new helper to generator compact messages from an exception with underlying causes
- Alter ORA exception raising to report underlying causes; fixes #6231


Together this change improves from `maint` behavior:

`RuntimeError(Failed to download from any of 1 locations)`

from `master`

```
  external special remote protocol error, unexpectedly received ")" (unable to parse command)
  unable to use special remote due to protocol error
```

to 

`Failed to download from any of 1 locations [S3ResponseError: 403 Forbidden\n]`
