### PR TITLE
Expand the use of GIT_CONFIG_GLOBAL to Windows

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -101,7 +101,10 @@ test_http_server = None
 
 def setup_package():
     import os
-    from datalad.utils import on_osx
+    from datalad.utils import (
+        on_osx,
+        on_windows,
+    )
     from datalad.tests import _TEMP_PATHS_GENERATED
 
     if on_osx:
@@ -138,7 +141,7 @@ def setup_package():
 	exc = 1
 """
     from datalad.support.external_versions import external_versions
-    if not on_osx or external_versions['cmd:git'] < "2.32":
+    if external_versions['cmd:git'] < "2.32":
         # To overcome pybuild overriding HOME but us possibly wanting our
         # own HOME where we pre-setup git for testing (name, email)
         if 'GIT_HOME' in os.environ:

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -130,29 +130,41 @@ def setup_package():
                "'init.defaultBranch={}' 'clone.defaultRemoteName={}'"
                .format(DEFAULT_BRANCH, DEFAULT_REMOTE))
 
-    # To overcome pybuild overriding HOME but us possibly wanting our
-    # own HOME where we pre-setup git for testing (name, email)
-    if 'GIT_HOME' in os.environ:
-        set_envvar('HOME', os.environ['GIT_HOME'])
-    else:
-        # we setup our own new HOME, the BEST and HUGE one
-        from datalad.utils import make_tempfile
-        # TODO: split into a function + context manager
-        with make_tempfile(mkdir=True) as new_home:
-            pass
-        for v, val in get_home_envvars(new_home).items():
-            set_envvar(v, val)
-        if not os.path.exists(new_home):
-            os.makedirs(new_home)
-        with open(os.path.join(new_home, '.gitconfig'), 'w') as f:
-            f.write("""\
+    gitconfig = """\
 [user]
 	name = DataLad Tester
 	email = test@example.com
 [datalad "log"]
 	exc = 1
-""")
-        _TEMP_PATHS_GENERATED.append(new_home)
+"""
+    from datalad.support.external_versions import external_versions
+    if not on_osx or external_versions['cmd:git'] < "2.32":
+        # To overcome pybuild overriding HOME but us possibly wanting our
+        # own HOME where we pre-setup git for testing (name, email)
+        if 'GIT_HOME' in os.environ:
+            set_envvar('HOME', os.environ['GIT_HOME'])
+        else:
+            # we setup our own new HOME, the BEST and HUGE one
+            from datalad.utils import make_tempfile
+            # TODO: split into a function + context manager
+            with make_tempfile(mkdir=True) as new_home:
+                pass
+            for v, val in get_home_envvars(new_home).items():
+                set_envvar(v, val)
+            if not os.path.exists(new_home):
+                os.makedirs(new_home)
+            with open(os.path.join(new_home, '.gitconfig'), 'w') as f:
+                f.write(gitconfig)
+            _TEMP_PATHS_GENERATED.append(new_home)
+    else:
+        from datalad.utils import make_tempfile
+        with make_tempfile(mkdir=True) as cfg_dir:
+            pass
+        os.makedirs(cfg_dir, exist_ok=True)
+        cfg_file = os.path.join(cfg_dir, '.gitconfig')
+        with open(cfg_file, 'w') as f:
+            f.write(gitconfig)
+        set_envvar('GIT_CONFIG_GLOBAL', cfg_file)
 
     # Re-load ConfigManager, since otherwise it won't consider global config
     # from new $HOME (see gh-4153

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -165,6 +165,7 @@ def setup_package():
         with open(cfg_file, 'w') as f:
             f.write(gitconfig)
         set_envvar('GIT_CONFIG_GLOBAL', cfg_file)
+        _TEMP_PATHS_GENERATED.append(cfg_dir)
 
     # Re-load ConfigManager, since otherwise it won't consider global config
     # from new $HOME (see gh-4153

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -511,7 +511,6 @@ def test_force_checkdatapresent(srcpath, dstpath):
                       message='Slated for transport, but no content present')
 
 
-@skip_if_on_windows  # https://github.com/datalad/datalad/issues/4278
 @with_tempfile(mkdir=True)
 @with_tree(tree={'ria-layout-version': '1\n'})
 def test_ria_push(srcpath, dstpath):

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -39,7 +39,6 @@ from datalad.customremotes.ria_utils import (
 #       different layouts via those requests is up to the server side, which we
 #       don't test here.
 
-@known_failure_windows  # see gh-4469
 @with_tempfile(mkdir=True)
 @serve_path_via_http
 @with_tempfile

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -77,8 +77,6 @@ def _make_dataset_hierarchy(path):
     return origin, origin_sub1, origin_sub2, origin_sub3, origin_sub4
 
 
-# AssertionError since does get extra record {'cost': 400, 'name': 'bang', 'url': 'youredead', 'from_config': True},
-@known_failure_githubci_win
 @with_tempfile
 @with_tempfile
 @with_tempfile

--- a/datalad/local/tests/test_add_archive_content.py
+++ b/datalad/local/tests/test_add_archive_content.py
@@ -570,7 +570,6 @@ class TestAddArchiveOptions():
         # there should be no .datalad temporary files hanging around
         self.assert_no_trash_left_behind()
 
-    @known_failure_windows
     def test_add_delete_after_and_drop_subdir(self):
         os.mkdir(opj(self.annex.path, 'subdir'))
         mv_out = self.annex.call_git(

--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -73,8 +73,17 @@ def test_no_empty_http_proxy():
 def test_git_config_warning(path):
     if 'GIT_AUTHOR_NAME' in os.environ:
         raise SkipTest("Found existing explicit identity config")
+
+    # Note: An easier way to test this, would be to just set GIT_CONFIG_GLOBAL
+    # to point somewhere else. However, this is not supported by git before
+    # 2.32. Hence, stick with changed HOME in this test, but be sure to unset a
+    # possible GIT_CONFIG_GLOBAL in addition.
+
+    patched_env = os.environ.copy()
+    patched_env.pop('GIT_CONFIG_GLOBAL', None)
+    patched_env.update(get_home_envvars(path))
     with chpwd(path), \
-            patch.dict('os.environ', get_home_envvars(path)), \
+            patch.dict('os.environ', patched_env, clear=True), \
             swallow_logs(new_level=30) as cml:
         # no configs in that empty HOME
         from datalad.api import Dataset

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -230,9 +230,18 @@ def test_something(path, new_home):
     # very carefully test non-local config
     # so carefully that even in case of bad weather Yarik doesn't find some
     # lame datalad unittest sections in his precious ~/.gitconfig
-    env = get_home_envvars(new_home)
+
+    # Note: An easier way to test this, would be to just set GIT_CONFIG_GLOBAL
+    # to point somewhere else. However, this is not supported by git before
+    # 2.32. Hence, stick with changed HOME in this test, but be sure to unset a
+    # possible GIT_CONFIG_GLOBAL in addition.
+
+    patched_env = os.environ.copy()
+    patched_env.pop('GIT_CONFIG_GLOBAL', None)
+    patched_env.update(get_home_envvars(new_home))
     with patch.dict('os.environ',
-                    dict(get_home_envvars(new_home), DATALAD_SNEAKY_ADDITION='ignore')):
+                    dict(patched_env, DATALAD_SNEAKY_ADDITION='ignore'),
+                    clear=True):
         global_gitconfig = opj(new_home, '.gitconfig')
         assert(not exists(global_gitconfig))
         globalcfg = ConfigManager()
@@ -606,8 +615,12 @@ def test_dataset_systemglobal_mode(path):
 def test_global_config():
 
     # from within tests, global config should be read from faked $HOME (see
-    # setup_package)
-    glb_cfg_file = Path(os.path.expanduser('~')) / '.gitconfig'
+    # setup_package) or from GIT_CONFIG_GLOBAL
+
+    if 'GIT_CONFIG_GLOBAL' in os.environ.keys():
+        glb_cfg_file = Path(os.environ.get('GIT_CONFIG_GLOBAL'))
+    else:
+        glb_cfg_file = Path(os.path.expanduser('~')) / '.gitconfig'
     assert any(glb_cfg_file.samefile(Path(p)) for p in dl_cfg._stores['git']['files'])
     assert_equal(dl_cfg.get("user.name"), "DataLad Tester")
     assert_equal(dl_cfg.get("user.email"), "test@example.com")

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -247,6 +247,7 @@ def get_home_envvars(new_home):
         # since python 3.8: https://bugs.python.org/issue36264
         out['USERPROFILE'] = new_home
         out['HOMEDRIVE'], out['HOMEPATH'] = splitdrive(new_home)
+
     return {v: val for v, val in out.items() if v in os.environ}
 
 


### PR DESCRIPTION
this change sits on top of #6251 and simply expands it to all systems with a high enough git installation (i.e., I removed the ``if not on_osx`` constraint). Things pass on locally for me both on Windows (6 more tests start to pass with this change, including the one where #6160 originally surfaces) and Debian, but let's see what breaks in the CIs.
I think that with the exception of a few tests (e.g. ``test_expanduser``) this would avoid leaking cache dirs and the like into temporary repositories during testing. :crossed_fingers: 