### PR TITLE
Docstring handling upgrade

### DIFF
--- a/datalad/distributed/create_sibling_gin.py
+++ b/datalad/distributed/create_sibling_gin.py
@@ -70,6 +70,8 @@ class CreateSiblingGin(Interface):
     In order to be able to use this command, a personal access token has to be
     generated on the platform (Account->Your Settings->Applications->Generate
     New Token).
+
+    .. versionadded:: 0.16
     """
 
     _examples_ = [

--- a/datalad/distributed/create_sibling_gitea.py
+++ b/datalad/distributed/create_sibling_gitea.py
@@ -93,6 +93,8 @@ class CreateSiblingGitea(Interface):
 
     In order to be able to use this command, a personal access token has to be
     generated on the platform (Account->Settings->Applications->Generate Token).
+
+    .. versionadded:: 0.16
     """
 
     _params_ = _Gitea.create_sibling_params

--- a/datalad/distributed/create_sibling_github.py
+++ b/datalad/distributed/create_sibling_github.py
@@ -128,6 +128,21 @@ class CreateSiblingGithub(Interface):
     In order to be able to use this command, a personal access token has to be
     generated on the platform (Account->Settings->Developer Settings->Personal
     access tokens->Generate new token).
+
+    .. versionchanged:: 0.16
+       || REFLOW >>
+       The API has been aligned with the some
+       ``create_sibling_...||create-sibling-...`` commands of other GitHub-like
+       services, such as GOGS, GIN, GitTea.<< REFLOW ||
+
+    .. deprecated:: 0.16
+       The ``dryrun||--dryrun`` option will be removed in a future release, use
+       the renamed ``dry_run||--dry-run`` option instead.
+       The ``github_login||--github-login`` option will be removed in a future
+       release, use the ``credential||--credential`` option instead.
+       The ``github_organization||--github-organization`` option will be
+       removed in a future release, prefix the reposity name with ``<org>/``
+       instead.
     """
 
     _examples_ = [

--- a/datalad/distributed/create_sibling_github.py
+++ b/datalad/distributed/create_sibling_github.py
@@ -208,8 +208,8 @@ class CreateSiblingGithub(Interface):
         dryrun=Parameter(
             args=("--dryrun",),
             action="store_true",
-            doc="""Deprecated. Use the renamed
-            [CMD: --dry-run CMD][PY: `dry_run` PY] parameter"""),
+            doc="""Deprecated. Use the renamed ``dry_run||--dry-run``
+            parameter"""),
     )
 
     @staticmethod

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -201,7 +201,7 @@ class CreateSiblingGitlab(Interface):
             args=("--dryrun",),
             action="store_true",
             doc="""Deprecated. Use the renamed
-            [CMD: --dry-run CMD][PY: `dry_run` PY] parameter""")
+            ``dry_run||--dry-run`` parameter""")
     )
 
     @staticmethod

--- a/datalad/distributed/create_sibling_gogs.py
+++ b/datalad/distributed/create_sibling_gogs.py
@@ -62,6 +62,8 @@ class CreateSiblingGogs(Interface):
     In order to be able to use this command, a personal access token has to be
     generated on the platform
     (Account->Your Settings->Applications->Generate New Token).
+
+    .. versionadded:: 0.16
     """
 
     _params_ = _GOGS.create_sibling_params

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -150,11 +150,11 @@ class CreateSiblingRia(Interface):
             args=("url",),
             metavar="ria+<ssh|file|http(s)>://<host>[/path]",
             doc="""URL identifying the target RIA store and access protocol. If
-            [CMD: --push-url CMD][PY: push_url PY] is given in addition, this is
+            ``push_url||--push-url`` is given in addition, this is
             used for read access only. Otherwise it will be used for write
             access too and to create the repository sibling in the RIA store.
             Note, that HTTP(S) currently is valid for consumption only thus
-            requiring to provide [CMD: --push-url CMD][PY: push_url PY].
+            requiring to provide ``push_url||--push-url``.
             """,
             constraints=EnsureStr() | EnsureNone()),
         push_url=Parameter(

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -221,6 +221,11 @@ def alter_interface_docs_for_api(docs):
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE)
+    # select only the python alternative from argument specifications
+    docs = re.sub(
+        r'``([a-zA-Z0-9_,.]+)\|\|([a-zA-Z0-9-,.]+)``',
+        lambda match: f'``{match.group(1)}``',
+        docs)
     docs = re.sub(
         r'\|\| PYTHON \>\>(.*?)\<\< PYTHON \|\|',
         lambda match: match.group(1),
@@ -301,6 +306,11 @@ def alter_interface_docs_for_cmdline(docs):
     docs = re.sub(
         r'`\S*`',
         lambda match: match.group(0).strip('`').upper(),
+        docs)
+    # select only the cmdline alternative from argument specifications
+    docs = re.sub(
+        r'``([a-zA-Z0-9_,.]+)\|\|([a-zA-Z0-9-,.]+)``',
+        lambda match: f'``{match.group(2)}``',
         docs)
     # clean up sphinx API refs
     docs = re.sub(

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -245,8 +245,8 @@ def alter_interface_docs_for_api(docs):
             '\\1 (http://handbook.datalad.org/symbols)',
             docs)
     docs = re.sub(
-        r'\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
-        lambda match: textwrap.fill(match.group(1)),
+        r'^([ ]*)\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
+        lambda match: textwrap.fill(match.group(2), subsequent_indent=match.group(1)),
         docs,
         flags=re.MULTILINE | re.DOTALL)
     return docs
@@ -324,8 +324,8 @@ def alter_interface_docs_for_cmdline(docs):
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        r'\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
-        lambda match: textwrap.fill(match.group(1)),
+        r'^([ ]*)\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
+        lambda match: textwrap.fill(match.group(2), subsequent_indent=match.group(1)),
         docs,
         flags=re.MULTILINE | re.DOTALL)
     return docs

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -304,8 +304,8 @@ def alter_interface_docs_for_cmdline(docs):
     # capitalize variables and remove backticks to uniformize with
     # argparse output
     docs = re.sub(
-        r'`\S*`',
-        lambda match: match.group(0).strip('`').upper(),
+        r'([^`]+)`([a-zA-Z0-9_]+)`([^`]+)',
+        lambda match: f'{match.group(1)}{match.group(2).upper()}{match.group(3)}',
         docs)
     # select only the cmdline alternative from argument specifications
     docs = re.sub(

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -317,6 +317,10 @@ def alter_interface_docs_for_cmdline(docs):
         r'\~datalad\.api\.\S*',
         lambda match: "`{0}`".format(match.group(0)[13:]),
         docs)
+    # dedicated support for version markup
+    docs = docs.replace('.. versionadded::', 'New in version')
+    docs = docs.replace('.. versionchanged::', 'Changed in version')
+    docs = docs.replace('.. deprecated::', 'Deprecated in version')
     # Remove RST paragraph markup
     docs = re.sub(
         r'^.. \S+::',

--- a/docs/source/design/docstrings.rst
+++ b/docs/source/design/docstrings.rst
@@ -13,8 +13,8 @@ Docstrings
    implementation.
 
 Docstrings in DataLad source code are used and consumed in many ways. Besides
-serving as documentation directly in the sources, the are also transformed
-rendered in various ways.
+serving as documentation directly in the sources, they are also transformed
+and rendered in various ways.
 
 - Command line ``--help`` output
 - Python's ``help()`` or IPython's ``?``

--- a/docs/source/design/docstrings.rst
+++ b/docs/source/design/docstrings.rst
@@ -1,0 +1,83 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_design_docstrings:
+
+**********
+Docstrings
+**********
+
+.. topic:: Specification scope and status
+
+   This specification provides a partial overview of the current
+   implementation.
+
+Docstrings in DataLad source code are used and consumed in many ways. Besides
+serving as documentation directly in the sources, the are also transformed
+rendered in various ways.
+
+- Command line ``--help`` output
+- Python's ``help()`` or IPython's ``?``
+- Manpages
+- Sphinx-rendered documentation for the Python API and the command line API
+
+A common source docstring is transformed, amended and tuned specifically for
+each consumption scenario.
+
+
+Formatting overview and guidelines
+==================================
+
+Version information
+-------------------
+
+Additions, changes, or deprecation should be recorded in a docstring using the
+standard Sphinx directives ``versionadded``, ``versionchanged``,
+``deprecated``::
+
+  .. deprecated:: 0.16
+     The ``dryrun||--dryrun`` option will be removed in a future release, use
+     the renamed ``dry_run||--dry-run`` option instead.
+
+
+API-conditional docs
+--------------------
+
+The ``CMD`` and ``PY`` macros can be used to selectively include documentation
+for specific APIs only::
+
+  options to pass to :command:`git init`. [PY: Options can be given as a list
+  of command line arguments or as a GitPython-style option dictionary PY][CMD:
+  Any argument specified after the destination path of the repository will be
+  passed to git-init as-is CMD].
+
+For API-alternative command and argument specifications the following format
+can be used::
+
+  ``<python-api>||<cmdline-api``
+
+where the double backticks are mandatory and ``<python-part>`` and
+``<cmdline-part>`` represent the respective argument specification for each
+API. In these specifications only valid argument/command names are allowed,
+plus a comma character to list multiples, and the dot character to include an
+ellipsis::
+
+   ``github_organization||-g,--github-organization``
+
+   ``create_sibling_...||create-sibling-...``
+
+
+Reflow text
+-----------
+
+When automatic transformations negatively affect the presentation of a
+docstring due to excessive removal of content, leaving "holes", the ``REFLOW``
+macro can be used to enclose such segments, in order to reformat them
+as the final processing step. Example::
+
+  || REFLOW >>
+  The API has been aligned with the some
+  ``create_sibling_...||create-sibling-...`` commands of other GitHub-like
+  services, such as GOGS, GIN, GitTea.<< REFLOW ||
+
+The start macro must appear on a dedicated line.

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -25,3 +25,4 @@ subsystems in DataLad.
    url_substitution
    batched_command
    standard_parameters
+   docstrings


### PR DESCRIPTION
Prompoted by https://github.com/datalad/datalad/issues/6247#issuecomment-979218397

- Start of a design document on docstring handling and formatting (it does not document all possibilities on purpose, because some seem arcane and redundant)
- Add support for sphinx versioning directives
- Make `REFLOW` work with indented paragraphs
- Support a simpler specification for API argument alternatives
- Use versioning directives for the 0.16 set of changes to `create_sibling_g*``

Demos:

The is how the following sources look across all kinds of rendering scenarios:

```rst
    .. versionchanged:: 0.16
       || REFLOW >>
       The API has been aligned with the some
       ``create_sibling_...||create-sibling-...`` commands of other GitHub-like
       services, such as GOGS, GIN, GitTea.<< REFLOW ||

    .. deprecated:: 0.16
       The ``dryrun||--dryrun`` option will be removed in a future release, use
       the renamed ``dry_run||--dry-run`` option instead.
       The ``github_login||--github-login`` option will be removed in a future
       release, use the ``credential||--credential`` option instead.
       The ``github_organization||--github-organization`` option will be
       removed in a future release, prefix the reposity name with ``<org>/``
       instead.
```

![image](https://user-images.githubusercontent.com/136479/143558696-4a1b892a-1486-402f-a064-8339f161caca.png)

![image](https://user-images.githubusercontent.com/136479/143558739-a4f7112b-935a-436e-9324-a81be0d15d5a.png)

![image](https://user-images.githubusercontent.com/136479/143558806-6a1a1cee-dfd3-47df-abba-c9e46c2c0dd3.png)

![image](https://user-images.githubusercontent.com/136479/143558882-f144fe85-ae3b-4ca3-b8e4-d61401b60a8b.png)

![image](https://user-images.githubusercontent.com/136479/143558979-bbb6086a-e9ef-45d9-84d4-084b000963cb.png)
