### PR TITLE
Discontinue use of and deprecate get_repo_instance()

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -311,6 +311,10 @@ def get_repo_instance(path=os.curdir, class_=None):
     returns an instance representing it. May also check for a certain type
     instead of detecting the type of repository.
 
+    .. deprecated:: 0.16
+       Use the pattern `Dataset(get_dataset_root(path)).repo` instead. This
+       function will be removed in a future release.
+
     Parameters
     ----------
     path: str
@@ -323,15 +327,15 @@ def get_repo_instance(path=os.curdir, class_=None):
     ------
     RuntimeError, in case cwd is not inside a known repository.
     """
+    warnings.warn("get_repo_instance() was deprecated in 0.16. "
+                  "It will be removed in a future release.",
+                  DeprecationWarning)
 
-    from os.path import ismount, exists, normpath, isabs
-    from datalad.support.exceptions import InvalidGitRepositoryError
-    from ..utils import expandpath
-    from ..support.gitrepo import GitRepo
-    from ..support.annexrepo import AnnexRepo
+    from datalad.utils import get_dataset_root
+    from datalad.distribution.dataset import Dataset
+    from datalad.support.annexrepo import AnnexRepo
+    from datalad.support.gitrepo import GitRepo
 
-    dir_ = expandpath(path)
-    abspath_ = path if isabs(path) else dir_
     if class_ is not None:
         if class_ == AnnexRepo:
             type_ = "annex"
@@ -339,34 +343,15 @@ def get_repo_instance(path=os.curdir, class_=None):
             type_ = "git"
         else:
             raise RuntimeError("Unknown class %s." % str(class_))
-
-    while not ismount(dir_):  # TODO: always correct termination?
-        if exists(opj(dir_, '.git')):
-            # found git dir
-            if class_ is None:
-                # detect repo type:
-                try:
-                    return AnnexRepo(dir_, create=False)
-                except RuntimeError as e:
-                    pass
-                try:
-                    return GitRepo(dir_, create=False)
-                except InvalidGitRepositoryError as e:
-                    raise RuntimeError("No datalad repository found in %s" %
-                                       abspath_)
-            else:
-                try:
-                    return class_(dir_, create=False)
-                except (RuntimeError, InvalidGitRepositoryError) as e:
-                    raise RuntimeError("No %s repository found in %s." %
-                                       (type_, abspath_))
-        else:
-            dir_ = normpath(opj(dir_, ".."))
-
-    if class_ is not None:
-        raise RuntimeError("No %s repository found in %s" % (type_, abspath_))
     else:
-        raise RuntimeError("No datalad repository found in %s" % abspath_)
+        type_ = ''
+
+    dsroot = get_dataset_root(path)
+    if not dsroot:
+        raise RuntimeError(f"No {type_}s repository found at {path}.")
+
+    return Dataset(dsroot).repo
+
 
 #
 # Some logic modules extracted from main.py to de-spagetify

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -16,12 +16,13 @@ import os.path as op
 import shutil
 from collections import OrderedDict
 from operator import itemgetter
+from pathlib import Path
 from urllib.parse import urlparse
 
 from annexremote import UnsupportedRequest
 
-from datalad.cmdline.helpers import get_repo_instance
 from datalad.consts import ARCHIVES_SPECIAL_REMOTE
+from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.archives import ArchivesCache
 from datalad.support.cache import DictCache
@@ -31,6 +32,7 @@ from datalad.support.network import URL
 from datalad.utils import (
     ensure_bytes,
     getpwd,
+    get_dataset_root,
     unique,
     unlink,
 )
@@ -97,7 +99,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
 
         # MIH figure out what the following is all about
         # in particular path==None
-        self.repo = get_repo_instance(class_=AnnexRepo) \
+        self.repo = Dataset(get_dataset_root(Path.cwd())).repo \
             if not path \
             else AnnexRepo(path, create=False, init=False)
 


### PR DESCRIPTION
This is an old, now duplicate, implementation of getting a repo instance
from a path (that may point into a dataset, and not at its root). This
was only used in a few spots. I replaced it with the standard approach.