### PR TITLE
Allow other URLs than local file as dataset parameter

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -48,7 +48,7 @@ from datalad.support.exceptions import (
 )
 from datalad import cfg as dlcfg
 from datalad.dochelpers import single_or_plural
-from datalad.support.network import URL
+
 from datalad.ui import ui
 import datalad.support.ansi_colors as ac
 
@@ -368,11 +368,13 @@ def eval_results(wrapped):
         ds = None
         if dataset_arg is not None:
             from datalad.distribution.dataset import Dataset
-            ds = dataset_arg  \
-                if isinstance(dataset_arg, Dataset) \
-                else Dataset(dataset_arg) \
-                if URL(dataset_arg).is_local() \
-                else None
+            if isinstance(dataset_arg, Dataset):
+                ds = dataset_arg
+            else:
+                try:
+                    ds = Dataset(dataset_arg)
+                except ValueError:
+                    pass
 
         # look for hooks
         hooks = get_jsonhooks_from_config(ds.config if ds else dlcfg)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -48,7 +48,7 @@ from datalad.support.exceptions import (
 )
 from datalad import cfg as dlcfg
 from datalad.dochelpers import single_or_plural
-
+from datalad.support.network import URL
 from datalad.ui import ui
 import datalad.support.ansi_colors as ac
 
@@ -365,9 +365,15 @@ def eval_results(wrapped):
         # .is_installed and .config can be costly, so ensure we do
         # it only once. See https://github.com/datalad/datalad/issues/3575
         dataset_arg = allkwargs.get('dataset', None)
-        from datalad.distribution.dataset import Dataset
-        ds = dataset_arg if isinstance(dataset_arg, Dataset) \
-            else Dataset(dataset_arg) if dataset_arg else None
+        ds = None
+        if dataset_arg is not None:
+            from datalad.distribution.dataset import Dataset
+            ds = dataset_arg  \
+                if isinstance(dataset_arg, Dataset) \
+                else Dataset(dataset_arg) \
+                if URL(dataset_arg).is_local() \
+                else None
+
         # look for hooks
         hooks = get_jsonhooks_from_config(ds.config if ds else dlcfg)
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -696,7 +696,7 @@ class URL(RI):
 
     @property
     def localpath(self):
-        if not self.is_local():
+        if self.scheme != 'file':
             raise ValueError(
                 "Non 'file://' URL cannot be resolved to a local path")
         hostname = self.hostname
@@ -704,9 +704,6 @@ class URL(RI):
                 or hostname.startswith('127.')):
             raise ValueError("file:// URL does not point to 'localhost'")
         return self.path
-
-    def is_local(self):
-        return self.scheme == 'file'
 
 
 class PathRI(RI):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -696,7 +696,7 @@ class URL(RI):
 
     @property
     def localpath(self):
-        if self.scheme != 'file':
+        if not self.is_local():
             raise ValueError(
                 "Non 'file://' URL cannot be resolved to a local path")
         hostname = self.hostname
@@ -704,6 +704,9 @@ class URL(RI):
                 or hostname.startswith('127.')):
             raise ValueError("file:// URL does not point to 'localhost'")
         return self.path
+
+    def is_local(self):
+        return self.scheme == 'file'
 
 
 class PathRI(RI):


### PR DESCRIPTION
This PR fixes issue #6275.

The PR removes the restriction of dataset parameters to locally resolvable file-URLs. This is used, for example, in the new metalad version where you can dump metadata from remote repositories.

The main difference introduced is that the decorator `eval_results` only looks for hooks in the default configuration, if the dataset parameter does not specify a locally resolvable file-URL.
