### PR TITLE
TST: no HOME change on OSX

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -130,29 +130,41 @@ def setup_package():
                "'init.defaultBranch={}' 'clone.defaultRemoteName={}'"
                .format(DEFAULT_BRANCH, DEFAULT_REMOTE))
 
-    # To overcome pybuild overriding HOME but us possibly wanting our
-    # own HOME where we pre-setup git for testing (name, email)
-    if 'GIT_HOME' in os.environ:
-        set_envvar('HOME', os.environ['GIT_HOME'])
-    else:
-        # we setup our own new HOME, the BEST and HUGE one
-        from datalad.utils import make_tempfile
-        # TODO: split into a function + context manager
-        with make_tempfile(mkdir=True) as new_home:
-            pass
-        for v, val in get_home_envvars(new_home).items():
-            set_envvar(v, val)
-        if not os.path.exists(new_home):
-            os.makedirs(new_home)
-        with open(os.path.join(new_home, '.gitconfig'), 'w') as f:
-            f.write("""\
+    gitconfig = """\
 [user]
 	name = DataLad Tester
 	email = test@example.com
 [datalad "log"]
 	exc = 1
-""")
-        _TEMP_PATHS_GENERATED.append(new_home)
+"""
+    from datalad.support.external_versions import external_versions
+    if not on_osx or external_versions['cmd:git'] < "2.32":
+        # To overcome pybuild overriding HOME but us possibly wanting our
+        # own HOME where we pre-setup git for testing (name, email)
+        if 'GIT_HOME' in os.environ:
+            set_envvar('HOME', os.environ['GIT_HOME'])
+        else:
+            # we setup our own new HOME, the BEST and HUGE one
+            from datalad.utils import make_tempfile
+            # TODO: split into a function + context manager
+            with make_tempfile(mkdir=True) as new_home:
+                pass
+            for v, val in get_home_envvars(new_home).items():
+                set_envvar(v, val)
+            if not os.path.exists(new_home):
+                os.makedirs(new_home)
+            with open(os.path.join(new_home, '.gitconfig'), 'w') as f:
+                f.write(gitconfig)
+            _TEMP_PATHS_GENERATED.append(new_home)
+    else:
+        from datalad.utils import make_tempfile
+        with make_tempfile(mkdir=True) as cfg_dir:
+            pass
+        os.makedirs(cfg_dir, exist_ok=True)
+        cfg_file = os.path.join(cfg_dir, '.gitconfig')
+        with open(cfg_file, 'w') as f:
+            f.write(gitconfig)
+        set_envvar('GIT_CONFIG_GLOBAL', cfg_file)
 
     # Re-load ConfigManager, since otherwise it won't consider global config
     # from new $HOME (see gh-4153

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -165,6 +165,7 @@ def setup_package():
         with open(cfg_file, 'w') as f:
             f.write(gitconfig)
         set_envvar('GIT_CONFIG_GLOBAL', cfg_file)
+        _TEMP_PATHS_GENERATED.append(cfg_dir)
 
     # Re-load ConfigManager, since otherwise it won't consider global config
     # from new $HOME (see gh-4153

--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -73,8 +73,17 @@ def test_no_empty_http_proxy():
 def test_git_config_warning(path):
     if 'GIT_AUTHOR_NAME' in os.environ:
         raise SkipTest("Found existing explicit identity config")
+
+    # Note: An easier way to test this, would be to just set GIT_CONFIG_GLOBAL
+    # to point somewhere else. However, this is not supported by git before
+    # 2.32. Hence, stick with changed HOME in this test, but be sure to unset a
+    # possible GIT_CONFIG_GLOBAL in addition.
+
+    patched_env = os.environ.copy()
+    patched_env.pop('GIT_CONFIG_GLOBAL', None)
+    patched_env.update(get_home_envvars(path))
     with chpwd(path), \
-            patch.dict('os.environ', get_home_envvars(path)), \
+            patch.dict('os.environ', patched_env, clear=True), \
             swallow_logs(new_level=30) as cml:
         # no configs in that empty HOME
         from datalad.api import Dataset

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -230,9 +230,18 @@ def test_something(path, new_home):
     # very carefully test non-local config
     # so carefully that even in case of bad weather Yarik doesn't find some
     # lame datalad unittest sections in his precious ~/.gitconfig
-    env = get_home_envvars(new_home)
+
+    # Note: An easier way to test this, would be to just set GIT_CONFIG_GLOBAL
+    # to point somewhere else. However, this is not supported by git before
+    # 2.32. Hence, stick with changed HOME in this test, but be sure to unset a
+    # possible GIT_CONFIG_GLOBAL in addition.
+
+    patched_env = os.environ.copy()
+    patched_env.pop('GIT_CONFIG_GLOBAL', None)
+    patched_env.update(get_home_envvars(new_home))
     with patch.dict('os.environ',
-                    dict(get_home_envvars(new_home), DATALAD_SNEAKY_ADDITION='ignore')):
+                    dict(patched_env, DATALAD_SNEAKY_ADDITION='ignore'),
+                    clear=True):
         global_gitconfig = opj(new_home, '.gitconfig')
         assert(not exists(global_gitconfig))
         globalcfg = ConfigManager()
@@ -606,8 +615,12 @@ def test_dataset_systemglobal_mode(path):
 def test_global_config():
 
     # from within tests, global config should be read from faked $HOME (see
-    # setup_package)
-    glb_cfg_file = Path(os.path.expanduser('~')) / '.gitconfig'
+    # setup_package) or from GIT_CONFIG_GLOBAL
+
+    if 'GIT_CONFIG_GLOBAL' in os.environ.keys():
+        glb_cfg_file = Path(os.environ.get('GIT_CONFIG_GLOBAL'))
+    else:
+        glb_cfg_file = Path(os.path.expanduser('~')) / '.gitconfig'
     assert any(glb_cfg_file.samefile(Path(p)) for p in dl_cfg._stores['git']['files'])
     assert_equal(dl_cfg.get("user.name"), "DataLad Tester")
     assert_equal(dl_cfg.get("user.email"), "test@example.com")


### PR DESCRIPTION
System level configured git-credential helper osxkeychain on OSX hangs
if it can't find the Keyring under HOME, which we change to some bogus
dir for the tests. On OSX change the approach to make use of
GIT_CONFIG_GLOBAL instead of changing HOME if git version supports it (>= 2.32).