### PR TITLE
BF: Properly pass result kwargs into result record of create-sibling-ria

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -416,8 +416,8 @@ class CreateSiblingRia(Interface):
                     status='error',
                     message="No store found at '{}'. Forgot "
                             "--new-store-ok ?".format(
-                        Path(base_path), **res_kwargs),
-                    )
+                        Path(base_path)),
+                    **res_kwargs)
                 yield res
                 return
 


### PR DESCRIPTION
The ``res_kwargs`` were accidentally placed into the format method
instead of ``get_status_dict``, thus failing to deliver
common keys into the result record, ultimately leading
to omission of the result record in #6250.
This change should fix this, and close #6250
