### PR TITLE
Enable ORA remote to recover from an interupted upload

### DIFF
--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -117,6 +117,8 @@ def verify_ria_url(url, cfg):
         portdlm=':' if url_ri.port else '',
         port=url_ri.port or '',
     )
+    # this != file is critical behavior, if removed, it will ruin the IO selection
+    # in RIARemote!!
     return host if protocol != 'file' else None, \
         url_ri.path if url_ri.path else '/', \
         url

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1180,7 +1180,7 @@ class RIARemote(SpecialRemote):
                     self.io.close()
 
                 # XXX now also READ IO is done with the write IO
-                # this explicitely ignores the remote config
+                # this explicitly ignores the remote config
                 # that distinguishes READ from WRITE with different
                 # methods
                 self._io = self._push_io

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1101,6 +1101,8 @@ class RIARemote(SpecialRemote):
 
         # TODO: Isn't that wrong with HTTP anyway?
         #       + just isinstance(LocalIO)?
+        # XXX isinstance(LocalIO) would not work, this method is used
+        # before LocalIO is instantiated
         return not self.storage_host
 
     def _set_read_only(self, msg):
@@ -1177,6 +1179,10 @@ class RIARemote(SpecialRemote):
                     unregister(self.io.close)
                     self.io.close()
 
+                # XXX now also READ IO is done with the write IO
+                # this explicitely ignores the remote config
+                # that distinguishes READ from WRITE with different
+                # methods
                 self._io = self._push_io
                 if hasattr(self.io, 'close'):
                     register(self.io.close)

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1020,6 +1020,10 @@ class RIARemote(SpecialRemote):
         """
         # make sure the base path is a platform path when doing local IO
         # the incoming Path object is a PurePosixPath
+        # XXX this else branch is wrong: Incoming is PurePosixPath
+        # but it is subsequently assumed to be a platform path, by
+        # get_layout_locations() etc. Hence it must be converted
+        # to match the *remote* platform, not the local client
         store_base_path = Path(self.store_base_path) \
             if self._local_io else self.store_base_path
 


### PR DESCRIPTION
Fixes #6252 which comprises two problems.

ORA remote used the uuid of the *remote* to place a file in transfer
in a tmp dir. But this actually causes transfer conflicts with
simultanous uploads of the same key from multiple clones.

This is fixed by using the `here` uuid.

The second issue is a test for existence of the transfer file, and
failing if there is one already. This prevents the first issue from
having practical relevance re data integrity. With the usage of `here`
uuids, the conflict can no longer happen, and the test is obsolete.

The fix involves import and instantiation of `AnnexRepo()`. The
additional cost for that is minimal (~10-50ms on my machine) and is only
payed once per process at PREPARE. This newly available repo API, will
enable removal of custom code from the implementation in subsequent
changes.

Additional changes

- Introduce an `AnnexRepo` instance to stop repeated git-config queries (but see #6264)
- Leave several notes on potential problems for future RF