### PR TITLE
ENH(TST): add some "pragma: no cover" wherever test code is not expected to run

### DIFF
--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -177,7 +177,7 @@ def test_getargspec():
         # and lets try on a wrapped one -- only ours can do the right thing
         def decorator(f):
             @wraps(f)
-            def wrapper(*args, **kwargs):
+            def wrapper(*args, **kwargs):  # pragma: no cover
                 return f(*args, **kwargs)
             return wrapper
         fw = decorator(f)
@@ -187,24 +187,24 @@ def test_getargspec():
             assert_raises(ValueError, getargspec, fw)
         eq_(getargspec(fw, include_kwonlyargs=has_kwonlyargs), expected)
 
-    def f0():
+    def f0():  # pragma: no cover
         pass
 
     yield eq_argspec, f0, ([], None, None, None)
 
-    def f1(a1, kw1=None, kw0=1):
+    def f1(a1, kw1=None, kw0=1):  # pragma: no cover
         pass
 
     yield eq_argspec, f1, (['a1', 'kw1', 'kw0'], None, None, (None, 1))
 
     # Having *a already makes keyword args to be kwonlyargs, in that
     # inspect.get*spec would barf
-    def f1_args(a1, *a, kw1=None, kw0=1, **kw):
+    def f1_args(a1, *a, kw1=None, kw0=1, **kw):  # pragma: no cover
         pass
 
     yield eq_argspec, f1_args, (['a1', 'kw1', 'kw0'], 'a', 'kw', (None, 1)), True
 
-    def f1_star(a1, *, kw1=None, kw0=1):
+    def f1_star(a1, *, kw1=None, kw0=1):  # pragma: no cover
         pass
 
     assert_raises(ValueError, getargspec, f1_star)
@@ -719,7 +719,7 @@ def test_all_same():
         yield 'a'
         yield 'a'
         yield 'b'
-        raise ValueError("Should not get here since on b should return")
+        raise ValueError("Should not get here since on b should return")  # pragma: no cover
 
     ok_(not all_same(never_get_to_not_needed()))
 


### PR DESCRIPTION
Just spotted while staring in a stale browser tab of
https://github.com/datalad/datalad/pull/6190/files
which is now merged
