### PR TITLE
TST: Enable filter.annex.process on windows to speed things up

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -220,6 +220,11 @@ init:
   # Identity setup
   - git config --global user.email "test@appveyor.land"
   - git config --global user.name "Appveyor Almighty"
+  # globally setting filter.annex.process (needs git-annex 8.20211117) to reduce git-add runtime
+  # https://git-annex.branchable.com/bugs/Windows__58___substantial_per-file_cost_for___96__add__96__/
+  - cmd: git config --system filter.annex.process "git-annex filter-process"
+  # might also bring a slight speed-up on Mac, but Ubuntu git-annex is currently too old
+  #- sh: sudo git config --system filter.annex.process "git-annex filter-process"
   # Scratch space
   - cmd: md C:\DLTMP
   # we place the "unix" one into the user's HOME to avoid git-annex issues on MacOSX


### PR DESCRIPTION
See https://git-annex.branchable.com/bugs/Windows__58___substantial_per-file_cost_for___96__add__96__/ and https://github.com/datalad/datalad/issues/5994 for the saga.

Let's see what effect it would have.

Pre:

![image](https://user-images.githubusercontent.com/136479/143424082-1a1b8a99-cab0-4cba-b524-9b54b278c5b2.png)


Post:

![image](https://user-images.githubusercontent.com/136479/143424175-de977f07-affb-4079-94e9-db952f7cd557.png)


Pretty interesting. A substantial improvement (16% overall), but not evenly across jobs (between 5% and 32%)... No idea what is happening here.

The job that saw the massive speed-up is running:

```
local/
test_add_archive_content.py
test_add_readme.py
test_addurls.py
test_check_dates.py
test_clean.py
test_copy_file.py
test_download_url.py
test_export_archive.py
test_no_annex.py
test_remove.py
test_rerun_merges.py
test_rerun.py
test_run_procedure.py
test_subdataset.py
test_unlock.py
test_wtf.py

support/
test_annexrepo.py
test_ansi_colors.py
test_cache.py
test_captured_exception.py
test_cookies.py
test_digests.py
test_due_utils.py
test_external_versions.py
test_fileinfo.py
test_gitrepo.py
test_globbedpaths.py
test_json_py.py
test_locking.py
test_network.py
test_parallel.py
test_path.py
test_repodates.py
test_repo_save.py
test_sshconnector.py
test_sshrun.py
test_stats.py
test_status.py
test_vcr_.py

ui/
test_base.py
test_dialog.py
```