### PR TITLE
Do not run tests where test setup isn't safe

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -172,6 +172,12 @@ def setup_package():
         return new_home, cfg_file
 
     if external_versions['cmd:git'] < "2.32":
+        if (on_osx or on_windows) and \
+                not cfg.obtain("datalad.tests.force-fake-home", default=False):
+            raise RuntimeError("Refuse to execute datalad tests with git<2.32, "
+                               "see config datalad.tests.force-fake-home for "
+                               "details.")
+
         # To overcome pybuild overriding HOME but us possibly wanting our
         # own HOME where we pre-setup git for testing (name, email)
         if 'GIT_HOME' in os.environ:

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -129,6 +129,7 @@ def setup_package():
     from datalad.utils import (
         make_tempfile,
         on_osx,
+        on_windows
     )
 
     if on_osx:

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -202,7 +202,7 @@ definitions = {
     },
     'datalad.tests.force-fake-home': {
         'ui': ('yesno', {
-               'title': 'Force running tests on OSX and window with manipulated HOME or USERPROFILE respectively.',
+               'title': 'Force running tests on OSX and window with manipulated HOME or USERPROFILE respectively',
                'text': "This is potentially dangerous and only applies on OSX and Windows if the git version used by datalad is older than 2.32."
                        "By default, tests are not executed under these circumstances, since the legacy setup for the test environment can have unintended side-effects:{nl}"
                        "1. On Windows, sub-processes launched by the tests fail to use the desired, isolated locations for configs, caches, etc."

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -12,7 +12,10 @@
 
 __docformat__ = 'restructuredtext'
 
-from os import environ
+from os import (
+    environ,
+    linesep
+)
 from os.path import expanduser
 from os.path import join as opj
 
@@ -196,6 +199,18 @@ definitions = {
         'ui': ('yesno', {
                'title': 'Does not execute teardown_package which cleans up temp files and directories created by tests if this flag is set'}),
         'type': EnsureBool(),
+    },
+    'datalad.tests.force-fake-home': {
+        'ui': ('yesno', {
+               'title': 'Force running tests on OSX and window with manipulated HOME or USERPROFILE respectively.',
+               'text': "This is potentially dangerous and only applies on OSX and Windows if the git version used by datalad is older than 2.32."
+                       "By default, tests are not executed under these circumstances, since the legacy setup for the test environment can have unintended side-effects:{nl}"
+                       "1. On Windows, subprocesses launched by the tests (incl. indirectly started ones), may end up reading from and writing to wrong locations, as any subprocess will fail to retrieve correct standard locations for configs, caches, etc. This issue is discussed in gh-6160 and gh-6260."
+                       "See also: https://github.com/datalad/datalad/issues/6160 and https://github.com/datalad/datalad/pull/6260 for more details.{nl}"
+                       "2. OSX, most notably the system-level osxkeychain git-credential helper, which will lead to hanging git commands if it fails to find the keychain in its expected location under $HOME/Library/Keychain."
+                       "Do you want to run tests nevertheless?".format(nl=linesep)}),
+        'type': EnsureBool(),
+        'default': False
     },
     'datalad.tests.dataladremote': {
         'ui': ('yesno', {

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -205,8 +205,8 @@ definitions = {
                'title': 'Force running tests on OSX and window with manipulated HOME or USERPROFILE respectively.',
                'text': "This is potentially dangerous and only applies on OSX and Windows if the git version used by datalad is older than 2.32."
                        "By default, tests are not executed under these circumstances, since the legacy setup for the test environment can have unintended side-effects:{nl}"
-                       "1. On Windows, subprocesses launched by the tests (incl. indirectly started ones), may end up reading from and writing to wrong locations, as any subprocess will fail to retrieve correct standard locations for configs, caches, etc. This issue is discussed in gh-6160 and gh-6260."
-                       "See also: https://github.com/datalad/datalad/issues/6160 and https://github.com/datalad/datalad/pull/6260 for more details.{nl}"
+                       "1. On Windows, sub-processes launched by the tests fail to use the desired, isolated locations for configs, caches, etc."
+                       "See https://github.com/datalad/datalad/issues/6160 and https://github.com/datalad/datalad/pull/6260 for more details.{nl}"
                        "2. OSX, most notably the system-level osxkeychain git-credential helper, which will lead to hanging git commands if it fails to find the keychain in its expected location under $HOME/Library/Keychain."
                        "Do you want to run tests nevertheless?".format(nl=linesep)}),
         'type': EnsureBool(),


### PR DESCRIPTION
As lined out in PR #6260, I think we should not run the tests on OSX and Windows with too old a git for the changed approach in that PR to be applied.

Not only may tests fail or hang, they can also have unintended side-effects on user's files.

ATM, I'm thinking just raising from within `setup_package` in this case may do. WDYT, @datalad/developers ?