### PR TITLE
Generator-style runner with application in BatchedCommand and AnnexRepo

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -7,16 +7,26 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """
-Wrapper for command and function calls, allowing for dry runs and output handling
+Class the starts a subprocess and keeps it around to communicate with it
+via stdin. For each instruction send over stdin, a response is read and
+returned. The response structure is determined by "output_proc"
 
 """
 
 import logging
 import os
-import subprocess
+import queue
 import sys
-import tempfile
 import warnings
+from subprocess import TimeoutExpired
+from typing import (
+    Any,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 from datetime import datetime
 from operator import attrgetter
 from weakref import WeakValueDictionary
@@ -39,14 +49,20 @@ from datalad.runner.nonasyncrunner import run_command
 from datalad.runner.protocol import WitlessProtocol
 from datalad.runner.runner import WitlessRunner
 from datalad.support.exceptions import CommandError
+# end of legacy import block
+
+from datalad.runner.coreprotocols import StdOutErrCapture
+from datalad.runner.nonasyncrunner import (
+    STDERR_FILENO,
+    STDOUT_FILENO,
+)
+from datalad.runner.protocol import GeneratorMixIn
+from datalad.runner.runner import WitlessRunner
+from datalad.runner.utils import LineSplitter
 from datalad.utils import (
     auto_repr,
     ensure_unicode,
-    try_multiple,
-    unlink,
 )
-
-# end of legacy import block
 
 
 lgr = logging.getLogger('datalad.cmd')
@@ -77,6 +93,63 @@ def _readline_rstripped(stdout):
     return stdout.readline().rstrip()
 
 
+class BatchedCommandProtocol(GeneratorMixIn, StdOutErrCapture):
+    def __init__(self,
+                 batched_command: "BatchedCommand",
+                 done_future: Any = None,
+                 encoding: Optional[str] = None,
+                 output_proc: Callable = None,
+                 ):
+        GeneratorMixIn.__init__(self)
+        StdOutErrCapture.__init__(self, done_future, encoding)
+        self.batched_command = batched_command
+        self.output_proc = output_proc
+        self.line_splitter = LineSplitter()
+
+    def pipe_data_received(self, fd: int, data: bytes):
+        if fd == STDERR_FILENO:
+            self.send_result((fd, data))
+        elif fd == STDOUT_FILENO:
+            for line in self.line_splitter.process(data.decode(self.encoding)):
+                self.send_result((fd, line))
+        else:
+            raise ValueError(f"unknown file descriptor: {fd}")
+
+    def pipe_connection_lost(self, fd: int, exc: Optional[Exception]):
+        if fd == STDOUT_FILENO:
+            remaining_line = self.line_splitter.finish_processing()
+            if remaining_line is not None:
+                lgr.warning(f"unterminated line: {remaining_line}")
+                self.send_result((fd, remaining_line))
+
+    def timeout(self, fd: Optional[int]) -> bool:
+        timeout_error = self.batched_command.get_timeout_exception(fd)
+        if timeout_error:
+            raise timeout_error
+        self.send_result(("timeout", fd))
+        return False
+
+
+class ReadlineEmulator:
+    """
+    This class implements readline() on the basis of an instance of
+    BatchedCommand. Its purpose is to emulate stdout's for output_procs,
+    This allows us to provide a BatchedCommand API that is identical
+    to the old version, but with an implementation that is based on the
+    threaded runner.
+    """
+    def __init__(self,
+                 batched_command: "BatchedCommand"):
+        self.batched_command = batched_command
+
+    def readline(self):
+        """
+        Read from the stdout provider until we have a line or None (which
+        indicates some error).
+        """
+        return self.batched_command.get_one_line()
+
+
 class SafeDelCloseMixin(object):
     """A helper class to use where __del__ would call .close() which might
     fail if "too late in GC game"
@@ -94,22 +167,39 @@ class SafeDelCloseMixin(object):
 
 @auto_repr
 class BatchedCommand(SafeDelCloseMixin):
-    """Container for a process which would allow for persistent communication
+    """
+    Container for a running subprocess. Supports communication with the
+    subprocess via stdin and stdout.
     """
 
     # Collection of active BatchedCommands as a mapping from object IDs to
     # instances
     _active_instances = WeakValueDictionary()
 
-    def __init__(self, cmd, path=None, output_proc=None):
-        if not isinstance(cmd, list):
-            cmd = [cmd]
-        self.cmd = cmd
+    def __init__(self,
+                 cmd: Union[str, Tuple, List],
+                 path: Optional[str] = None,
+                 output_proc: Callable = None,
+                 timeout: Optional[float] = None,
+                 exception_on_timeout: bool = False,
+                 ):
+
+        command = cmd
+        self.command = [command] if not isinstance(command, List) else command
         self.path = path
-        self.output_proc = output_proc if output_proc else _readline_rstripped
-        self._process = None
-        self._stderr_out = None
-        self._stderr_out_fname = None
+        self.output_proc = output_proc
+        self.timeout = timeout
+        self.exception_on_timeout = exception_on_timeout
+
+        self.stdin_queue = None
+        self.stderr_output = b""
+        self.runner = None
+        self.generator = None
+        self.encoding = None
+        self.wait_timed_out = None
+        self.return_code = None
+        self._abandon_cache = None
+
         self._active = 0
         self._active_last = _now()
         self.clean_inactive()
@@ -156,197 +246,291 @@ class BatchedCommand(SafeDelCloseMixin):
                 )
 
     def _initialize(self):
-        lgr.debug("Initiating a new process for %s", repr(self))
-        lgr.log(5, "Command: %s", self.cmd)
-        # according to the internet wisdom there is no easy way with subprocess
-        # while avoid deadlocks etc.  We would need to start a thread/subprocess
-        # to timeout etc
-        # kwargs = dict(bufsize=1, universal_newlines=True) if PY3 else {}
-        self._stderr_out, self._stderr_out_fname = tempfile.mkstemp()
-        self._process = subprocess.Popen(
-            self.cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=self._stderr_out,
-            env=GitRunnerBase.get_git_environ_adjusted(),
+
+        lgr.debug("Starting new runner for %s", repr(self))
+        lgr.log(5, "Command: %s", self.command)
+
+        self.stdin_queue = queue.Queue()
+        self.stderr_output = b""
+        self.wait_timed_out = None
+        self.return_code = None
+
+        self.runner = WitlessRunner(
             cwd=self.path,
-            bufsize=1,
-            universal_newlines=True  # **kwargs
+            env=GitRunnerBase.get_git_environ_adjusted()
         )
+        self.generator = self.runner.run(
+            cmd=self.command,
+            protocol=BatchedCommandProtocol,
+            stdin=self.stdin_queue,
+            cwd=self.path,
+            env=GitRunnerBase.get_git_environ_adjusted(),
+            # This mimics the behavior of the old implementation w.r.t
+            # timeouts when waiting for the closing process
+            timeout=self.timeout or 11.0,
+            # Keyword arguments for the protocol
+            batched_command=self,
+            output_proc=self.output_proc,
+        )
+        self.encoding = self.generator.runner.protocol.encoding
+
         self._active_last = _now()
 
-    def _check_process(self, restart=False):
-        """Check if the process was terminated and restart if restart
+    def process_running(self) -> bool:
+        if self.runner:
+            return self.generator.runner.process.poll() is None
+        return False
 
-        Returns
-        -------
-        bool
-          True if process was alive.
-        str
-          stderr if any recorded if was terminated
+    def __call__(self,
+                 cmds: Union[str, Tuple, List]):
         """
-        process = self._process
-        ret = True
-        ret_stderr = None
-        if process and process.poll():
-            lgr.warning("Process %s was terminated with returncode %s" % (process, process.returncode))
-            ret_stderr = self.close(return_stderr=True)
-            ret = False
-        if self._process is None and restart:
-            lgr.warning("Restarting the process due to previous failure")
-            self._initialize()
-        return ret, ret_stderr
+        Send requests to the subprocess and return the responses. We expect one
+        response per request. How the response is structured is determined by
+        output_proc. If output_proc returns not-None, the responses is
+        considered to be a response.
 
-    def __call__(self, cmds):
-        """
+        If output_proc is not provided, we assume that a single response is
+        a single line.
+
+        If the subprocess does not exist yet it is started before the first
+        command is sent.
 
         Parameters
         ----------
         cmds : str or tuple or list of (str or tuple)
+            request for the subprocess
 
         Returns
         -------
         str or list
-          Output received from process.  list in case if cmds was a list
+            Responses received from process. Either a string, or a list of
+            strings, if cmds was a list.
         """
         self._active += 1
-        try:
-            input_multiple = isinstance(cmds, list)
-            if not input_multiple:
-                cmds = [cmds]
+        requests = cmds
 
-            output = [o for o in self.yield_(cmds)]
-            return output if input_multiple else output[0]
+        input_multiple = isinstance(requests, list)
+        if not input_multiple:
+            requests = [requests]
+
+        responses = []
+        try:
+            # This code assumes that each processing request is
+            # a single line and leads to a response that triggers a
+            # `send_result` in the protocol.
+            for request in requests:
+                while True:
+                    try:
+                        responses.append(self.process_request(request))
+                        break
+                    except StopIteration:
+                        # The process finished executing, store the last return
+                        # code and restart the process.
+                        lgr.debug(f"{self}: command exited")
+                        self.return_code = self.generator.return_code
+                        self.runner = None
+
+        except CommandError as command_error:
+            # The command exited with a non-zero return code
+            lgr.error(f"{self}: command error: {command_error}")
+            self.return_code = command_error.code
+            self.runner = None
+
         finally:
             self._active -= 1
+        return responses if input_multiple else responses[0] if responses else None
 
-    def yield_(self, cmds):
-        """Same as __call__, but requires `cmds` to be an iterable
+    def process_request(self,
+                        request: Union[Tuple, str]) -> str:
 
-        and yields results for each item."""
         self._active += 1
         try:
-            for entry in cmds:
-                if not isinstance(entry, str):
-                    entry = ' '.join(entry)
-                self._active_last = _now()
-                yield self.proc1(entry)
-        finally:
-            self._active -= 1
 
-    def proc1(self, arg):
-        """Same as __call__, but only takes a single command argument
-
-        and returns a single result.
-        """
-        self._active += 1
-        try:
-            # TODO: add checks -- may be process died off and needs to be reinitiated
-            if not self._process:
+            if not self.process_running():
                 self._initialize()
 
-            entry = arg + '\n'
-            lgr.log(5, "Sending %r to batched command %s", entry, self)
-            # apparently communicate is just a one time show
-            # stdout, stderr = self._process.communicate(entry)
-            # according to the internet wisdom there is no easy way with subprocess
-            self._check_process(restart=True)
-            process = self._process  # _check_process might have restarted it
-            process.stdin.write(entry)
-            process.stdin.flush()
-            lgr.log(5, "Done sending.")
-            still_alive, stderr = self._check_process(restart=False)
-            # TODO: we might want to handle still_alive, e.g. to allow for
-            #       a number of restarts/resends, but it should be per command
-            #       since for some we cannot just resend the same query. But if
-            #       it is just a "get"er - we could resend it few times
-            # The default output_proc expects a single line output.
-            # TODO: timeouts etc
-            stdout = ensure_unicode(self.output_proc(process.stdout)) \
-                if not process.stdout.closed else None
-            if stderr:
-                lgr.warning("Received output in stderr: %r", stderr)
-            lgr.log(5, "Received output: %r", stdout)
-            return stdout
+            # Send request to subprocess
+            if not isinstance(request, str):
+                request = ' '.join(request)
+            self.stdin_queue.put((request + "\n").encode())
+
+            # Get the response from the generator. We only consider
+            # data received on stdout as a response.
+            if self.output_proc:
+                # If we have an output procedure, let the output procedure
+                # read stdout and decide about the nature of the response
+                response = self.output_proc(ReadlineEmulator(self))
+            else:
+                # If there is no output procedure we assume that a response
+                # is one line.
+                response = self.get_one_line()
+                if response is not None:
+                    response = response.rstrip()
+            return response
+
         finally:
             self._active -= 1
 
+    def proc1(self,
+              single_command: str):
+        """
+        Simulate the old interface. This method is used only once in
+        AnnexRepo.get_metadata()
+        """
+        self._active += 1
+        try:
+            assert isinstance(single_command, str)
+            return self(single_command)
+        finally:
+            self._active -= 1
+
+    def get_one_line(self) -> Optional[str]:
+        """
+        Get a single stdout line from the generator.
+
+        If timeout was specified, and exception_on_timeout is False,
+        and if a timeout occurs, return None. Otherwise return the
+        str that was read from the generator.
+        """
+
+        # Implementation remarks:
+        # 1. We known that BatchedCommandProtocol only returns complete lines on
+        #    stdout, that makes this code simple.
+        # 2. stderr is handled transparently within this method,
+        #    by adding all stderr-content to an internal buffer.
+        while True:
+            source, data = self.generator.send(None)
+            if source == STDERR_FILENO:
+                self.stderr_output += data
+            elif source == STDOUT_FILENO:
+                return data
+            elif source == "timeout":
+                # TODO: we should restart the subprocess on timeout, otherwise
+                #  we might end up with results from a previous instruction,
+                #  when handling multiple instructions at once. Until this is
+                #  done properly, communication timeouts are ignored in order
+                #  to avoid errors.
+                pass
+            else:
+                raise ValueError(f"{self}: unknown source: {source}")
+
     def close(self, return_stderr=False):
-        """Close communication and wait for process to terminate
+        """
+        Close communication and wait for process to terminate. If the "timeout"
+        parameter to the constructor was not None, and if the configuration
+        setting "datalad.runtime.stalled-external" is set to "abandon",
+        the method will return latest after "timeout" seconds. If the subprocess
+        did not exit within this time, the attribute "wait_timed_out" will
+        be set to "True".
+
+        Parameters
+        ----------
+        return_stderr: bool
+          if set to "True", the call will return all collected stderr content
+          as string. In addition, if return_stderr is True and the log level
+          is 5 or lower, and the configuration setting "datalad.log.outputs"
+          evaluates to "True", the content of stderr will be logged.
 
         Returns
         -------
-        str
-          stderr output if return_stderr and stderr file was there.
-          None otherwise
+        str, optional
+          stderr output if return_stderr is True, None otherwise
         """
-        ret = None
-        process = self._process
-        if self._stderr_out:
-            # close possibly still open fd
-            lgr.debug(
-                "Closing stderr of %s", process)
-            os.fdopen(self._stderr_out).close()
-            self._stderr_out = None
-        if process:
-            lgr.debug(
-                "Closing stdin of %s and waiting process to finish", process)
-            process.stdin.close()
-            process.stdout.close()
-            from . import cfg
-            cfg_var = 'datalad.runtime.stalled-external'
-            cfg_val = cfg.obtain(cfg_var)
-            if cfg_val == 'wait':
-                process.wait()
-            elif cfg_val == 'abandon':
-                # try waiting for the annex process to finish 3 times for 3 sec
-                # with 1s pause in between
-                try:
-                    try_multiple(
-                        # ntrials
-                        3,
-                        # exception to catch
-                        subprocess.TimeoutExpired,
-                        # base waiting period
-                        1.0,
-                        # function to run
-                        process.wait,
-                        timeout=3.0,
-                    )
-                except subprocess.TimeoutExpired:
-                    lgr.warning(
-                        "Batched process %s did not finish, abandoning it without killing it",
-                        process)
-            else:
-                raise ValueError(f"Unexpected {cfg_var}={cfg_val!r}")
-            self._process = None
-            lgr.debug("Process %s has finished", process)
 
-        # It is hard to debug when something is going wrong. Hopefully logging stderr
-        # if generally asked might be of help
+        if self.runner:
+
+            abandon = self._get_abandon()
+
+            # Close stdin to let the process know that we want to end
+            # communication. We also close stdout and stderr to inform
+            # the generator that we do not care about them anymore. This
+            # will trigger process wait timeouts.
+            self.generator.runner.close_stdin()
+
+            # Process all remaining messages until the subprocess exits.
+            remaining = []
+            timeout = False
+            try:
+                for source, data in self.generator:
+                    if source == STDERR_FILENO:
+                        self.stderr_output += data
+                    elif source == STDOUT_FILENO:
+                        remaining.append(data)
+                    elif source == "timeout":
+                        if data is None and abandon is True:
+                            timeout = True
+                            break
+                    else:
+                        raise ValueError(f"{self}: unknown source: {source}")
+                self.return_code = self.generator.return_code
+
+            except CommandError as command_error:
+                lgr.error(f"{self} subprocess failed with {command_error}")
+                self.return_code = command_error.code
+
+            if remaining:
+                lgr.warning(f"{self}: remaining content: {remaining}")
+
+            self.wait_timed_out = timeout is True
+            if self.wait_timed_out:
+                lgr.debug(
+                    f"{self}: timeout while waiting for subprocess to exit")
+                lgr.warning(
+                    f"Batched process ({self.generator.runner.process.pid}) "
+                    f"did not finish, abandoning it without killing it")
+
+        result = self.get_requested_error_output(return_stderr)
+        self.runner = None
+        self.stderr_output = b""
+        return result
+
+    def get_requested_error_output(self, return_stderr: bool):
+        if not self.runner:
+            return None
+
+        stderr_content = ensure_unicode(self.stderr_output)
         if lgr.isEnabledFor(5):
             from . import cfg
-            log_stderr = cfg.getbool('datalad.log', 'outputs', default=False)
-        else:
-            log_stderr = False
+            if cfg.getbool("datalad.log", "outputs", default=False):
+                stderr_lines = stderr_content.splitlines()
+                lgr.log(
+                    5,
+                    "stderr of %s had %d lines:",
+                    self.generator.runner.process.pid,
+                    len(stderr_lines))
+                for line in stderr_lines:
+                    lgr.log(5, "| " + line)
+        if return_stderr:
+            return stderr_content
+        return None
 
-        if self._stderr_out_fname and os.path.exists(self._stderr_out_fname):
-            if return_stderr or log_stderr:
-                with open(self._stderr_out_fname, 'r') as f:
-                    stderr = f.read()
-            if return_stderr:
-                ret = stderr
-            if log_stderr:
-                stderr = ensure_unicode(stderr)
-                stderr = stderr.splitlines()
-                lgr.log(5, "stderr of %s had %d lines:", process.pid, len(stderr))
-                for l in stderr:
-                    lgr.log(5, "| " + l)
+    def get_timeout_exception(self,
+                              fd: Optional[int]
+                              ) -> Optional[TimeoutExpired]:
+        """
+        Get a process timeout exception if timeout exceptions should
+        be generated for a process that continues longer than timeout
+        seconds after self.close() was initiated.
+        """
+        if self.timeout is None \
+                or fd is not None \
+                or self.exception_on_timeout is False\
+                or self._get_abandon() == "wait":
+            return None
+        return TimeoutExpired(
+            cmd=self.command,
+            timeout=self.timeout or 11.0,
+            stderr=self.stderr_output)
 
-            # remove the file where we kept dumping stderr
-            unlink(self._stderr_out_fname)
-            self._stderr_out_fname = None
-        return ret
+    def _get_abandon(self):
+        if self._abandon_cache is None:
+            from . import cfg
+            cfg_var = "datalad.runtime.stalled-external"
+            cfg_val = cfg.obtain(cfg_var)
+            if cfg_val not in ("wait", "abandon"):
+                raise ValueError(f"Unexpected value: {cfg_var}={cfg_val!r}")
+            self._abandon_cache = cfg_val == "abandon"
+        return self._abandon_cache
 
 
 def _now():

--- a/datalad/runner/exception.py
+++ b/datalad/runner/exception.py
@@ -10,6 +10,11 @@
 """
 
 import logging
+from typing import (
+    Dict,
+    List,
+)
+
 
 lgr = logging.getLogger('datalad.runner.exception')
 
@@ -76,7 +81,7 @@ class CommandError(RuntimeError):
         return self.to_str()
 
 
-def _format_json_error_messages(recs):
+def _format_json_error_messages(recs: List[Dict]):
     # there could be many, condense
     msgs = {}
     for r in recs:

--- a/datalad/runner/gitrunner.py
+++ b/datalad/runner/gitrunner.py
@@ -13,7 +13,10 @@ import logging
 import os
 import os.path as op
 
-from .runner import WitlessRunner
+from .runner import (
+    GeneratorMixIn,
+    WitlessRunner,
+)
 from .utils import (
     borrowdoc,
     generate_file_chunks,
@@ -133,9 +136,41 @@ class GitWitlessRunner(WitlessRunner, GitRunnerBase):
             copy=False,
         )
 
-    def run_on_filelist_chunks(self, cmd, files, protocol=None,
-                               cwd=None, env=None, **kwargs):
-        """Run a git-style command multiple times if `files` is too long
+    def _get_chunked_results(self,
+                             cmd,
+                             files,
+                             protocol=None,
+                             cwd=None,
+                             env=None,
+                             **kwargs):
+
+        assert isinstance(cmd, list)
+
+        file_chunks = generate_file_chunks(files, cmd)
+        for i, file_chunk in enumerate(file_chunks):
+            # do not pollute with message when there only ever is a single chunk
+            if len(file_chunk) < len(files):
+                lgr.debug(
+                    'Process file list chunk %i (length %i)', i, len(file_chunk))
+
+            yield self.run(
+                cmd=cmd + ['--'] + file_chunk,
+                protocol=protocol,
+                cwd=cwd,
+                env=env,
+                **kwargs)
+
+    def run_on_filelist_chunks(self,
+                                cmd,
+                                files,
+                                protocol=None,
+                                cwd=None,
+                                env=None,
+                                **kwargs):
+        """
+        Run a git-style command multiple times if `files` is too long,
+        using a non-generator protocol, i.e. a protocol that is not
+        derived from `datalad.runner.protocol.GeneratorMixIn`.
 
         Parameters
         ----------
@@ -177,24 +212,57 @@ class GitWitlessRunner(WitlessRunner, GitRunnerBase):
         FileNotFoundError
           When a given executable does not exist.
         """
-        assert isinstance(cmd, list)
-        file_chunks = generate_file_chunks(files, cmd)
+
+        assert not issubclass(protocol, GeneratorMixIn), \
+            "cannot use GitWitlessRunner.run_on_filelist_chunks() " \
+            "with a protocol that inherits GeneratorMixIn, use " \
+            "GitWitlessRunner.run_on_filelist_chunks_items_() instead"
 
         results = None
-        for i, file_chunk in enumerate(file_chunks):
-            # do not pollute with message when there only ever is a single chunk
-            if len(file_chunk) < len(files):
-                lgr.debug('Process file list chunk %i (length %i)',
-                          i, len(file_chunk))
-            res = self.run(
-                cmd + ['--'] + file_chunk,
-                protocol=protocol,
-                cwd=cwd,
-                env=env,
-                **kwargs)
+        for res in self._get_chunked_results(cmd=cmd,
+                                             files=files,
+                                             protocol=protocol,
+                                             cwd=cwd,
+                                             env=env,
+                                             **kwargs):
             if results is None:
                 results = res
             else:
                 for k, v in res.items():
                     results[k] += v
         return results
+
+    def run_on_filelist_chunks_items_(self,
+                                      cmd,
+                                      files,
+                                      protocol=None,
+                                      cwd=None,
+                                      env=None,
+                                      **kwargs):
+        """
+        Run a git-style command multiple times if `files` is too long,
+        using a generator protocol, i.e. a protocol that is
+        derived from `datalad.runner.protocol.GeneratorMixIn`.
+
+        Parameters
+        ----------
+        see GitWitlessRunner.run_on_filelist_chunks() for a definition
+        of parameters
+
+        Returns
+        -------
+        Generator that yields output of the cmd
+        """
+
+        assert issubclass(protocol, GeneratorMixIn), \
+            "cannot use GitWitlessRunner.run_on_filelist_chunks_items_() " \
+            "with a protocol that does not inherits GeneratorMixIn, use " \
+            "GitWitlessRunner.run_on_filelist_chunks() instead"
+
+        for chunk_generator in self._get_chunked_results(cmd=cmd,
+                                                         files=files,
+                                                         protocol=protocol,
+                                                         cwd=cwd,
+                                                         env=env,
+                                                         **kwargs):
+            yield from chunk_generator

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -10,16 +10,20 @@
 Thread based subprocess execution with stdout and stderr passed to protocol objects
 """
 
+import enum
 import logging
-import os
-import queue
 import subprocess
-import threading
 import time
+from collections import deque
+from collections.abc import Generator
+from queue import (
+    Empty,
+    Queue,
+)
 from typing import (
-    IO,
     Any,
     Dict,
+    IO,
     List,
     Optional,
     Type,
@@ -27,7 +31,20 @@ from typing import (
 )
 
 from datalad.utils import on_windows
-from .protocol import WitlessProtocol
+
+from .exception import CommandError
+from .protocol import (
+    GeneratorMixIn,
+    WitlessProtocol,
+)
+from .runnerthreads import (
+    _try_close,
+    IOState,
+    ReadThread,
+    WaitThread,
+    WriteThread,
+)
+
 
 lgr = logging.getLogger("datalad.runner.nonasyncrunner")
 
@@ -36,237 +53,584 @@ STDOUT_FILENO = 1
 STDERR_FILENO = 2
 
 
-class _ReaderThread(threading.Thread):
+class _ResultGenerator(Generator):
+    """
+    Generator returned by run_command if the protocol class
+    is a subclass of `datalad.runner.protocol.GeneratorMixIn`
+    """
+    class GeneratorState(enum.Enum):
+        process_running = 0
+        process_exited = 1
+        connection_lost = 2
+        waiting_for_process = 3
 
     def __init__(self,
-                 file: IO,
-                 q: queue.Queue,
-                 command: Union[str, List]):
+                 runner: "ThreadedRunner",
+                 result_queue: deque
+                 ):
+
+        super().__init__()
+        self.runner = runner
+        self.result_queue = result_queue
+        self.return_code = None
+        self.state = self.GeneratorState.process_running
+        self.all_closed = False
+
+    def _check_result(self):
+        self.runner._check_result()
+
+    def send(self, _):
+        runner = self.runner
+        if self.state == self.GeneratorState.process_running:
+
+            # If we have elements in the result queue, return one
+            while len(self.result_queue) == 0 and runner.should_continue():
+                runner.process_queue()
+            if len(self.result_queue) > 0:
+                return self.result_queue.popleft()
+
+            # The process must have exited
+            # Let the protocol prepare the result. This has to be done after
+            # the loop was left to ensure that all data from stdout and stderr
+            # is processed.
+            runner.protocol.process_exited()
+            self.return_code = runner.process.poll()
+            self._check_result()
+            self.state = self.GeneratorState.process_exited
+
+        if self.state == self.GeneratorState.process_exited:
+            # The protocol might have added result in the
+            # _prepare_result()- or in the process_exited()-
+            # callback. Those are returned here.
+            if len(self.result_queue) > 0:
+                return self.result_queue.popleft()
+
+            runner.ensure_stdin_stdout_stderr_closed()
+            runner.protocol.connection_lost(None)   # TODO: check for exceptions
+            runner.wait_for_threads()
+            self.state = self.GeneratorState.connection_lost
+
+        if self.state == self.GeneratorState.connection_lost:
+            # Get all results that were enqueued in
+            # state: GeneratorState.process_exited.
+            if len(self.result_queue) > 0:
+                return self.result_queue.popleft()
+            raise StopIteration(self.return_code)
+
+    def throw(self, exception_type, value=None, trace_back=None):
+        return Generator.throw(self, exception_type, value, trace_back)
+
+
+class ThreadedRunner:
+    """
+    A class the contains a naive implementation for concurrent sub-process
+    execution. It uses `subprocess.Popen` and threads to read from stdout and
+    stderr of the subprocess, and to write to stdin of the subprocess.
+
+    All read data and timeouts are passed to a protocol instance, which can
+    create the final result.
+    """
+    # Interval in seconds after which we check that a subprocess
+    # is still running.
+    timeout_resolution = 0.2
+
+    def __init__(self,
+                 cmd: Union[str, List],
+                 protocol_class: Type[WitlessProtocol],
+                 stdin: Any,
+                 protocol_kwargs: Optional[Dict] = None,
+                 timeout: Optional[float] = None,
+                 exception_on_error: bool = True,
+                 **popen_kwargs
+                 ):
         """
         Parameters
         ----------
-        file:
-          File object from which the thread will read data
-          and write it into the queue. This is usually the
-          read end of a pipe.
-        q:
-          A queue into which the thread writes what it reads
-          from file.
-        command:
-          The command for which the thread was created. This
-          is mainly used to improve debug output messages.
+        cmd : list or str
+            Command to be executed, passed to `subprocess.Popen`. If cmd
+            is a str, `subprocess.Popen will be called with `shell=True`.
+
+        protocol : WitlessProtocol class or subclass which will be
+            instantiated for managing communication with the subprocess.
+
+            If the protocol is a subclass of
+            `datalad.runner.protocol.GeneratorMixIn`, this function will
+            return a `Generator` which yields whatever the protocol callback
+            fed into `GeneratorMixIn.send_result()`.
+
+            If the protocol is not a subclass of
+            `datalad.runner.protocol.GeneratorMixIn`, the function will return
+            the result created by the protocol method `_generate_result`.
+
+        stdin : file-like, string, bytes, Queue, or None
+            If stdin is a file-like, it will be directly used as stdin for the
+            subprocess. The caller is responsible for writing to it and closing
+            it. If stdin is a string or bytes, those will be fed to stdin of the
+            subprocess. If all data is written, stdin will be closed.
+            If stdin is a Queue, all elements (bytes) put into the Queue will
+            be passed to stdin until None is read from the queue. If None is
+            read, stdin of the subprocess is closed.
+            If stdin is None, nothing will be sent to stdin of the subprocess.
+            More precisely, `subprocess.Popen` will be called with `stdin=None`.
+
+        protocol_kwargs : dict, optional
+            Passed to the protocol class constructor.
+
+        timeout : float, optional
+            If a non-`None` timeout is specified, the `timeout`-method of
+            the protocol will be called if:
+
+            - stdin-write, stdout-read, or stderr-read time out. In this case
+              the file descriptor will be given as argument to the
+              timeout-method. If the timeout-method return `True`, the file
+              descriptor will be closed.
+
+            - process.wait() timeout: if waiting for process completion after
+              stdin, stderr, and stdout takes longer than `timeout` seconds,
+              the timeout-method will be called with the argument `None`. If
+              it returns `True`, the process will be terminated.
+
+        exception_on_error : bool, optional
+            This argument is only interpreted if the protocol is a subclass
+            of `GeneratorMixIn`. If it is `True` (default), a
+            `CommandErrorException` is raised by the generator if the
+            sub process exited with a return code not equal to zero. If the
+            parameter is `False`, no exception is raised. In both cases the
+            return code can be read from the attribute `return_code` of
+            the generator.
+
+        popen_kwargs : dict, optional
+            Passed to `subprocess.Popen`, will typically be parameters
+            supported by `subprocess.Popen`. Note that `bufsize`, `stdin`,
+            `stdout`, `stderr`, and `shell` will be overwritten internally.
         """
-        super().__init__(daemon=True)
-        self.file = file
-        self.queue = q
-        self.command = command
-        self.quit = False
 
-    def __str__(self):
-        return f"ReaderThread({self.file}, {self.queue}, {self.command})"
+        self.cmd = cmd
+        self.protocol_class = protocol_class
+        self.stdin = stdin
+        self.protocol_kwargs = protocol_kwargs or {}
+        self.timeout = timeout
+        self.exception_on_error = exception_on_error
+        self.popen_kwargs = popen_kwargs
 
-    def request_exit(self):
+        self.catch_stdout = self.protocol_class.proc_out is not None
+        self.catch_stderr = self.protocol_class.proc_err is not None
+        self.generator = self.protocol_class.generator is not None
+
+        self.write_stdin = False
+        self.stdin_queue = None
+        self.protocol = None
+        self.process = None
+        self.process_stdin_fileno = None
+        self.process_stdout_fileno = None
+        self.process_stderr_fileno = None
+        self.stderr_enqueueing_thread = None
+        self.stdout_enqueueing_thread = None
+        self.stdin_enqueueing_thread = None
+        self.process_waiting_thread = None
+
+        self.process_running = False
+        self.fileno_mapping = None
+        self.fileno_to_file = None
+        self.file_to_fileno = None
+        self.output_queue = Queue()
+        self.result = None
+        self.process_removed = False
+        self.return_code = None
+
+        self.last_touched = dict()
+        self.active_file_numbers = set()
+
+    def _check_result(self):
+        if self.exception_on_error is True:
+            if self.return_code != 0:
+                protocol = self.protocol
+                decoded_output = {
+                    source: protocol.fd_infos[fileno][1].decode(protocol.encoding)
+                    for source, fileno in (
+                        ("stdout", protocol.stdout_fileno),
+                        ("stderr", protocol.stderr_fileno))
+                    if protocol.fd_infos[fileno][1] is not None
+                }
+                raise CommandError(cmd=self.cmd,
+                                   code=self.return_code,
+                                   stdout=decoded_output.get("stdout", None),
+                                   stderr=decoded_output.get("stderr", None))
+
+    def run(self) -> Union[Any, Generator]:
         """
-        Request the thread to exit. This is not guaranteed to
-        have any effect, because the thread might be waiting in
-        `os.read()` or on `queue.put()`, if the queue size is finite.
-        To ensure thread termination, you can ensure that another thread
-        empties the queue, and try to trigger a read on `self.file.fileno()`,
-        e.g. by writing into the write-end of a pipe that is connected to
-        `self.file.fileno()`.
+        Run the command as specified in __init__.
+
+        Returns
+        -------
+        Any
+            If the protocol is not a subclass of `GeneratorMixIn`, the
+            result of protocol._prepare_result will be returned.
+
+        Generator
+            If the protocol is a subclass of `GeneratorMixIn`, a Generator
+            will be returned. This allows to use this method in constructs
+            like:
+
+                for protocol_output in runner.run():
+                    ...
+
+            Where the iterator yields whatever protocol.pipe_data_received
+            sends into the generator.
+            If all output was yielded and the process has terminated, the
+            generator will raise StopIteration(return_code), where
+            return_code is the return code of the process. The return code
+            of the process will also be stored in the "return_code"-attribute
+            of the runner. So you could write:
+
+               gen = runner.run()
+               for file_descriptor, data in gen:
+                   ...
+
+               # get the return code of the process
+               result = gen.return_code
         """
-        self.quit = True
+        if isinstance(self.stdin, (int, IO, type(None))):
+            # indicate that we will not write anything to stdin, that
+            # means the user can pass None, or he can pass a
+            # file-like and write to it from a different thread.
+            self.write_stdin = False  # the caller will write to the parameter
 
-    def run(self):
-        lgr.log(5, "%s started", self)
+        elif isinstance(self.stdin, (str, bytes)):
+            # Establish a queue to write to the process and
+            # enqueue the input that is already provided.
+            self.write_stdin = True
+            self.stdin_queue = Queue()
+            self.stdin_queue.put(self.stdin)
+            self.stdin_queue.put(None)
+        elif isinstance(self.stdin, Queue):
+            # Establish a queue to write to the process.
+            self.write_stdin = True
+            self.stdin_queue = self.stdin
+        else:
+            # indicate that we will not write anything to stdin, that
+            # means the user can pass None, or he can pass a
+            # file-like and write to it from a different thread.
+            lgr.warning(f"Unknown instance class: {type(self.stdin)}, "
+                        f"assuming file-like input: {self.stdin}")
+            # We assume that the caller will write to the given
+            # file descriptor.
+            self.write_stdin = False
 
-        while not self.quit:
+        self.protocol = self.protocol_class(**self.protocol_kwargs)
 
-            data = os.read(self.file.fileno(), 1024)
-            if data == b"":
-                lgr.log(5, "%s exiting (stream end)", self)
-                self.queue.put((self.file.fileno(), None, time.time()))
-                return
+        kwargs = {
+            **self.popen_kwargs,
+            **dict(
+                bufsize=0,
+                stdin=subprocess.PIPE if self.write_stdin else self.stdin,
+                stdout=subprocess.PIPE if self.catch_stdout else None,
+                stderr=subprocess.PIPE if self.catch_stderr else None,
+                shell=True if isinstance(self.cmd, str) else False
+            )
+        }
 
-            self.queue.put((self.file.fileno(), data, time.time()))
+        try:
+            self.process = subprocess.Popen(self.cmd, **kwargs)
+        except OSError as e:
+            if not on_windows and "argument list too long" in str(e).lower():
+                lgr.error(
+                    "Caught exception suggesting too large stack size limits. "
+                    "Hint: use 'ulimit -s' command to see current limit and "
+                    "e.g. 'ulimit -s 8192' to reduce it to avoid this exception. "
+                    "See https://github.com/datalad/datalad/issues/6106 for more "
+                    "information."
+                )
+            raise
+        self.process_running = True
+        self.active_file_numbers.add(None)
 
+        self.process_stdin_fileno = self.process.stdin.fileno() if self.write_stdin else None
+        self.process_stdout_fileno = self.process.stdout.fileno() if self.catch_stdout else None
+        self.process_stderr_fileno = self.process.stderr.fileno() if self.catch_stderr else None
 
-class _StdinWriterThread(threading.Thread):
-    def __init__(self, stdin_data, process, stdin_fileno, q, command=""):
-        """
-        Parameters
-        ----------
-        stdin_data:
-          Data that should be written to the file given by `stdin_fileno´.
-        process:
-          a subprocess.Popen-instance. It is mainly used to access
-          popen._stdin_write(...)
-        q:
-          A queue into which the thread writes a None-data object to
-          indicate that all stdin_data was written.
-        command:
-          The command for which the thread was created. This
-          is mainly used to improve debug output messages.
-        """
-        super().__init__(daemon=True)
-        self.stdin_data = stdin_data
-        self.process = process
-        self.stdin_fileno = stdin_fileno
-        self.queue = q
-        self.command = command
+        # We pass process as transport-argument. It does not have the same
+        # semantics as the asyncio-signature, but since it is only used in
+        # WitlessProtocol, all necessary changes can be made there.
+        self.protocol.connection_made(self.process)
 
-    def __str__(self):
+        # Map the pipe file numbers to stdout and stderr file number, because
+        # the latter are hardcoded in the protocol code
+        self.fileno_mapping = {
+            self.process_stdout_fileno: STDOUT_FILENO,
+            self.process_stderr_fileno: STDERR_FILENO,
+            self.process_stdin_fileno: STDIN_FILENO,
+        }
+
+        self.fileno_to_file = {
+            self.process_stdout_fileno: self.process.stdout,
+            self.process_stderr_fileno: self.process.stderr,
+            self.process_stdin_fileno: self.process.stdin
+        }
+
+        self.file_to_fileno = {
+            f: f.fileno()
+            for f in (
+                self.process.stdout,
+                self.process.stderr,
+                self.process.stdin
+            ) if f is not None
+        }
+
+        current_time = time.time()
+        if self.timeout:
+            self.last_touched[None] = current_time
+
+        cmd_string = self.cmd if isinstance(self.cmd, str) else " ".join(self.cmd)
+        if self.catch_stderr:
+            if self.timeout:
+                self.last_touched[self.process_stderr_fileno] = current_time
+            self.active_file_numbers.add(self.process_stderr_fileno)
+            self.last_touched[self.process_stderr_fileno] = current_time
+            self.stderr_enqueueing_thread = ReadThread(
+                identifier="STDERR: " + cmd_string[:20],
+                signal_queues=[self.output_queue],
+                user_info=self.process_stderr_fileno,
+                source=self.process.stderr,
+                destination_queue=self.output_queue)
+            self.stderr_enqueueing_thread.start()
+
+        if self.catch_stdout:
+            if self.timeout:
+                self.last_touched[self.process_stdout_fileno] = current_time
+            self.active_file_numbers.add(self.process_stdout_fileno)
+            self.last_touched[self.process_stdout_fileno] = current_time
+            self.stdout_enqueueing_thread = ReadThread(
+                identifier="STDOUT: " + cmd_string[:20],
+                signal_queues=[self.output_queue],
+                user_info=self.process_stdout_fileno,
+                source=self.process.stdout,
+                destination_queue=self.output_queue)
+            self.stdout_enqueueing_thread.start()
+
+        if self.write_stdin:
+            # No timeouts for stdin
+            self.active_file_numbers.add(self.process_stdin_fileno)
+            self.stdin_enqueueing_thread = WriteThread(
+                identifier="STDIN: " + cmd_string[:20],
+                user_info=self.process_stdin_fileno,
+                signal_queues=[self.output_queue],
+                source_queue=self.stdin_queue,
+                destination=self.process.stdin)
+            self.stdin_enqueueing_thread.start()
+
+        self.process_waiting_thread = WaitThread(
+            "process_waiter",
+            [self.output_queue],
+            self.process)
+        self.process_waiting_thread.start()
+
+        if issubclass(self.protocol_class, GeneratorMixIn):
+            assert isinstance(self.protocol, GeneratorMixIn)
+            return _ResultGenerator(self, self.protocol.result_queue)
+
+        return self.process_loop()
+
+    def process_loop(self) -> Any:
+        # Process internal messages until no more active file descriptors
+        # are present. This works because active file numbers are only
+        # removed when an EOF is received in `self.process_queue`.
+        while self.should_continue():
+            self.process_queue()
+
+        # Let the protocol prepare the result. This has to be done after
+        # the loop was left to ensure that all data from stdout and stderr
+        # is processed.
+        self.result = self.protocol._prepare_result()
+        self.protocol.process_exited()
+
+        # Ensure that all communication channels are closed.
+        self.ensure_stdin_stdout_stderr_closed()
+        self.protocol.connection_lost(None)  # TODO: check exception
+        self.wait_for_threads()
+        return self.result
+
+    def process_timeouts(self):
+        if self.timeout is not None:
+            last_touched = list(self.last_touched.items())
+            new_times = dict()
+            current_time = time.time()
+            for source, last_time in last_touched:
+                if current_time - last_time >= self.timeout:
+                    new_times[source] = current_time
+                    if source is None:
+                        if self.protocol.timeout(None) is True:
+                            self.ensure_stdin_stdout_stderr_closed()
+                            self.process.terminate()
+                            self.process.wait()
+                            self.remove_process()
+                    else:
+                        if self.protocol.timeout(self.fileno_mapping[source]) is True:
+                            self.remove_file_number(source)
+
+            # Update triggered timeouts
+            self.last_touched = {
+                **self.last_touched,
+                **new_times
+            }
+
+    def should_continue(self) -> bool:
+        # Continue with queue processing if there is still a process or
+        # monitored files, or if there are still elements in the output queue.
+        live_threads = [
+                thread.is_alive()
+                for thread in (
+                    self.stdin_enqueueing_thread,
+                    self.stdout_enqueueing_thread,
+                    self.stderr_enqueueing_thread,
+                    self.process_waiting_thread,
+                ) if thread is not None]
         return (
-            f"WriterThread(stdin_data[0 ... {len(self.stdin_data) - 1}], "
-            f"{self.process}, {self.stdin_fileno}, {self.command})")
+            len(self.active_file_numbers) > 0
+            or self.output_queue.empty() is False
+            or any(live_threads))
 
-    def run(self):
-        lgr.log(5, "%s started", self)
+    def process_queue(self):
+        """
+        Get a single event from the queue or handle a timeout. This method
+        might modify the set of active file numbers if a file-closed event
+        is read from the output queue, or if a timeout-callback return True.
+        """
+        data = None
+        while True:
+            # We do not need a user provided timeout here. If
+            # self.timeout is None, no timeouts are reported anyway.
+            # If self.timeout is not None, and any enqueuing (stdin)
+            # or de-queuing (stdout, stderr) operation takes longer than
+            # self.timeout, we will get a queue entry for that.
+            # We still use a "system"-timeout, i.e.
+            # `ThreadedRunner.process_check_interval`, to check whether the
+            # process is still running.
+            try:
+                file_number, state, data = self.output_queue.get(
+                    timeout=ThreadedRunner.timeout_resolution)
+                break
+            except Empty:
+                self.process_timeouts()
+                continue
 
-        # (ab)use internal helper that takes care of a bunch of corner cases
-        # and closes stdin at the end
-        self.process._stdin_write(self.stdin_data)
+        if state == IOState.process_exit:
+            self.remove_process()
+            return
 
-        lgr.log(5, "%s exiting (write completed or interrupted)", self)
-        self.queue.put((self.stdin_fileno, None, time.time()))
+        if self.write_stdin and file_number == self.process_stdin_fileno:
+            # The only data-signal we expect from stdin thread
+            # is None, indicating that the thread ended
+            assert data is None
+            self.remove_file_number(self.process_stdin_fileno)
+
+        elif self.catch_stderr or self.catch_stdout:
+            if data is None:
+                # Received an EOF for stdout or stderr.
+                self.remove_file_number(file_number)
+            else:
+                # Call the protocol handler for data
+                assert isinstance(data, bytes)
+                self.last_touched[file_number] = time.time()
+                self.protocol.pipe_data_received(
+                    self.fileno_mapping[file_number],
+                    data)
+
+    def remove_process(self):
+        if None not in self.active_file_numbers:
+            # Might already be removed due to a timeout callback returning
+            # True and subsequent removal of the process.
+            return
+        self.active_file_numbers.remove(None)
+        if self.timeout:
+            del self.last_touched[None]
+
+        # Remove stdin from the active set because the process will
+        # no longer consume input from stdin. This is done by enqueuing
+        # None to the stdin queue.
+        if self.write_stdin:
+            self.stdin_queue.put(None)
+
+        self.return_code = self.process.poll()
+
+    def remove_file_number(self, file_number: int):
+        """
+        Remove a file number from the active set and from
+        the timeout set.
+        """
+
+        # TODO: check exception
+        # Let the protocol know that the connection was lost.
+        self.protocol.pipe_connection_lost(
+            self.fileno_mapping[file_number],
+            None)
+
+        if file_number in self.active_file_numbers:
+            # Remove the file number from the set of active numbers.
+            self.active_file_numbers.remove(file_number)
+
+        # If we are checking timeouts, remove the file number from
+        # timeouts.
+        if self.timeout and file_number in self.last_touched:
+            del self.last_touched[file_number]
+
+        _try_close(self.fileno_to_file[file_number])
+
+    def close_stdin(self):
+        if self.stdin_queue:
+            self.stdin_queue.put(None)
+
+    def _ensure_closed(self, file_objects):
+        for file_object in file_objects:
+            if file_object is not None:
+                file_number = self.file_to_fileno.get(file_object, None)
+                if file_number is not None:
+                    if self.timeout and file_number in self.last_touched:
+                        del self.last_touched[file_number]
+                    if file_number in self.active_file_numbers:
+                        self.active_file_numbers.remove(file_number)
+                _try_close(file_object)
+
+    def ensure_stdin_stdout_stderr_closed(self):
+        self.close_stdin()
+        self._ensure_closed((self.process.stdin,
+                             self.process.stdout,
+                             self.process.stderr))
+
+    def ensure_stdout_stderr_closed(self):
+        self._ensure_closed((self.process.stdout, self.process.stderr))
+
+    def wait_for_threads(self):
+        for thread in (self.stderr_enqueueing_thread,
+                       self.stdout_enqueueing_thread,
+                       self.stdin_enqueueing_thread):
+            if thread is not None:
+                thread.request_exit()
 
 
 def run_command(cmd: Union[str, List],
                 protocol: Type[WitlessProtocol],
                 stdin: Any,
                 protocol_kwargs: Optional[Dict] = None,
-                **kwargs) -> Any:
+                timeout: Optional[float] = None,
+                exception_on_error: bool = True,
+                **popen_kwargs) -> Union[Any, Generator]:
     """
     Run a command in a subprocess
 
-    This is a naive implementation that uses sub`process.Popen`
-    and threads to read from sub-proccess' stdout and stderr and
-    put it into a queue from which the main-thread reads.
-    Upon receiving data from the queue, the main thread
-    will delegate data handling to a protocol_class instance
-
-    Parameters
-    ----------
-    cmd : list or str
-      Command to be executed, passed to `subprocess.Popen`. If cmd
-      is a str, `subprocess.Popen will be called with `shell=True`.
-    protocol : WitlessProtocol class or subclass
-      Protocol class to be instantiated for managing communication
-      with the subprocess.
-    stdin : file-like, subprocess.PIPE, str, bytes or None
-      Passed to the subprocess as its standard input. In the case of a str
-      or bytes objects, the subprocess stdin is set to subprocess.PIPE
-      and the given input is written to it after the process has started.
-    protocol_kwargs : dict, optional
-       Passed to the Protocol class constructor.
-    kwargs : Pass to `subprocess.Popen`, will typically be parameters
-       supported by `subprocess.Popen`. Note that `bufsize`, `stdin`,
-       `stdout`, `stderr`, and `shell` will be overwritten by
-       `run_command`.
-
-    Returns
-    -------
-    undefined
-      The nature of the return value is determined by the method
-      `_prepare_result` of the given protocol class or its superclass.
+    this function delegates the execution to an instance of
+    `ThreadedRunner`, please see `ThreadedRunner.__init__()` for a
+    documentation of the parameters, and `ThreadedRunner.run()` for a
+    documentation of the return values.
     """
+    runner = ThreadedRunner(
+        cmd=cmd,
+        protocol_class=protocol,
+        stdin=stdin,
+        protocol_kwargs=protocol_kwargs,
+        timeout=timeout,
+        exception_on_error=exception_on_error,
+        **popen_kwargs,
+    )
 
-    protocol_kwargs = {} if protocol_kwargs is None else protocol_kwargs
-
-    catch_stdout = protocol.proc_out is not None
-    catch_stderr = protocol.proc_err is not None
-
-    if isinstance(stdin, (str, bytes)):
-        # we got something that is not readily usable stdin, but must be
-        # fed to the processes stdin
-        stdin_data = stdin
-    else:
-        # indicate that there is nothing to write to stdin
-        stdin_data = None
-
-    write_stdin = stdin_data is not None
-
-    kwargs = {
-        **kwargs,
-        **dict(
-            bufsize=0,
-            stdin=subprocess.PIPE if write_stdin else stdin,
-            stdout=subprocess.PIPE if catch_stdout else None,
-            stderr=subprocess.PIPE if catch_stderr else None,
-            shell=True if isinstance(cmd, str) else False
-        )
-    }
-
-    protocol = protocol(**protocol_kwargs)
-
-    try:
-        process = subprocess.Popen(cmd, **kwargs)
-    except OSError as e:
-        if not on_windows and "argument list too long" in str(e).lower():
-            lgr.error(
-                "Caught exception suggesting too large stack size limits. "
-                "Hint: use 'ulimit -s' command to see current limit and "
-                "e.g. 'ulimit -s 8192' to reduce it to avoid this exception. "
-                "See https://github.com/datalad/datalad/issues/6106 for more "
-                "information."
-            )
-        raise
-    process_stdin_fileno = process.stdin.fileno() if write_stdin else None
-    process_stdout_fileno = process.stdout.fileno() if catch_stdout else None
-    process_stderr_fileno = process.stderr.fileno() if catch_stderr else None
-
-    # We pass process as transport-argument. It does not have the same
-    # semantics as the asyncio-signature, but since it is only used in
-    # WitlessProtocol, all necessary changes can be made there.
-    protocol.connection_made(process)
-
-    # Map the pipe file numbers to stdout and stderr file number, because
-    # the latter are hardcoded in the protocol code
-    fileno_mapping = {
-        process_stdout_fileno: STDOUT_FILENO,
-        process_stderr_fileno: STDERR_FILENO
-    }
-
-    if catch_stdout or catch_stderr or write_stdin:
-
-        output_queue = queue.Queue()
-        active_file_numbers = set()
-        if catch_stderr:
-            active_file_numbers.add(process_stderr_fileno)
-            stderr_reader_thread = _ReaderThread(process.stderr, output_queue, cmd)
-            stderr_reader_thread.start()
-        if catch_stdout:
-            active_file_numbers.add(process_stdout_fileno)
-            stdout_reader_thread = _ReaderThread(process.stdout, output_queue, cmd)
-            stdout_reader_thread.start()
-        if write_stdin:
-            active_file_numbers.add(process_stdin_fileno)
-            stdin_writer_thread = _StdinWriterThread(stdin_data, process, process_stdin_fileno, output_queue, cmd)
-            stdin_writer_thread.start()
-
-        while True:
-
-            file_number, data, time_stamp = output_queue.get()
-            if write_stdin and file_number == process_stdin_fileno:
-                # Input writing is transparent to the main thread,
-                # we just check whether the input writer is still running.
-                active_file_numbers.remove(process_stdin_fileno)
-            else:
-                if isinstance(data, bytes):
-                    protocol.pipe_data_received(fileno_mapping[file_number], data)
-                else:
-                    protocol.pipe_connection_lost(fileno_mapping[file_number], data)
-                    active_file_numbers.remove(file_number)
-
-            if not active_file_numbers:
-                break
-
-    process.wait()
-    result = protocol._prepare_result()
-    protocol.process_exited()
-    protocol.connection_lost(None)  # TODO: check exception
-    for fd in (process.stdin, process.stdout, process.stderr):
-        if fd is not None:
-            fd.close()
-
-    return result
+    return runner.run()

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -477,18 +477,9 @@ class ThreadedRunner:
     def should_continue(self) -> bool:
         # Continue with queue processing if there is still a process or
         # monitored files, or if there are still elements in the output queue.
-        live_threads = [
-                thread.is_alive()
-                for thread in (
-                    self.stdin_enqueueing_thread,
-                    self.stdout_enqueueing_thread,
-                    self.stderr_enqueueing_thread,
-                    self.process_waiting_thread,
-                ) if thread is not None]
         return (
             len(self.active_file_numbers) > 0
-            or self.output_queue.empty() is False
-            or any(live_threads))
+            or not self.output_queue.empty())
 
     def process_queue(self):
         """
@@ -511,11 +502,6 @@ class ThreadedRunner:
                     timeout=ThreadedRunner.timeout_resolution)
                 break
             except Empty:
-                # Check should continue regularly, because we might
-                # have entered with an empty set and running threads
-                # that were just about to exit.
-                if not self.should_continue():
-                    return
                 self.process_timeouts()
                 continue
 

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -511,6 +511,11 @@ class ThreadedRunner:
                     timeout=ThreadedRunner.timeout_resolution)
                 break
             except Empty:
+                # Check should continue regularly, because we might
+                # have entered with an empty set and running threads
+                # that were just about to exit.
+                if not self.should_continue():
+                    return
                 self.process_timeouts()
                 continue
 

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -240,6 +240,7 @@ class ThreadedRunner:
 
         self.last_touched = dict()
         self.active_file_numbers = set()
+        self.deadlock_check_interval = 10
 
     def _check_result(self):
         if self.exception_on_error is True:
@@ -502,6 +503,14 @@ class ThreadedRunner:
                     timeout=ThreadedRunner.timeout_resolution)
                 break
             except Empty:
+                # Check for deadlock situation every 1000 ms
+                if self.deadlock_check_interval == 0:
+                    self.deadlock_check_interval = 11
+                    if not self.should_continue():
+                        lgr.warning(
+                            "ThreadedRunner.process_queue(): deadlock detected")
+                        return
+                self.deadlock_check_interval -= 1
                 self.process_timeouts()
                 continue
 

--- a/datalad/runner/protocol.py
+++ b/datalad/runner/protocol.py
@@ -12,12 +12,37 @@
 import asyncio
 import logging
 import warnings
+from collections import deque
 from locale import getpreferredencoding
+from typing import Optional
 
 from .exception import CommandError
 from .utils import ensure_unicode
 
 lgr = logging.getLogger('datalad.runner.protocol')
+
+
+class GeneratorMixIn:
+    """ Protocol mix in that will instruct runner.run to return a generator
+
+    When this class is in the parent of a protocol given to runner.run (and
+    some other functions/methods) the run-method will return a `Generator`,
+    which yields whatever the protocol callbacks send to the `Generator`,
+    via the `send_result`-method of this class.
+
+    This allows to use runner.run() in constructs like:
+
+        for result in runner.run(...):
+            # do something, for example write to stdin of the subprocess
+
+    """
+    generator = True
+
+    def __init__(self):
+        self.result_queue = deque()
+
+    def send_result(self, result):
+        self.result_queue.append(result)
 
 
 class WitlessProtocol(asyncio.SubprocessProtocol):
@@ -36,6 +61,8 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
 
     proc_out = None
     proc_err = None
+
+    generator = None
 
     def __init__(self, done_future=None, encoding=None):
         """
@@ -97,10 +124,44 @@ class WitlessProtocol(asyncio.SubprocessProtocol):
 
     def pipe_data_received(self, fd, data):
         self._log(fd, data)
-        # store received output if stream was to be captured
+        # Store received output if stream was to be captured.
         fd_name, buffer = self.fd_infos[fd]
         if buffer is not None:
             buffer.extend(data)
+
+    def timeout(self, fd: Optional[int]) -> bool:
+        """
+        Called if the timeout parameter to WitlessRunner.run()
+        is not `None` and a process file descriptor could not
+        be read (stdout or stderr) or not be written (stdin)
+        within the specified time in seconds, or if waiting for
+        a subprocess to exit takes longer than the specified time.
+
+        stdin timeouts are only caught when the type of the `stdin`-
+        parameter to WitlessRunner.run() is either a `Queue`,
+        a `str`, or `bytes`. `Stdout` or `stderr` timeouts
+        are only caught of proc_out and proc_err are
+        not None in the protocol class. Process wait timeouts are
+        always caught if `timeout` is not `None`. In this case the
+        `fd`-argument will be `None`.
+
+        fd:
+          The file descriptor that timed out or `None` if no
+          progress was made at all, i.e. no stdin element was
+          enqueued and no output was read from either stdout
+          or stderr.
+
+        return:
+          If the callback returns `True`, the file descriptor
+          (if any was given) will be closed and no longer monitored.
+          If the return values is anything else than `True`,
+          the file-descriptor will be monitored further
+          and additional timeouts might occur indefinitely.
+          If `None` was given, i.e. a process runtime-timeout
+          was detected, and `True` is returned, the process
+          will be terminated.
+        """
+        return False
 
     def _prepare_result(self):
         """Prepares the final result to be returned to the runner

--- a/datalad/runner/runner.py
+++ b/datalad/runner/runner.py
@@ -10,20 +10,12 @@
 """
 
 import logging
-import os
-import subprocess
-import tempfile
-import warnings
 
 from .coreprotocols import NoCapture
 from .exception import CommandError
 from .nonasyncrunner import run_command
-from .utils import (
-    auto_repr,
-    ensure_unicode,
-    try_multiple,
-    unlink,
-)
+from .protocol import GeneratorMixIn
+
 
 lgr = logging.getLogger('datalad.runner.runner')
 
@@ -67,7 +59,15 @@ class WitlessRunner(object):
             env['PWD'] = cwd
         return env
 
-    def run(self, cmd, protocol=None, stdin=None, cwd=None, env=None, **kwargs):
+    def run(self,
+            cmd,
+            protocol=None,
+            stdin=None,
+            cwd=None,
+            env=None,
+            timeout=None,
+            exception_on_error=True,
+            **kwargs):
         """Execute a command and communicate with it.
 
         Parameters
@@ -79,9 +79,16 @@ class WitlessRunner(object):
           Protocol class handling interaction with the running process
           (e.g. output capture). A number of pre-crafted classes are
           provided (e.g `KillOutput`, `NoCapture`, `GitProgress`).
-        stdin : byte stream, optional
-          File descriptor like, or bytes objects used as stdin for the process.
-          Passed verbatim to run_command().
+          If the protocol has the GeneratorMixIn-mixin, the run-method
+          will return an iterator and can therefore be used in a for-clause.
+        stdin : file-like, string, bytes, Queue, or None
+          If stdin is a file-like, it will be directly used as stdin for the
+          subprocess. The caller is responsible for writing to it and closing it.
+          If stdin is a string or bytes, those will be fed to stdin of the
+          subprocess. If all data is written, stdin will be closed.
+          If stdin is a Queue, all elements (bytes) put into the Queue will
+          be passed to stdin until None is read from the queue. If None is read,
+          stdin of the subprocess is closed.
         cwd : path-like, optional
           If given, commands are executed with this path as PWD,
           the PWD of the parent process is used otherwise. Overrides
@@ -92,15 +99,49 @@ class WitlessRunner(object):
           This must be a complete environment definition, no values
           from the current environment will be inherited. Overrides
           any `env` given to the constructor.
+        timeout:
+          None or the seconds after which a timeout callback is
+          invoked, if no progress was made in communicating with
+          the sub-process, or if waiting for the subprocess exit
+          took more than the specified time. See the protocol and
+          `ThreadedRunner` descriptions for a more detailed discussion
+          on timeouts.
+        exception_on_error : bool, optional
+          This argument is only interpreted if the protocol is a subclass
+          of `GeneratorMixIn`. If it is `True` (default), a
+          `CommandErrorException` is raised by the generator if the
+          sub process exited with a return code not equal to zero. If the
+          parameter is `False`, no exception is raised. In both cases the
+          return code can be read from the attribute `return_code` of
+          the generator.
         kwargs :
           Passed to the Protocol class constructor.
 
-        Returns
-        -------
-        dict
-          At minimum there will be keys 'stdout', 'stderr' with
-          unicode strings of the cumulative standard output and error
-          of the process as values.
+        : returns : Union[Any, Generator]
+
+            If the protocol is not a subclass of `GeneratorMixIn`, the
+            result of protocol._prepare_result will be returned.
+
+            If the protocol is a subclass of `GeneratorMixIn`, a Generator
+            will be returned. This allows to use this method in constructs like:
+
+                for protocol_output in runner.run():
+                    ...
+
+            Where the iterator yields whatever protocol.pipe_data_received
+            sends into the generator.
+            If all output was yielded and the process has terminated, the
+            generator will raise StopIteration(return_code), where
+            return_code is the return code of the process. The return code
+            of the process will also be stored in the "return_code"-attribute
+            of the runner. So you could write:
+
+               gen = runner.run()
+               for file_descriptor, data in gen:
+                   ...
+
+               # get the return code of the process
+               result = gen.return_code
 
         Raises
         ------
@@ -123,14 +164,21 @@ class WitlessRunner(object):
         )
 
         lgr.debug('Run %r (cwd=%s)', cmd, cwd)
-        results = run_command(
+        results_or_iterator = run_command(
             cmd,
             protocol,
             stdin,
             protocol_kwargs=kwargs,
             cwd=cwd,
             env=env,
+            timeout=timeout,
+            exception_on_error=exception_on_error
         )
+
+        if issubclass(protocol, GeneratorMixIn):
+            return results_or_iterator
+        else:
+            results = results_or_iterator
 
         # log before any exception is raised
         lgr.debug("Finished %r with status %s", cmd, results['code'])

--- a/datalad/runner/runnerthreads.py
+++ b/datalad/runner/runnerthreads.py
@@ -1,0 +1,249 @@
+import logging
+import os
+import threading
+from abc import (
+    abstractmethod,
+    ABCMeta,
+)
+from enum import Enum
+from queue import (
+    Full,
+    Queue,
+)
+from subprocess import Popen
+from typing import (
+    Any,
+    IO,
+    List,
+    Union,
+)
+
+
+lgr = logging.getLogger("datalad.runner.runnerthreads")
+
+
+def _try_close(file_object: IO):
+    if file_object is not None:
+        try:
+            file_object.close()
+        except OSError:
+            pass
+
+
+class IOState(Enum):
+    ok = "ok"
+    process_exit = "process_exit"
+
+
+class SignalingThread(threading.Thread):
+    def __init__(self,
+                 identifier: str,
+                 signal_queues: List[Queue]):
+
+        super().__init__(daemon=True)
+        self.identifier = identifier
+        self.signal_queues = signal_queues
+
+    def __repr__(self):
+        return f"Thread<{self.identifier}>"
+
+    def __str__(self):
+        return self.__repr__()
+
+    def signal(self, content):
+        error_occurred = False
+        for signal_queue in self.signal_queues:
+            try:
+                signal_queue.put(content, block=True, timeout=.1)
+            except Full:
+                lgr.debug(f"timeout while trying to signal: {content}")
+                error_occurred = True
+        return not error_occurred
+
+
+class WaitThread(SignalingThread):
+    """
+    Instances of this thread wait for a process to exit and enqueue
+    an exit event in the signal queues.
+    """
+    def __init__(self,
+                 identifier: str,
+                 signal_queues: List[Queue],
+                 process: Popen
+                 ):
+        super().__init__(identifier, signal_queues)
+        self.process = process
+
+    def run(self):
+
+        lgr.log(5, "%s (%s) started", self.identifier, self)
+
+        self.process.wait()
+        self.signal((self.identifier, IOState.process_exit, None))
+
+        lgr.log(5, "%s (%s) exiting", self.identifier, self)
+
+
+class ExitingThread(SignalingThread):
+    def __init__(self,
+                 identifier: str,
+                 signal_queues: List[Queue]
+                 ):
+
+        super().__init__(identifier, signal_queues)
+        self.exit_requested = False
+
+    def request_exit(self):
+        """
+        Request the thread to exit. This is not guaranteed to
+        have any effect, because the instance has to check for
+        self.exit_requested and act accordingly. It might not
+        do that.
+        """
+        self.exit_requested = True
+
+
+class TransportThread(ExitingThread, metaclass=ABCMeta):
+    def __init__(self,
+                 identifier: str,
+                 signal_queues: List[Queue],
+                 user_info: Any
+                 ):
+
+        super().__init__(identifier, signal_queues)
+        self.user_info = user_info
+
+    def __repr__(self):
+        return f"Thread<({self.identifier}, {self.user_info})>"
+
+    def __str__(self):
+        return self.__repr__()
+
+    def signal_event(self,
+                     state: IOState,
+                     data: Union[bytes, None]
+                     ) -> bool:
+        return self.signal((self.user_info, state, data))
+
+    @abstractmethod
+    def read(self) -> Union[bytes, None]:
+        """
+        Read data from source return None, if source is close,
+        or destination close is required.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def write(self,
+              data: Union[bytes, None]):
+        """
+        Write given data to destination, return True if data is
+        written successfully, False otherwise.
+        """
+        raise NotImplementedError
+
+    def run(self):
+
+        lgr.log(5, "%s (%s) started", self.identifier, self)
+
+        # Copy data from source queue to destination queue
+        # until exit is requested. If timeouts arise, signal
+        # them to the receiver via the signal queue.
+        data = b""
+        while not self.exit_requested:
+
+            data = self.read()
+            # If the source sends None-data it wants
+            # us to exit the thread. Signal this to
+            # the downstream queues (which might or might
+            # not be contain the output queue),
+            # and exit the thread.
+            if data is None:
+                break
+
+            if self.exit_requested:
+                break
+
+            succeeded = self.write(data)
+            if not succeeded:
+                break
+
+        self.signal_event(IOState.ok, None)
+        lgr.log(
+            5,
+            "%s (%s) exiting (exit_requested: %s, last data: %s)",
+            self.identifier,
+            self,
+            self.exit_requested, data)
+
+
+class ReadThread(TransportThread):
+    def __init__(self,
+                 identifier: str,
+                 signal_queues: List[Queue],
+                 user_info: Any,
+                 source: IO,
+                 destination_queue: Queue,
+                 length: int = 1024
+                 ):
+
+        super().__init__(identifier, signal_queues, user_info)
+        self.source = source
+        self.destination_queue = destination_queue
+        self.length = length
+
+    def read(self) -> Union[bytes, None]:
+        try:
+            data = os.read(self.source.fileno(), self.length)
+        except (ValueError, OSError):
+            # The destination was most likely closed, nevertheless,
+            # try to close it and indicate EOF.
+            _try_close(self.source)
+            return None
+        return data or None
+
+    def write(self,
+              data: Union[bytes, None]) -> bool:
+
+        # We write to an unlimited queue, no need for timeout checking.
+        self.destination_queue.put((self.user_info, IOState.ok, data))
+        return True
+
+
+class WriteThread(TransportThread):
+    def __init__(self,
+                 identifier: str,
+                 signal_queues: List[Queue],
+                 user_info: Any,
+                 source_queue: Queue,
+                 destination: IO
+                 ):
+
+        super().__init__(identifier, signal_queues, user_info)
+        self.source_queue = source_queue
+        self.destination = destination
+
+    def read(self) -> Union[bytes, None]:
+        data = self.source_queue.get()
+        if data is None:
+            # Close stdin file descriptor here, since we know that no more
+            # data will be sent to stdin.
+            _try_close(self.destination)
+        return data
+
+    def write(self,
+              data: bytes) -> bool:
+        try:
+            written = 0
+            while written < len(data):
+                written += os.write(
+                    self.destination.fileno(),
+                    data[written:])
+                if self.exit_requested:
+                    return written == len(data)
+        except (BrokenPipeError, OSError, ValueError):
+            # The destination was most likely closed, nevertheless,
+            # try to close it and indicate EOF.
+            _try_close(self.destination)
+            return False
+        return True

--- a/datalad/runner/tests/test_exception.py
+++ b/datalad/runner/tests/test_exception.py
@@ -1,0 +1,113 @@
+from typing import (
+    Dict,
+    List,
+)
+
+from datalad.tests.utils import assert_equal
+
+from ..exception import (
+    _format_json_error_messages,
+    CommandError,
+)
+
+
+def get_json_objects(object_count, message_count) -> List[Dict]:
+    return [
+        {
+            "success": index % 2 == 0,
+            "file": f"file-{index}",
+            "note": f"note-{index}",
+            "error-messages": [
+                f"error-message-{index}-{j}"
+                for j in range(message_count)
+            ]
+        }
+        for index in range(object_count)
+    ]
+
+
+def test_format_error_with_duplicates():
+
+    object_count = 10
+    message_count = 3
+
+    json_objects = get_json_objects(object_count, message_count)
+    failed_object_indices = [
+        index
+        for index in range(object_count)
+        if json_objects[index]["success"] is False
+    ]
+
+    # Check single appearance
+    result = _format_json_error_messages(json_objects)
+    lines = result.splitlines()
+    del lines[0]
+    assert_equal(len(lines), len(failed_object_indices) * 4)
+    for i, failed_index in enumerate(failed_object_indices):
+        # Accommodate for non-consistent message formatting, I don't
+        # want to change the formatting because external tools might
+        # depend on it.
+        if i == 0:
+            assert_equal(lines[4 * i], f"> note-{failed_index}")
+        else:
+            assert_equal(lines[4 * i], f">  note-{failed_index}")
+        for j in range(message_count):
+            assert_equal(
+                lines[4 * i + 1 + j],
+                f"error-message-{failed_index}-{j}")
+
+    # Check double appearance
+    result = _format_json_error_messages(json_objects + json_objects)
+    lines = result.splitlines()
+    del lines[0]
+    assert_equal(len(lines), len(failed_object_indices) * 4)
+
+    for i, failed_index in enumerate(failed_object_indices):
+        if i == 0:
+            assert_equal(lines[4 * i], f"> note-{failed_index}")
+        else:
+            assert_equal(lines[4 * i], f">  note-{failed_index}")
+        for j in range(message_count - 1):
+            assert_equal(
+                lines[4 * i + 1 + j],
+                f"error-message-{failed_index}-{j}")
+        j = message_count - 1
+        assert_equal(
+            lines[4 * i + 1 + j],
+            f"error-message-{failed_index}-{j} [2 times]")
+
+
+def test_format_no_errors():
+    json_objects = get_json_objects(1, 3)
+
+    result = _format_json_error_messages(json_objects)
+    assert_equal(result, "")
+
+    result = _format_json_error_messages(json_objects + json_objects)
+    assert_equal(result, "")
+
+
+def test_command_error_rendering():
+    command_error = CommandError(
+        cmd="<cmd>",
+        msg="<msg>",
+        code=1,
+        stdout="<stdout>",
+        stderr="<stderr>",
+        cwd="<cwd>",
+        kwarg1="<kwarg1>",
+        kwarg2="<kwarg2>")
+
+    result = command_error.to_str()
+    assert_equal(
+        result,
+        "CommandError: '<cmd>' failed with exitcode 1 under <cwd> [<msg>] "
+        "[info keys: kwarg1, kwarg2] [out: '<stdout>'] [err: '<stderr>']"
+    )
+
+    result = command_error.to_str(False)
+    assert_equal(
+        result,
+        "CommandError: '<cmd>' failed with exitcode 1 under <cwd> [<msg>] "
+        "[info keys: kwarg1, kwarg2]"
+    )

--- a/datalad/runner/tests/test_generatormixin.py
+++ b/datalad/runner/tests/test_generatormixin.py
@@ -1,0 +1,131 @@
+import sys
+from queue import Queue
+from typing import Optional
+
+from datalad.runner.nonasyncrunner import run_command
+from datalad.runner.protocol import GeneratorMixIn
+from datalad.runner.coreprotocols import (
+    NoCapture,
+    StdOutErrCapture,
+)
+from datalad.tests.utils import (
+    assert_equal,
+    assert_raises,
+)
+
+from ..exception import CommandError
+from ..runner import WitlessRunner
+from .utils import py2cmd
+
+
+class TestProtocol(GeneratorMixIn, StdOutErrCapture):
+    def __init__(self,
+                 done_future=None,
+                 encoding=None):
+
+        StdOutErrCapture.__init__(
+            self,
+            done_future=done_future,
+            encoding=encoding)
+        GeneratorMixIn.__init__(self)
+
+    def pipe_data_received(self, fd, data):
+        self.send_result((fd, data.decode()))
+
+
+def test_generator_mixin_basic():
+
+    stdin_queue = Queue()
+
+    i = 0
+    for fd, data in run_command([sys.executable, "-i", "-"], TestProtocol, stdin_queue):
+        if i > 10:
+            stdin_queue.put(b"exit(0)\n")
+            stdin_queue.put(None)
+        else:
+            stdin_queue.put(f"print({i}*{i})\n".encode())
+        i += 1
+
+
+def test_generator_mixin_runner():
+
+    stdin_queue = Queue()
+
+    runner = WitlessRunner()
+    i = 0
+    for fd, data in runner.run(cmd=[sys.executable, "-i", "-"], protocol=TestProtocol, stdin=stdin_queue):
+        if i > 10:
+            stdin_queue.put(b"exit(0)\n")
+            stdin_queue.put(None)
+        else:
+            stdin_queue.put(f"print({i}*{i})\n".encode())
+        i += 1
+
+
+def test_post_pipe_callbacks():
+    # Expect that the process_exited and connection_lost callbacks
+    # are also called in a GeneratorMixIn protocol
+    class TestPostPipeProtocol(GeneratorMixIn, StdOutErrCapture):
+        def __init__(self):
+            GeneratorMixIn.__init__(self)
+            StdOutErrCapture.__init__(self)
+
+        def process_exited(self):
+            self.send_result(1)
+            self.send_result(2)
+
+        def connection_lost(self, exc: Optional[Exception]) -> None:
+            self.send_result(3)
+            self.send_result(4)
+
+    runner = WitlessRunner()
+    results = list(runner.run(cmd=["echo", "a"], protocol=TestPostPipeProtocol))
+    assert_equal(results, [1, 2, 3, 4])
+
+
+def test_file_number_activity_detection():
+    # Expect an output queue that just has the process exit notification.
+    # empty output queue without active threads
+    # waits for the process and progresses the generator state
+    # to `_ResultGenerator.GeneratorState.process_exited`.
+    class TestFNADProtocol(GeneratorMixIn, NoCapture):
+        def __init__(self):
+            GeneratorMixIn.__init__(self)
+            NoCapture.__init__(self)
+
+        def process_exited(self):
+            self.send_result(3)
+
+        def connection_lost(self, exc: Optional[Exception]) -> None:
+            self.send_result(4)
+
+    wl_runner = WitlessRunner()
+    result_generator = wl_runner.run(cmd=["echo", "a"], protocol=TestFNADProtocol)
+
+    runner = result_generator.runner
+    output_queue = runner.output_queue
+    assert len(result_generator.runner.active_file_numbers) == 1
+    while runner.should_continue():
+        runner.process_queue()
+
+    # Expect process exited and connection lost to be called.
+    assert_equal(result_generator.send(None), 3)
+    assert_equal(result_generator.send(None), 4)
+    assert_raises(StopIteration, result_generator.send, None)
+
+
+def test_failing_process():
+    class TestProtocol(GeneratorMixIn, NoCapture):
+        def __init__(self):
+            GeneratorMixIn.__init__(self)
+            NoCapture.__init__(self)
+
+    try:
+        for _ in run_command(py2cmd("exit(1)"),
+                             protocol=TestProtocol,
+                             stdin=None):
+            pass
+        assert_equal(1, 2)
+    except CommandError:
+        return
+    assert_equal(2, 3)

--- a/datalad/runner/tests/test_gitrunner.py
+++ b/datalad/runner/tests/test_gitrunner.py
@@ -26,3 +26,18 @@ def test_gitrunner_generator():
     with patch.object(git_runner, "_get_chunked_results") as get_mock:
         get_mock.return_value = (range(2), range(3))
         assert_equal(tuple(generator), (0, 1, 0, 1, 2))
+
+
+def test_gitrunner_list():
+    # Expect GitRunner._get_chunked_results() to return generators,
+    # if the protocol is a subclass of GeneratorMixIn, and expect
+    # run_on_filelist_chunks_items_ to yield elements from
+    # all generators returned by GitRunner._get_chunked_results().
+    git_runner = GitWitlessRunner(["a", "b", "c"])
+    with patch.object(git_runner, "_get_chunked_results") as get_mock:
+        get_mock.return_value = ({"a": 1, "b": 2}, {"a": 3, "b": 4})
+        result = git_runner.run_on_filelist_chunks(
+            ["a", "b", "c"],
+            ["f1.txt", "f2.txt"],
+            StdOutErrCapture)
+        assert_equal(result, {"a": 4, "b": 6})

--- a/datalad/runner/tests/test_gitrunner.py
+++ b/datalad/runner/tests/test_gitrunner.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+from datalad.runner.protocol import GeneratorMixIn
+from datalad.runner.coreprotocols import (
+    StdOutErrCapture,
+)
+from datalad.tests.utils import assert_equal
+
+from ..gitrunner import GitWitlessRunner
+
+
+class TestGeneratorProtocol(GeneratorMixIn, StdOutErrCapture):
+    pass
+
+
+def test_gitrunner_generator():
+    # Expect GitRunner._get_chunked_results() to return generators,
+    # if the protocol is a subclass of GeneratorMixIn, and expect
+    # run_on_filelist_chunks_items_ to yield elements from
+    # all generators returned by GitRunner._get_chunked_results().
+    git_runner = GitWitlessRunner(["a", "b", "c"])
+    generator = git_runner.run_on_filelist_chunks_items_(
+        ["a", "b", "c"],
+        ["f1.txt", "f2.txt"],
+        TestGeneratorProtocol)
+    with patch.object(git_runner, "_get_chunked_results") as get_mock:
+        get_mock.return_value = (range(2), range(3))
+        assert_equal(tuple(generator), (0, 1, 0, 1, 2))

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -562,3 +562,11 @@ def test_exiting_process():
                          protocol=NoCapture,
                          stdin=None)
     eq_(result["code"], 0)
+
+
+def test_deadlock_detection():
+    runner = ThreadedRunner("something", StdOutErrCapture, None)
+    with patch("datalad.runner.nonasyncrunner.lgr") as logger:
+        runner.process_queue()
+    eq_(logger.method_calls[0][0], "warning")
+    eq_(logger.method_calls[0][1][0], "ThreadedRunner.process_queue(): deadlock detected")

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -14,10 +14,17 @@ import queue
 import signal
 import subprocess
 import sys
+from itertools import count
 from time import sleep
+from typing import (
+    List,
+    Optional,
+)
+from unittest.mock import patch
 
 from datalad.tests.utils import (
     assert_false,
+    assert_raises,
     assert_true,
     eq_,
     known_failure_osx,
@@ -27,14 +34,53 @@ from datalad.tests.utils import (
 from datalad.utils import on_windows
 
 from .. import (
+    NoCapture,
     Protocol,
     Runner,
     StdOutCapture,
+    StdOutErrCapture,
 )
 from ..nonasyncrunner import (
-    _ReaderThread,
+    IOState,
+    ThreadedRunner,
     run_command,
 )
+from ..protocol import (
+    GeneratorMixIn,
+)
+from ..runnerthreads import (
+    ReadThread,
+    WriteThread,
+)
+from .utils import py2cmd
+
+
+# Protocol classes used for a set of generator tests later
+class GenStdoutStderr(GeneratorMixIn, StdOutErrCapture):
+    def __init__(self,
+                 done_future=None,
+                 encoding=None):
+
+        StdOutErrCapture.__init__(
+            self,
+            done_future=done_future,
+            encoding=encoding)
+        GeneratorMixIn.__init__(self)
+
+    def timeout(self, fd: Optional[int]) -> bool:
+        return True
+
+
+class GenNothing(GeneratorMixIn, NoCapture):
+    def __init__(self,
+                 done_future=None,
+                 encoding=None):
+
+        NoCapture.__init__(
+            self,
+            done_future=done_future,
+            encoding=encoding)
+        GeneratorMixIn.__init__(self)
 
 
 def test_subprocess_return_code_capture():
@@ -68,7 +114,8 @@ def test_subprocess_return_code_capture():
                          {
                              "signal_to_send": signal_to_send,
                              "result_pool": result_pool
-                         })
+                         },
+                         exception_on_error=False)
     if not on_windows:
         # this one specifically tests the SIGINT case, which is not supported
         # on windows
@@ -122,32 +169,200 @@ def test_interactive_communication():
     assert_true(result_pool["process_exited_called"], True)
 
 
-def test_thread_exit():
+def test_blocking_thread_exit():
+    read_queue = queue.Queue()
 
     (read_descriptor, write_descriptor) = os.pipe()
     read_file = os.fdopen(read_descriptor, "rb")
-    read_queue = queue.Queue()
-
-    reader_thread = _ReaderThread(read_file, read_queue, "test")
-    reader_thread.start()
+    read_thread = ReadThread(
+        identifier="test thread",
+        user_info=read_descriptor,
+        source=read_file,
+        destination_queue=read_queue,
+        signal_queues=[]
+    )
+    read_thread.start()
 
     os.write(write_descriptor, b"some data")
-    assert_true(reader_thread.is_alive())
-    data = read_queue.get()
-    eq_(data[1], b"some data")
+    assert_true(read_thread.is_alive())
+    identifier, state, data = read_queue.get()
+    eq_(data, b"some data")
 
-    reader_thread.request_exit()
+    read_thread.request_exit()
 
     # Check the blocking part
-    sleep(5)
-    assert_true(reader_thread.is_alive())
+    sleep(.3)
+    assert_true(read_thread.is_alive())
 
-    # Check actual exit
+    # Check actual exit, we will not get
+    # "more data" when exit was requested,
+    # because the thread will not attempt
+    # a write
     os.write(write_descriptor, b"more data")
-    reader_thread.join()
-    data = read_queue.get()
-    eq_(data[1], b"more data")
+    read_thread.join()
+    print(read_queue.queue)
     assert_true(read_queue.empty())
+
+
+def test_blocking_read_exception_catching():
+    read_queue = queue.Queue()
+
+    (read_descriptor, write_descriptor) = os.pipe()
+    read_file = os.fdopen(read_descriptor, "rb")
+    read_thread = ReadThread(
+        identifier="test thread",
+        user_info=read_descriptor,
+        source=read_file,
+        destination_queue=read_queue,
+        signal_queues=[read_queue]
+    )
+    read_thread.start()
+
+    os.write(write_descriptor, b"some data")
+    assert_true(read_thread.is_alive())
+    identifier, state, data = read_queue.get()
+    eq_(data, b"some data")
+    os.close(write_descriptor)
+    read_thread.join()
+    identifier, state, data = read_queue.get()
+    eq_(data, None)
+
+
+def test_blocking_read_closing():
+    # Expect that a reader thread exits when os.read throws an error.
+    class FakeFile:
+        def fileno(self):
+            return -1
+
+        def close(self):
+            pass
+
+    def fake_read(*args):
+        raise ValueError("test exception")
+
+    read_queue = queue.Queue()
+    with patch("datalad.runner.runnerthreads.os.read") as read:
+        read.side_effect = fake_read
+
+        read_thread = ReadThread(
+            identifier="test thread",
+            user_info=None,
+            source=FakeFile(),
+            destination_queue=None,
+            signal_queues=[read_queue])
+
+        read_thread.start()
+        read_thread.join()
+
+    identifier, state, data = read_queue.get()
+    eq_(data, None)
+
+
+def test_blocking_write_exception_catching():
+    # Expect that a blocking writer catches exceptions and exits gracefully.
+
+    write_queue = queue.Queue()
+    signal_queue = queue.Queue()
+
+    (read_descriptor, write_descriptor) = os.pipe()
+    write_file = os.fdopen(write_descriptor, "rb")
+    write_thread = WriteThread(
+        identifier="test thread",
+        user_info=write_descriptor,
+        source_queue=write_queue,
+        destination=write_file,
+        signal_queues=[signal_queue]
+    )
+    write_thread.start()
+
+    write_queue.put(b"some data")
+    data = os.read(read_descriptor, 1024)
+    eq_(data, b"some data")
+
+    os.close(read_descriptor)
+    os.close(write_descriptor)
+
+    write_queue.put(b"more data")
+    write_thread.join()
+    eq_(signal_queue.get(), (write_descriptor, IOState.ok, None))
+
+
+def test_blocking_writer_closing():
+    # Expect that a blocking writer closes its file when `None` is sent to it.
+    write_queue = queue.Queue()
+    signal_queue = queue.Queue()
+
+    (read_descriptor, write_descriptor) = os.pipe()
+    write_file = os.fdopen(write_descriptor, "rb")
+    write_thread = WriteThread(
+        identifier="test thread",
+        user_info=write_descriptor,
+        source_queue=write_queue,
+        destination=write_file,
+        signal_queues=[signal_queue]
+    )
+    write_thread.start()
+
+    write_queue.put(b"some data")
+    data = os.read(read_descriptor, 1024)
+    eq_(data, b"some data")
+
+    write_queue.put(None)
+    write_thread.join()
+    eq_(signal_queue.get(), (write_descriptor, IOState.ok, None))
+
+
+def test_blocking_writer_closing_timeout_signal():
+    # Expect that writer or reader do not block forever on a full signal queue
+
+    write_queue = queue.Queue()
+    signal_queue = queue.Queue(1)
+    signal_queue.put("This is data")
+
+    (read_descriptor, write_descriptor) = os.pipe()
+    write_file = os.fdopen(write_descriptor, "rb")
+    write_thread = WriteThread(
+        identifier="test thread",
+        user_info=write_descriptor,
+        source_queue=write_queue,
+        destination=write_file,
+        signal_queues=[signal_queue]
+    )
+    write_thread.start()
+
+    write_queue.put(b"some data")
+    data = os.read(read_descriptor, 1024)
+    eq_(data, b"some data")
+
+    write_queue.put(None)
+    write_thread.join()
+    eq_(signal_queue.get(), "This is data")
+
+
+def test_blocking_writer_closing_no_signal():
+    # Expect that writer or reader do not block forever on a full signal queue
+
+    write_queue = queue.Queue()
+    signal_queue = queue.Queue(1)
+    signal_queue.put("This is data")
+
+    (read_descriptor, write_descriptor) = os.pipe()
+    write_file = os.fdopen(write_descriptor, "rb")
+    write_thread = WriteThread(
+        identifier="test thread",
+        user_info=write_descriptor,
+        source_queue=write_queue,
+        destination=write_file,
+        signal_queues=[signal_queue]
+    )
+    write_thread.start()
+
+    write_queue.put(b"some data")
+    data = os.read(read_descriptor, 1024)
+    eq_(data, b"some data")
+
+    write_queue.put(None)
+    write_thread.join()
 
 
 def test_inside_async():
@@ -184,3 +399,166 @@ def test_popen_invocation(src_path, dest_path):
     fetching_data.start()
     fetching_data.join(5.0)
     assert_false(fetching_data.is_alive(), "Child is stuck!")
+
+
+def test_timeout():
+    # Expect timeout protocol calls on long running process
+    # if the specified timeout is short enough
+    class TestProtocol(StdOutErrCapture):
+
+        received_timeouts = list()
+
+        def __init__(self):
+            StdOutErrCapture.__init__(self)
+            self.counter = count()
+
+        def timeout(self, fd: Optional[int]):
+            TestProtocol.received_timeouts.append((self.counter.__next__(), fd))
+
+    run_command(
+        ['timeout', '1'] if on_windows else ["sleep", "1"],
+        stdin=None,
+        protocol=TestProtocol,
+        timeout=.1
+    )
+    assert_true(len(TestProtocol.received_timeouts) > 0)
+    assert_true(all(map(lambda e: e[1] in (1, 2, None), TestProtocol.received_timeouts)))
+
+
+def test_timeout_nothing():
+    # Expect timeout protocol calls for the process on long running processes,
+    # if the specified timeout is short enough.
+    class TestProtocol(NoCapture):
+        def __init__(self,
+                     timeout_queue: List):
+            NoCapture.__init__(self)
+            self.timeout_queue = timeout_queue
+            self.counter = count()
+
+        def timeout(self, fd: Optional[int]) -> bool:
+            self.timeout_queue.append(fd)
+            return False
+
+    stdin_queue = queue.Queue()
+    for i in range(12):
+        stdin_queue.put(b"\x00" * 1024)
+    stdin_queue.put(None)
+
+    timeout_queue = []
+    run_command(
+        py2cmd("import time; time.sleep(.4)\n"),
+        stdin=stdin_queue,
+        protocol=TestProtocol,
+        timeout=.1,
+        protocol_kwargs=dict(timeout_queue=timeout_queue)
+    )
+    # Ensure that we have only process timeouts and at least one
+    assert_true(all(map(lambda e: e is None, timeout_queue)))
+    assert_true(len(timeout_queue) > 0)
+
+
+def test_timeout_stdout_stderr():
+    # Expect timeouts on stdin, stdout, stderr, and the process
+    class TestProtocol(StdOutErrCapture):
+        def __init__(self,
+                     timeout_queue: List):
+            StdOutErrCapture.__init__(self)
+            self.timeout_queue = timeout_queue
+            self.counter = count()
+
+        def timeout(self, fd: Optional[int]) -> bool:
+            self.timeout_queue.append((self.counter.__next__(), fd))
+            return False
+
+    stdin_queue = queue.Queue()
+    for i in range(12):
+        stdin_queue.put(b"\x00" * 1024)
+    stdin_queue.put(None)
+
+    timeout_queue = []
+    run_command(
+        py2cmd("import time;time.sleep(.5)\n"),
+        stdin=stdin_queue,
+        protocol=TestProtocol,
+        timeout=.1,
+        protocol_kwargs=dict(timeout_queue=timeout_queue)
+    )
+
+    # Expect at least one timeout for stdout and stderr.
+    # there might be more.
+    sources = (1, 2)
+    assert_true(len(timeout_queue) >= len(sources))
+    for source in sources:
+        assert_true(any(filter(lambda t: t[1] == source, timeout_queue)))
+
+
+def test_timeout_process():
+    # Expect timeouts on stdin, stdout, stderr, and the process
+    class TestProtocol(StdOutErrCapture):
+        def __init__(self,
+                     timeout_queue: List):
+            StdOutErrCapture.__init__(self)
+            self.timeout_queue = timeout_queue
+            self.counter = count()
+
+        def timeout(self, fd: Optional[int]) -> bool:
+            self.timeout_queue.append((self.counter.__next__(), fd))
+            return False
+
+    stdin_queue = queue.Queue()
+    for i in range(12):
+        stdin_queue.put(b"\x00" * 1024)
+    stdin_queue.put(None)
+
+    timeout_queue = []
+    run_command(
+        py2cmd("import time;time.sleep(.5)\n"),
+        stdin=stdin_queue,
+        protocol=TestProtocol,
+        timeout=.1,
+        protocol_kwargs=dict(timeout_queue=timeout_queue)
+    )
+
+    # Expect at least one timeout for stdout and stderr.
+    # there might be more.
+    sources = (1, 2)
+    assert_true(len(timeout_queue) >= len(sources))
+    for source in sources:
+        assert_true(any(filter(lambda t: t[1] == source, timeout_queue)))
+
+
+def test_exit_3():
+    # Expect the process to be closed after
+    # the generator exits.
+    rt = ThreadedRunner(cmd=["sleep", "4"],
+                        stdin=None,
+                        protocol_class=GenStdoutStderr,
+                        timeout=.5,
+                        exception_on_error=False)
+    tuple(rt.run())
+    assert_true(rt.process.poll() is not None)
+
+
+def test_exit_4():
+    rt = ThreadedRunner(cmd=["sleep", "4"],
+                        stdin=None,
+                        protocol_class=GenNothing,
+                        timeout=.5)
+    tuple(rt.run())
+    assert_true(rt.process.poll() is not None)
+
+
+def test_generator_throw():
+    rt = ThreadedRunner(cmd=["sleep", "4"],
+                        stdin=None,
+                        protocol_class=GenNothing,
+                        timeout=.5)
+    gen = rt.run()
+    assert_raises(ValueError, gen.throw, ValueError, ValueError("abcdefg"))
+
+
+def test_exiting_process():
+    result = run_command(py2cmd("import time\ntime.sleep(3)\nprint('exit')"),
+                         protocol=NoCapture,
+                         stdin=None)
+    eq_(result["code"], 0)

--- a/datalad/runner/tests/test_utils.py
+++ b/datalad/runner/tests/test_utils.py
@@ -27,6 +27,16 @@ def test_line_splitter_basic():
     assert_is_none(line_splitter.finish_processing())
 
 
+def test_line_splitter_unterminated():
+    # Expect two lines split at "x", after the second process-call
+    line_splitter = LineSplitter("x")
+    lines = line_splitter.process("first line")
+    assert_equal(lines, [])
+    lines = line_splitter.process("xsecond linex")
+    assert_equal(lines, ["first line", "second line"])
+    assert_is_none(line_splitter.finish_processing())
+
+
 def test_line_splitter_separator():
     line_splitter = LineSplitter("X")
     lines = line_splitter.process(

--- a/datalad/runner/tests/test_utils.py
+++ b/datalad/runner/tests/test_utils.py
@@ -1,0 +1,86 @@
+from datalad.tests.utils import (
+    assert_equal,
+    assert_is_none,
+)
+
+from ..utils import LineSplitter
+
+
+def test_line_splitter_basic():
+    line_splitter = LineSplitter()
+    lines = line_splitter.process(
+        "first line\n"
+        "second line\r\n"
+        "third line\n"
+        "\n"
+    )
+
+    assert_equal(
+        lines,
+        [
+            "first line",
+            "second line",
+            "third line",
+            ""
+        ])
+
+    assert_is_none(line_splitter.finish_processing())
+
+
+def test_line_splitter_separator():
+    line_splitter = LineSplitter("X")
+    lines = line_splitter.process(
+        "first line\nX"
+        "second line\r\nX"
+        "third line\nX"
+        "\nX"
+    )
+
+    assert_equal(lines, [
+        "first line\n",
+        "second line\r\n",
+        "third line\n",
+        "\n"
+    ])
+
+    assert_is_none(line_splitter.finish_processing())
+
+
+def test_line_splitter_continue():
+    line_splitter = LineSplitter()
+    lines = line_splitter.process(
+        "first line\n"
+        "second line\r\n"
+        "third line\n"
+        "fourth "
+    )
+
+    assert_equal(lines, [
+        "first line",
+        "second line",
+        "third line"
+    ])
+
+    assert_equal(line_splitter.remaining_data, "fourth ")
+
+    lines = line_splitter.process("line\n")
+    assert_equal(lines, ["fourth line"])
+    assert_is_none(line_splitter.finish_processing())
+
+
+def test_line_splitter_corner_cases():
+    line_splitter = LineSplitter()
+    lines = line_splitter.process("")
+    assert_equal(lines, [])
+    assert_equal(line_splitter.remaining_data, None)
+
+    line_splitter = LineSplitter()
+    lines = line_splitter.process("")
+    assert_equal(lines, [])
+    lines = line_splitter.process("\n")
+    assert_equal(lines, [""])
+    assert_equal(line_splitter.remaining_data, None)
+
+    line_splitter = LineSplitter()
+    lines = line_splitter.process("  a   \f \r\n")
+    assert_equal(lines, ["  a   ", " "])

--- a/datalad/runner/tests/utils.py
+++ b/datalad/runner/tests/utils.py
@@ -1,0 +1,11 @@
+import sys
+
+
+def py2cmd(code: str,
+           *additional_arguments):
+    """Helper to invoke some Python code through a cmdline invocation of
+    the Python interpreter.
+
+    This should be more portable in some cases.
+    """
+    return [sys.executable, '-c', code] + list(additional_arguments)

--- a/datalad/runner/utils.py
+++ b/datalad/runner/utils.py
@@ -11,6 +11,10 @@
 All runner-related code imports from here, so this is a comprehensive declaration
 of utility dependencies.
 """
+from typing import (
+    List,
+    Optional,
+)
 
 from datalad.dochelpers import borrowdoc
 from datalad.utils import (
@@ -21,3 +25,75 @@ from datalad.utils import (
     try_multiple,
     unlink,
 )
+
+
+
+class LineSplitter:
+    """
+    An line splitter that handles 'streamed content' and is based
+    on python's built-in splitlines().
+    """
+    def __init__(self, separator: Optional[str] = None):
+        """
+        Create a line splitter that will split lines either on a
+        given separator, if 'separator' is not None, or on one of
+        the known line endings, if 'separator' is None. The
+        currently known line endings are "\n", and "\r\n".
+        """
+        self.separator = separator
+        self.remaining_data = None
+
+    def process(self, data: str) -> List[str]:
+
+        assert isinstance(data, str), f"data ({data}) is not of type str"
+
+        # There is nothing to do if we do not get any data, since
+        # remaining data would not change, and if it is not None,
+        # it has already been parsed.
+        if data == "":
+            return []
+
+        # Update remaining data before attempting to split lines.
+        if self.remaining_data is None:
+            self.remaining_data = ""
+        self.remaining_data += data
+
+        if self.separator is None:
+            # If no separator was specified, use python's built in
+            # line split wisdom to split on any known line ending.
+            lines_with_ends = self.remaining_data.splitlines(keepends=True)
+            detected_lines = self.remaining_data.splitlines()
+
+            # If the last line is identical in lines with ends and
+            # lines without ends, it was unterminated, remove it
+            # from the list of detected lines and keep it for the
+            # next round
+            if lines_with_ends[-1] == detected_lines[-1]:
+                self.remaining_data = detected_lines[-1]
+                del detected_lines[-1]
+            else:
+                self.remaining_data = None
+
+        else:
+            # Split lines on separator. This will create additional
+            # empty lines if `remaining_data` end with the separator.
+            detected_lines = self.remaining_data.split(self.separator)
+
+            # If replaced data did not end with the separator, it contains an
+            # unterminated line. We save that for the next round. Otherwise
+            # we mark that we do not have remaining data.
+            if not data.endswith(self.separator):
+                self.remaining_data = detected_lines[-1]
+            else:
+                self.remaining_data = None
+
+            # If replaced data ended with the canonical line ending, we
+            # have an extra empty line in detected_lines. If it did not
+            # end with canonical line ending, we have to remove the
+            # unterminated line.
+            del detected_lines[-1]
+
+        return detected_lines
+
+    def finish_processing(self) -> Optional[str]:
+        return self.remaining_data

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -18,8 +18,8 @@ import logging
 import os
 import re
 import warnings
-
 from itertools import chain
+from multiprocessing import cpu_count
 from os import linesep
 from os.path import (
     curdir,
@@ -27,19 +27,32 @@ from os.path import (
     exists,
     lexists,
     isdir,
-    normpath
+    normpath,
 )
-from multiprocessing import cpu_count
 from weakref import (
     finalize,
-    WeakValueDictionary
+    WeakValueDictionary,
 )
 
+from datalad.cmd import (
+    BatchedCommand,
+    GitWitlessRunner,
+    # KillOutput,
+    SafeDelCloseMixin,
+    StdOutCapture,
+    StdOutErrCapture,
+    WitlessProtocol,
+)
 from datalad.consts import WEB_SPECIAL_REMOTE_UUID
 from datalad.dochelpers import (
     borrowdoc,
-    borrowkwargs
+    borrowkwargs,
 )
+from datalad.log import log_progress
+from datalad.runner.protocol import GeneratorMixIn
+from datalad.runner.utils import LineSplitter
+# must not be loads, because this one would log, and we need to log ourselves
+from datalad.support.json_py import json_loads
 from datalad.ui import ui
 import datalad.utils as ut
 from datalad.utils import (
@@ -50,18 +63,6 @@ from datalad.utils import (
     PurePosixPath,
     split_cmdline,
     unlink,
-)
-from datalad.log import log_progress
-# must not be loads, because this one would log, and we need to log ourselves
-from datalad.support.json_py import json_loads
-from datalad.cmd import (
-    BatchedCommand,
-    GitWitlessRunner,
-    # KillOutput,
-    SafeDelCloseMixin,
-    StdOutCapture,
-    StdOutErrCapture,
-    WitlessProtocol,
 )
 
 # imports from same module:
@@ -935,12 +936,20 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         try:
             if files:
-                return runner.run_on_filelist_chunks(
-                    cmd,
-                    files,
-                    protocol=protocol,
-                    env=env,
-                    **kwargs)
+                if issubclass(protocol, GeneratorMixIn):
+                    return runner.run_on_filelist_chunks_items_(
+                        cmd,
+                        files,
+                        protocol=protocol,
+                        env=env,
+                        **kwargs)
+                else:
+                    return runner.run_on_filelist_chunks(
+                        cmd,
+                        files,
+                        protocol=protocol,
+                        env=env,
+                        **kwargs)
             else:
                 return runner.run(
                     cmd,
@@ -1215,11 +1224,29 @@ class AnnexRepo(GitRepo, RepoInterface):
         ------
         See `_call_annex()` for information on Exceptions.
         """
-        out = self._call_annex(
-            args,
-            files=files,
-            protocol=StdOutErrCapture)['stdout']
-        yield from (out.split(sep) if sep else out.splitlines())
+        class GeneratorStdOutErrCapture(GeneratorMixIn, StdOutErrCapture):
+            def __init__(self):
+                GeneratorMixIn.__init__(self)
+                StdOutErrCapture.__init__(self)
+
+            def pipe_data_received(self, fd, data):
+                if fd == 1:
+                    self.send_result(("stdout", data.decode(self.encoding)))
+                    return
+                super().pipe_data_received(fd, data)
+
+        line_splitter = LineSplitter(separator=sep)
+        for source, content in self._call_annex(
+                                args,
+                                files=files,
+                                protocol=GeneratorStdOutErrCapture):
+
+            if source == "stdout":
+                yield from line_splitter.process(content)
+
+        remaining_content = line_splitter.finish_processing()
+        if remaining_content is not None:
+            yield remaining_content + os.linesep
 
     def call_annex_oneline(self, args, files=None):
         """Call annex for a single line of output.
@@ -3519,6 +3546,9 @@ class AnnexJsonProtocol(WitlessProtocol):
         self.total_nbytes = total_nbytes
         self._unprocessed = None
 
+    def add_to_output(self, json_object):
+        self.json_out.append(json_object)
+
     def connection_made(self, transport):
         super().connection_made(transport)
         self._pbars = set()
@@ -3664,7 +3694,7 @@ class AnnexJsonProtocol(WitlessProtocol):
         # TODO the protocol could be made aware of the runner's CWD and
         # also any dataset the annex command is operating on. This would
         # enable 'file' property conversion to absolute paths
-        self.json_out.append(j)
+        self.add_to_output(j)
 
         if self.total_nbytes:
             if self.total_nbytes <= self._byte_count:
@@ -3710,6 +3740,17 @@ class AnnexJsonProtocol(WitlessProtocol):
                 len(self._unprocessed), self._unprocessed
             )
         super().process_exited()
+
+
+class GeneratorAnnexJsonProtocol(GeneratorMixIn, AnnexJsonProtocol):
+    def __init__(self,
+                 done_future=None,
+                 total_nbytes=None):
+        GeneratorMixIn.__init__(self)
+        AnnexJsonProtocol.__init__(self, done_future, total_nbytes)
+
+    def add_to_output(self, json_object):
+        self.send_result(json_object)
 
 
 class AnnexInitOutput(WitlessProtocol):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -29,6 +29,7 @@ from os.path import (
     pardir,
     exists,
 )
+from queue import Queue
 from shutil import copyfile
 
 from urllib.parse import urljoin
@@ -131,6 +132,7 @@ from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import (
     AnnexRepo,
     AnnexJsonProtocol,
+    GeneratorAnnexJsonProtocol,
 )
 
 
@@ -2570,3 +2572,28 @@ def test_done_deprecation():
     with unittest.mock.patch("datalad.cmd.warnings.warn") as warn_mock:
         _ = AnnexJsonProtocol()
         warn_mock.assert_not_called()
+
+
+def test_generator_annex_json_protocol():
+
+    runner = Runner()
+    stdin_queue = Queue()
+
+    def json_object(count: int):
+        json_template = '{{"id": "some-id", "count": {count}}}'
+        return json_template.format(count=count).encode()
+
+    count = 123
+    stdin_queue.put(json_object(count=count))
+    for result in runner.run(cmd="cat", protocol=GeneratorAnnexJsonProtocol, stdin=stdin_queue):
+        assert_equal(
+            result,
+            {
+                "id": "some-id",
+                "count": count,
+            }
+        )
+        if count == 133:
+            break
+        count += 1
+        stdin_queue.put(json_object(count=count))

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -10,12 +10,20 @@
 """
 import sys
 import unittest.mock
-
-from datalad.tests.utils import assert_equal
+from subprocess import TimeoutExpired
 
 from datalad.cmd import (
     readline_rstripped,
     BatchedCommand,
+)
+from datalad.runner.tests.utils import py2cmd
+from datalad.tests.utils import (
+    assert_equal,
+    assert_is_none,
+    assert_is_not_none,
+    assert_not_equal,
+    assert_raises,
+    assert_true,
 )
 
 
@@ -35,4 +43,145 @@ def test_batched_command():
     response = bc("print(2 + 1)")
     assert_equal(response, "3")
     stderr = bc.close(return_stderr=True)
-    assert_equal(stderr.strip(), ">>> >>> >>>")
+    assert_is_not_none(stderr)
+
+
+def test_batched_close_abandon():
+    # Expect a timeout if the process runs longer than timeout and the config
+    # for "datalad.runtime.stalled-external" is "abandon".
+    bc = BatchedCommand(
+        cmd=[sys.executable, "-i", "-u", "-q", "-"],
+        timeout=.1)
+    # Send at least one instruction to start the subprocess
+    response = bc("import time; print('a')")
+    assert_equal(response, "a")
+    bc.stdin_queue.put("time.sleep(2); exit(1)\n".encode())
+    with unittest.mock.patch("datalad.cfg") as cfg_mock:
+        cfg_mock.configure_mock(**{"obtain.return_value": "abandon"})
+        bc.close(return_stderr=False)
+        assert_true(bc.wait_timed_out is True)
+        assert_is_none(bc.return_code)
+
+
+def test_batched_close_timeout_exception():
+    # Expect a timeout if the process runs longer than timeout and the config
+    # for "datalad.runtime.stalled-external" is "abandon".
+    bc = BatchedCommand(
+        cmd=[sys.executable, "-i", "-u", "-q", "-"],
+        timeout=.5,
+        exception_on_timeout=True)
+
+    # Send at least one instruction to start the subprocess
+    response = bc("import time; print('a')")
+    assert_equal(response, "a")
+    bc.stdin_queue.put("time.sleep(2); exit(1)\n".encode())
+    with unittest.mock.patch("datalad.cfg") as cfg_mock:
+        cfg_mock.configure_mock(**{"obtain.return_value": "abandon"})
+        assert_raises(TimeoutExpired, bc.close)
+
+
+def test_batched_close_wait():
+    # Expect a long wait and no timeout if the process runs longer than timeout
+    # and the config for "datalad.runtime.stalled-external" has its default
+    # value.
+    bc = BatchedCommand(
+        cmd=[sys.executable, "-i", "-u", "-q", "-"],
+        timeout=.5)
+    # Send at least one instruction to start the subprocess
+    response = bc("import time; print('a')")
+    assert_equal(response, "a")
+    bc.stdin_queue.put("time.sleep(2); exit(2)\n".encode())
+    bc.close(return_stderr=False)
+    assert_true(bc.wait_timed_out is False)
+    assert_equal(bc.return_code, 2)
+
+
+def test_batched_close_ok():
+    # Expect a long wait and no timeout if the process runs longer than timeout
+    # seconds and the config for "datalad.runtime.stalled-external" has its
+    # default value.
+    bc = BatchedCommand(
+        cmd=[sys.executable, "-i", "-u", "-q", "-"],
+        timeout=2)
+    # Send at least one instruction to start the subprocess
+    response = bc("import time; print('a')")
+    assert_equal(response, "a")
+    bc.stdin_queue.put("time.sleep(.5); exit(3)\n".encode())
+    bc.close(return_stderr=False)
+    assert_true(bc.wait_timed_out is False)
+    assert_equal(bc.return_code, 3)
+
+
+def test_tuple_requests():
+    bc = BatchedCommand(
+        cmd=py2cmd(
+            """
+import time
+import sys
+print(f"{time.time()}:{sys.stdin.readline().strip()}")
+            """))
+
+    start_time_1, line = bc(("one", "line")).split(":")
+    assert_equal(line, "one line")
+    start_time_2, line = bc(("end", "now")).split(":")
+    assert_not_equal(start_time_1, start_time_2)
+    assert_equal(line, "end now")
+    bc.close(return_stderr=False)
+
+
+def test_batched_restart():
+    # Expect that the process is restarted after exit.
+    bc = BatchedCommand(
+        cmd=py2cmd(
+            "import os\n"
+            "import sys\n"
+            "print(os.getpid(), sys.stdin.readline().strip())\n"))
+
+    # Send four lines
+    lines = [f"line-{i}" for i in range(4)]
+    responses = [bc(lines[i]).split() for i in range(4)]
+    pid_set = set([int(r[0]) for r in responses])
+    assert_equal(len(pid_set), 4)
+    response_lines = [r[1] for r in responses]
+    assert_equal(lines, response_lines)
+    bc.close(return_stderr=False)
+
+
+def test_command_fail_1():
+    # Expect that the return code of a failing command is caught,
+    # that None is returned as result.
+    bc = BatchedCommand(
+        cmd=py2cmd(
+            """
+print("something")
+exit(3)
+            """))
+
+    # Send something to start the process
+    result = bc("line one")
+    assert_equal(bc.return_code, None)
+    assert_equal(result, "something")
+    result = bc("line two")
+    assert_equal(bc.return_code, 3)
+    assert_equal(result, None)
+    bc.close(return_stderr=False)
+
+
+def test_command_fail_2():
+    # Expect that the return code of a failing command is caught,
+    # that None is returned as result and that the process is restarted,
+    # if the batched command is called again.
+    bc = BatchedCommand(
+        cmd=py2cmd(
+            """
+print(a*b)
+            """))
+
+    # Send something to start the process
+    result = bc("line one")
+    assert_not_equal(bc.return_code, 0)
+    assert_is_none(result)
+    result = bc("line two")
+    assert_not_equal(bc.return_code, 0)
+    assert_is_none(result)
+    bc.close(return_stderr=False)

--- a/docs/source/design/batched_command.rst
+++ b/docs/source/design/batched_command.rst
@@ -9,37 +9,36 @@ BatchedCommand and BatchedAnnex
 
 .. topic:: Specification scope and status
 
-   This specification describes the implementation of ``BatchedCommand`` and
-   ``BatchedAnnex`` in ``datalad`` version <= 0.15.x of datalad.
+   This specification describes the new implementation of ``BatchedCommand`` and
+   ``BatchedAnnex`` in ``datalad``.
 
 
 Batched Command
 ===============
 
-The class ``BatchedCommand`` (in ``datalad.cmd``), holds an instance of a running subprocess, allows to send commands to the subprocess over its stdin, and to receive subprocess responses over its stdout.
+The class ``BatchedCommand`` (in ``datalad.cmd``), holds an instance of a running subprocess, allows to send requests to the subprocess over its stdin, and to receive responses from the subprocess over its stdout.
 
-Commands can be provided to an instance of ``BatchedCommand`` by passing a single command or a list of commands to ``BatchCommand.__call__()``, i.e. apply the function call-operator to an instance of ``BatchedCommand``. A command is either a string or a tuple of strings. In the latter case, the elements of the tuple will be joined by ``" "``. More than one command can be given by providing a list of commands, i.e. a list of strings or tuples.
+Requests can be provided to an instance of ``BatchedCommand`` by passing a single request or a list of requests to ``BatchCommand.__call__()``, i.e. by applying the function call-operator to an instance of ``BatchedCommand``. A request is either a string or a tuple of strings. In the latter case, the elements of the tuple will be joined by ``" "``. More than one request can be given by providing a list of requests, i.e. a list of strings or tuples. In this case, the return value will be a list with one response for every request.
 
-``BatchedCommand`` will send each command sent to the subprocess in a single line, terminated by ``"\n"``. After the command is sent, ``BatchedCommand`` calls an output-handler with stdout of the subprocess as argument. The output handler can be provided to the constructor. If no output handler is provided, a default output-handler is used. The default output-handler reads a single output line on stdout, using ``io.IOBase.readline()``, and returns the ``rstrip()``-ed line.
+``BatchedCommand`` will send each request that is sent to the subprocess as a single line, after terminating the line by ``"\n"``. After the request is sent, ``BatchedCommand`` calls an output-handler with stdout-ish (an object that provides a ``readline()``-function which operates on the stdout of the subprocess) of the subprocess as argument. The output-handler can be provided to the constructor. If no output-handler is provided, a default output-handler is used. The default output-handler reads a single output line on stdout, using ``io.IOBase.readline()``, and returns the ``rstrip()``-ed line.
 
-The subprocess must at least emit one line of output per line of input in order to prevent the calling thread from blocking. In addition, the size of the output, i.e. the number of lines that the result consists of, must be discernible by the processor. The subprocess must either return a fixed number of lines per input line, or it must indicate the end of a result in some other way, e.g. with an empty line.
+The subprocess must at least emit one line of output per line of input in order to prevent the calling thread from blocking. In addition, the size of the output, i.e. the number of lines that the result consists of, must be discernible by the output-handler. That means, the subprocess must either return a fixed number of lines per input line, or it must indicate the end of a result in some other way, e.g. with an empty line.
 
-Remark: In principle any output processing could be performed. But, if the output processor blocks on stdout, the calling thread will be blocked. In reality the fixed arguments that ``BatchedCommand`` provides to the Popen-constructor, i.e. ``bufsize=1`` and ``universal_newlines=True``, lead to line-based text processing in the output-handler. With the line-based command provision in addition, ``BatchedCommand`` is geared towards supporting the batch processing modes of ``git`` and ``git-annex``. *This has to be taken into account when providing a custom output handler.*
+Remark: In principle any output processing could be performed. But, if the output-handler blocks on stdout, the calling thread will be blocked. Due to the limited capabilities of the stdout-ish that is passed to the output-handler, the output-handler must rely on ``readline()`` to process the output of the subprocess. Together with the line-based request sending, ``BatchedCommand`` is geared towards supporting the batch processing modes of ``git`` and ``git-annex``. *This has to be taken into account when providing a custom output handler.*
 
-Remark 2: Although the default output handler, i.e. ``datalad.cmd.readline_stripped``, is deprecated, it is used by ``BatchedCommand``. It is not clear which alternative should be provided. Although, there is documentation (besides the source and this document) that mentions that stdout is line-buffered, and in text mode. This configuration would make it difficult (impossible) to use BatchedCommand to communicate with a subprocess that does not output line-breaks.
+When ``BatchedCommand.close()`` is called, stdin, stdout, and stderr of the subprocess are closed. This indicates the end of processing to the subprocess. Generally the subprocess is expected to exit shortly after that. ``BatchedCommand.close()`` will wait for the subprocess to end, if the configuration ``datalad.runtime.stalled-external`` is set to ``"wait"``. If the configuration ``datalad.runtime.stalled-external`` is set to ``"abandon"``, ``BatchedCommand.close()`` will return after "timeout" seconds if ``timeout`` was provided to ``BatchedCommand.__init__()``, otherwise it will return after 11 seconds. If a timeout occurred, the attribute ``wait_timed_out`` of the ``BatchedCommand`` instance will be set to ``True``. If ``exception_on_timeout=True`` is provided to ``BatchedCommand.__init__()``, a ``subprocess.TimeoutExpired`` exception will be raised on a timeout while waiting for the process. It is not safe to reused a ``BatchedCommand`` instance after such an exception was risen.
 
-When ``BatchedCommand.close()`` is called, stdin of the subprocess is closed. This indicates the end of processing to the subprocess. Generally the subprocess is expected to exit shortly after that. Stderr of the subprocess is redirected to a temporary file which is read when ``BatchedCommand.close()`` is called. Its content will be returnd by ``BatchCommand.close()`` if the parameter ``return_stderr`` is ``True``.
+Stderr of the subprocess is gathered in a byte-string. Its content will be returned by ``BatchCommand.close()`` if the parameter ``return_stderr`` is ``True``.
+
 
 Implementation details
 ......................
 
-``BatchedCommand`` uses ``subprocess.Popen`` directly. It constructs a ``Popen``-object with ``universal_newlines=True``, forcing stdin and stdout of the subprocess to text mode. It uses ``bufsize=1`` to enable line-buffering, allowing the output handler to use ``readline()`` and the stdout of the subprocess to fetch a single response line.
+``BatchedCommand`` uses ``WitlessRunner`` with a protocol that has ``datalad.runner.protocol.GeneratorMixIn`` as a super-class. The protocol uses an output-handler to process data, if an output-handler was specified during construction of ``BatchedCommand``.
 
-``BatchedCommand`` has a restart capability. If the subprocess exited, another process with the identical command line is started. (No state is transferred from the old process though)
+``BatchedCommand.close()`` queries the configuration key ``datalad.runtime.stalled-external`` to determine how to handle non-exiting processes (there is no killing, processes or process zombies might just linger around until the next reboot).
 
-``BatchedCommand.close()`` queries the configuration to determine how to handle non-exiting processes (there is no killing, processes or process zombies might just linger around until the next reboot).
-
-``BatchedCommand`` can process a list of multiple commands at once, but it will collect all answers before returning a result. That means, if you send 1000 commands, ``BatchedCommand`` will return after having received 1000 responses.
+The current implementation of ``BatchedCommand`` can process a list of multiple requests at once, but it will collect all answers before returning a result. That means, if you send 1000 requests, ``BatchedCommand`` will return after having received 1000 responses.
 
 
 BatchedAnnex

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -23,5 +23,6 @@ subsystems in DataLad.
    exception_handling
    credentials
    url_substitution
+   threaded_runner
    batched_command
    standard_parameters

--- a/docs/source/design/threaded_runner.rst
+++ b/docs/source/design/threaded_runner.rst
@@ -1,0 +1,87 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_threaded_runner:
+
+
+****************
+Threaded runner
+****************
+
+.. topic:: Specification scope and status
+
+   This specification provides an overview over the current implementation of the subprocess runner that is used throughout datalad.
+
+Threads
+=======
+
+Datalad often requires the execution of subprocesses. While subprocesses are executed, datalad, i.e. its main thread, should be able to read data from stdout and stderr of the subprocess as well as write data to stdin of the subprocess. This requires a way to efficiently multiplex reading from stdout and stderr of the subprocess as well as writing to stdin of the subprocess.
+
+Since non-blocking IO and waiting on multiple sources (poll or select) differs vastly in terms of capabilities and API on different OSs, we decided to use blocking IO and threads to multiplex reading from different sources.
+
+Generally we have a number of threads that might be created and executed, depending on the need for writing to stdin or reading from stdout or stderr. Each thread can read from either a single queue or a file descriptor. Reading is done blocking. Each thread can put data into multiple queues. This is used to transport data that was read as well as for signaling conditions like closed file descriptors.
+
+Conceptually, there are the main thread and two different types of threads:
+
+ - type 1: transport threads (1 thread per process I/O descriptor)
+ - type 2: process waiting thread (1 thread)
+
+Transport Threads
+.................
+
+Besides the main thread, there might be up to three additional threads to handle data transfer to ``stdin``, and from ``stdout`` and ``stderr``. Each of those threads copies data between queues and file descriptors in a tight loop. The stdin-thread reads from an input-queue, the stdout- and stderr-threads write to an output queue. Each thread signals its exit to a set of signal queues, which might be identical to the output queues.
+
+The ``stdin``-thread reads data from a queue and writes it to the ``stdin``-file descriptor of the sub-process. If it reads ``None`` from the queue, it will exit. The thread will also exit, if an exit is requested by calling ``thread.request_exit()``, or if an error occurs during writing. In all cases it will enqueue a ``None`` to all its signal-queues.
+
+The ``stdout``- and ``stderr``-threads read from the respective file descriptor and enqueue data into their output queue, unless the data has zero length (which indicates a closed descriptor). On a zero-length read they exit and enqueue ``None`` into their signal queues.
+
+All queues are infinite. Nevertheless signaling is performed with a timeout of one 100 milli seconds in order to ensure that threads can exit.
+
+
+Process Waiting Thread
+......................
+
+The process waiting thread waits for a given process to exit and enqueues an exit notification into it signal queues.
+
+
+
+Main Thread
+...........
+
+There is a single queue, the ``output_queue``, on which the main thread waits, after all transport threads, and the process waiting thread are started. The ``output_queue`` is the signaling queue and the output queue of the stderr-thread and the stdout-thread. It is also the signaling queue of the stdin-thread, and it is the signaling queue for the process waiting threads.
+
+The main thread waits on the ``output_queue`` for data or signals and handles them accordingly, i.e. calls data callbacks of the protocol if data arrives, and calls connection-related callbacks of the protocol if other signals arrive. If no messages arrive on the  ``output_queue``, the main thread blocks for 100ms. If it is unblocked, either by getting a message or due to elapsing of the 100ms, it will process timeouts. If the ``timeout``-parameter to the constructor was not ``None``, it will check the last time any of the monitored files (stdout and/or stderr) yielded data. If the time is larger than the specified timeout, it will call the ``tiemout`` method of the protocol instance. Due to this implementation, the resolution for timeouts is 100ms. The main thread handles the closing of ``stdin``-, ``stdout``-, and ``stderr``-file descriptors if all other threads have terminated and if ``output_queue`` is empty. These tasks are either performed in the method ``ThreadedRunner.run()`` or in a result generator that is returned by  ``ThreadedRunner.run()`` whenever ``send()`` is called on it.
+
+
+Protocols
+=========
+
+Due to its history the runner implementation uses the interface defined in ``SubprocessProtocol`` (asyncio.protocols.SubprocessProtocol) (although the sub process protocol interface is defined in the asyncio libraries, the current thread-runner implementation does not make use of ``async``).
+
+    - ``SubprocessProtocol.pipe_data_received(fd, data)``
+    - ``SubprocessProtocol.pipe_connection_lost(fd, exc)``
+    - ``SubprocessProtocol.process_exited()``
+
+In addition the methods of ``BaseProtocol`` are called, i.e.:
+
+    - ``BaseProtocol.connection_made(transport)``
+    - ``BaseProtocol.connection_lost(exc)``
+
+
+The datalad-provided protocol ``WitlessProtocol`` provides an additional callback:
+
+    - ``WitlessProtocol.timeout(fd)``
+
+The method ``timeout()`` will be called when the parameter ``timeout`` in ``WitlessRunner.run``, ``ThreadedRunner.run``, or ``run_command`` is set to a number specifying the desired timeout in seconds. If no data is received from ``stdin``, or ``stderr`` (if those are supposed to be captured), the method ``WitlessProtocol.timeout(fd)`` is called with ``fd`` set to the respective file number, e.g. 1, or 2. If ``WitlessProtocol.timeout(fd)`` returns ``True``, the file descriptor will be closed and the associated threads will exit.
+
+The method ``WitlessProtocol.timeout(fd)`` is also called if stdout, stderr and stdin are closed and the process does not exit within the given interval. In this case ``fd`` is set to ``None``. If ``WitlessProtocol.timeout(fd)`` returns ``True`` the process is terminated.
+
+
+Object and Generator Results
+================================
+
+If the protocol that is provided to ``run()`` does not inherit ``datalad.runner.protocol.GeneratorMixIn``, the final result that will be returned to the caller is determined by calling ``WitlessProtocol._prepare_result()``. Whatever object this method returns will be returned to the caller.
+
+If the protocol that is provided to ``run()`` does inherit ``datalad.runner.protocol.GeneratorMixIn``, ``run()`` will return a ``Generator``. This generator will yield the elements that were sent to it in the protocol-implementation by calling ``GeneratorMixIn.send_result()`` in the order in which the method ``GeneratorMixIn.send_result()`` is called. For example, if ``GeneratorMixIn.send_result(43)`` is called, the generator will yield ``43``, and if ``GeneratorMixIn.send_result({"a": 123, "b": "some data"})`` is called, the generator will yield ``{"a": 123, "b": "some data"}``.
+
+Internally the generator is implemented by keeping track of the process state and waiting in the ``output_queue`` once, when ``send`` is called on it.

--- a/docs/source/design/threaded_runner.rst
+++ b/docs/source/design/threaded_runner.rst
@@ -35,7 +35,7 @@ The ``stdin``-thread reads data from a queue and writes it to the ``stdin``-file
 
 The ``stdout``- and ``stderr``-threads read from the respective file descriptor and enqueue data into their output queue, unless the data has zero length (which indicates a closed descriptor). On a zero-length read they exit and enqueue ``None`` into their signal queues.
 
-All queues are infinite. Nevertheless signaling is performed with a timeout of one 100 milli seconds in order to ensure that threads can exit.
+All queues are infinite. Nevertheless signaling is performed with a timeout of one 100 milliseconds in order to ensure that threads can exit.
 
 
 Process Waiting Thread


### PR DESCRIPTION
This PR provides a new threaded runner implementation that supports timeouts and generator-based subprocess-communication, Which means stdout and stderr data are available from a generator. Our standard protocol-approach is also supported with generators, i.e. every data packet from stdout and stderr is passed through an instance of `WitlessProtocol` (or a subclass), by calling `WitlessProtocol.pipe_data_received()`.


This PR:

- [x] Allows using a queue.Queue() as stdin (in addition to previously supported types), for convenient stdin writing.
- [x] Implements generator-style run() semantics if the provided protocol is derived from `GeneratorMixIn`-class.
- [x] Adds timeout capabilities for output file traffic and for process exit
- [x] Adds basic protocol tests
- [x] Adds tests for runner exceptions
- [x] Adds documentation for the threaded runners
- [x] Adds tests for `BatchedCommand`

The PR uses and demonstrates the generator-capabilities in `AnnexRepo` and in `BatchedCommand`, it:

- [x] Adds a GeneratorAnnexJsonProtocol to demonstrate how to send data to the generator.
- [x] Supports a generator-style runner in `AnnexRepo._call_annex_items_()`. To support the new `_call_annex_items_()` the method `AnnexRepo._call_annex()` has been extended to support generator-style runner, i.e. it uses a generator-style `GitRunner.run_on_filelist_chunks_items_()`.
- [x] Implements `BatchedCommand` based on a generator-style runner, which consolidates our codebase and demonstrates the application of the generator-style runner interaction
- [x] Adds documentation for `BatchedCommand`

Although there are quite a number of changes in this PR, the modifications are mainly encapsulated in the runner code and in `BatchedCommand`. Both have a slightly extended, backward compatible API. That means the new implementations are drop-in replacements.

The "application"-code that changed is mostly in four dozen lines in `datalad/support/annexrepo.py`. Due to the structure of the existing code, large parts of `AnnexRepo` are not generator-based, i.e. they expect and return lists or tuples. This required to "unwind" the generator-style results in the functions that return to legacy code. I think this PR lays the groundwork for us to convert our code iteratively to "all the way" generator-based code (where it is appropriate).

> This PR is the cleaned-up, improved, and optimized version of PR #6125 which became convoluted. All reviewer comments on PR #6125 have been considered and their resolution is part of this PR