### PR TITLE
Cleanup datalad/__init__.py

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -16,17 +16,20 @@ documentation with `help`.
 """
 
 if not __debug__:
-    raise RuntimeError('DataLad cannot run in "optimized" mode, i.e. python -O')
+    raise RuntimeError(
+        'DataLad cannot run in "optimized" mode, i.e. python -O')
+
+import atexit
+import os
+
 
 # For reproducible demos/tests
-import os
 _seed = os.environ.get('DATALAD_SEED', None)
 if _seed is not None:
     import random
     _seed = int(_seed)
     random.seed(_seed)
 
-import atexit
 # Colorama (for Windows terminal colors) must be imported before we use/bind
 # any sys.stdout
 try:
@@ -46,6 +49,7 @@ except ImportError as e:
 from .config import ConfigManager
 cfg = ConfigManager()
 
+# must come after config manager
 from .log import lgr
 from datalad.support.exceptions import CapturedException
 from datalad.utils import (
@@ -98,21 +102,38 @@ _test_states = {
 # handle to an HTTP server instance that is used as part of the tests
 test_http_server = None
 
+
 def setup_package():
+    from io import StringIO as OrigStringIO
+    from nose.ext import dtcompat
+    from nose.plugins import (
+        capture,
+        multiprocess,
+        plugintest,
+    )
     import os
     from pathlib import Path
+    import tempfile
+
+    from datalad import consts
+    from datalad.interface.common_cfg import compute_cfg_defaults
+    from datalad.support.annexrepo import AnnexRepo
+    from datalad.support.external_versions import external_versions
+    from datalad.tests import _TEMP_PATHS_GENERATED
+    from datalad.tests.utils import (
+        DEFAULT_BRANCH,
+        DEFAULT_REMOTE,
+        HTTPPath,
+    )
+    from datalad.ui import ui
     from datalad.utils import (
+        make_tempfile,
         on_osx,
     )
-    from datalad.tests import _TEMP_PATHS_GENERATED
-    from datalad.utils import make_tempfile
 
     if on_osx:
         # enforce honoring TMPDIR (see gh-5307)
-        import tempfile
         tempfile.tempdir = os.environ.get('TMPDIR', tempfile.gettempdir())
-
-    from datalad import consts
 
     _test_states['env'] = {}
 
@@ -125,10 +146,6 @@ def setup_package():
     consts.DATASETS_TOPURL = 'https://datasets-tests.datalad.org/'
     set_envvar('DATALAD_DATASETS_TOPURL', consts.DATASETS_TOPURL)
 
-    from datalad.tests.utils import (
-        DEFAULT_BRANCH,
-        DEFAULT_REMOTE,
-    )
     set_envvar("GIT_CONFIG_PARAMETERS",
                "'init.defaultBranch={}' 'clone.defaultRemoteName={}'"
                .format(DEFAULT_BRANCH, DEFAULT_REMOTE))
@@ -154,7 +171,6 @@ def setup_package():
         cfg_file.write_text(gitconfig)
         return new_home, cfg_file
 
-    from datalad.support.external_versions import external_versions
     if external_versions['cmd:git'] < "2.32":
         # To overcome pybuild overriding HOME but us possibly wanting our
         # own HOME where we pre-setup git for testing (name, email)
@@ -173,7 +189,6 @@ def setup_package():
     # from new $HOME (see gh-4153
     cfg.reload(force=True)
 
-    from datalad.interface.common_cfg import compute_cfg_defaults
     compute_cfg_defaults()
     # datalad.locations.sockets has likely changed. Discard any cached values.
     ssh_manager._socket_dir = None
@@ -190,7 +205,6 @@ def setup_package():
     # During tests we allow for "insecure" access to local file:// and
     # http://localhost URLs since all of them either generated as tests
     # fixtures or cloned from trusted sources
-    from datalad.support.annexrepo import AnnexRepo
     AnnexRepo._ALLOW_LOCAL_URLS = True
 
     DATALAD_LOG_LEVEL = os.environ.get('DATALAD_LOG_LEVEL', None)
@@ -207,21 +221,16 @@ def setup_package():
         _test_states['loglevel'] = None
 
     # Set to non-interactive UI
-    from datalad.ui import ui
     _test_states['ui_backend'] = ui.backend
     # obtain() since that one consults for the default value
     ui.set_backend(cfg.obtain('datalad.tests.ui.backend'))
 
     # Monkey patch nose so it does not ERROR out whenever code asks for fileno
     # of the output. See https://github.com/nose-devs/nose/issues/6
-    from io import StringIO as OrigStringIO
-
     class StringIO(OrigStringIO):
         fileno = lambda self: 1
         encoding = None
 
-    from nose.ext import dtcompat
-    from nose.plugins import capture, multiprocess, plugintest
     dtcompat.StringIO = StringIO
     capture.StringIO = StringIO
     multiprocess.StringIO = StringIO
@@ -231,9 +240,6 @@ def setup_package():
     # file:// URLs in the tests, have a standard HTTP server
     # that serves an 'httpserve' directory in the test HOME
     # the URL will be available from datalad.test_http_server.url
-    from datalad.tests.utils import HTTPPath
-    import tempfile
-
     global test_http_server
     # Start the server only if not running already
     # Relevant: we have test_misc.py:test_test which runs datalad.test but
@@ -255,10 +261,19 @@ def setup_package():
 
 def teardown_package():
     import os
-    from datalad.tests.utils import rmtemp, OBSCURE_FILENAME
+    from datalad import consts
+    from datalad.interface.common_cfg import compute_cfg_defaults
+    from datalad.support.annexrepo import AnnexRepo
+    from datalad.support.cookies import cookies_db
+    from datalad.support.external_versions import external_versions as ev
+    from datalad.tests import _TEMP_PATHS_GENERATED
+    from datalad.tests.utils import (
+        rmtemp,
+        OBSCURE_FILENAME,
+    )
+    from datalad.ui import ui
 
     lgr.debug("Printing versioning information collected so far")
-    from datalad.support.external_versions import external_versions as ev
     print(ev.dumps(query=True))
     try:
         print("Obscure filename: str=%s repr=%r"
@@ -273,8 +288,6 @@ def teardown_package():
 
     if os.environ.get('DATALAD_TESTS_NOTEARDOWN'):
         return
-    from datalad.ui import ui
-    from datalad import consts
     ui.set_backend(_test_states['ui_backend'])
     if _test_states['loglevel'] is not None:
         lgr.setLevel(_test_states['loglevel'])
@@ -286,7 +299,6 @@ def teardown_package():
     else:
         lgr.debug("For some reason global http_server was not set/running, thus not stopping")
 
-    from datalad.tests import _TEMP_PATHS_GENERATED
     if len(_TEMP_PATHS_GENERATED):
         msg = "Removing %d dirs/files: %s" % (len(_TEMP_PATHS_GENERATED), ', '.join(_TEMP_PATHS_GENERATED))
     else:
@@ -308,15 +320,12 @@ def teardown_package():
     # either way.
     cfg.reload(force=True)
 
-    from datalad.interface.common_cfg import compute_cfg_defaults
     compute_cfg_defaults()
     ssh_manager._socket_dir = None
 
     consts.DATASETS_TOPURL = _test_states['DATASETS_TOPURL']
 
-    from datalad.support.cookies import cookies_db
     cookies_db.close()
-    from datalad.support.annexrepo import AnnexRepo
     AnnexRepo._ALLOW_LOCAL_URLS = False  # stay safe!
 
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -236,10 +236,10 @@ def get_home_envvars(new_home):
 
     Parameters
     ----------
-    new_home: str
+    new_home: str or Path
       New home path, in native to OS "schema"
     """
-    environ = os.environ
+    new_home = str(new_home)
     out = {'HOME': new_home}
     if on_windows:
         # requires special handling, since it has a number of relevant variables


### PR DESCRIPTION
Many small increments have led to an organic state. This makes a pass to consolidate, de-duplicate, and re-structure according to current practice -- unless counter-evidence was found.