### PR TITLE
BF: Keyring.delete called uninitialized attribute

### DIFF
--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -80,7 +80,7 @@ class Keyring(object):
         if field is None:
             raise NotImplementedError("Deletion of all fields associated with a name")
         try:
-            return self.__keyring.delete_password(self._get_service_name(name), field)
+            return self._keyring.delete_password(self._get_service_name(name), field)
         except self.__keyring_mod.errors.PasswordDeleteError as exc:
             if 'not found' in str(exc):
                 return


### PR DESCRIPTION
Likely a typo, delete() called an uninitialized private attribute instead
of the lazy loading, protected one.

Note, that this particular bug was only recently introduced to master, so "patch" but against master.

Introduced by: 3cddd7c4ac832e89241d5b396abf47fea994fc71