### PR TITLE
Generator-based GitRepo.call_git_items_()

### DIFF
--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -67,15 +67,15 @@ preferred_encoding = getpreferredencoding(do_setlocale=False)
 
 
 @contextmanager
-def lock_if_required(read_only,
-                     write_lock):
-    if not read_only:
-        write_lock.acquire()
+def lock_if_required(lock_required, lock):
+    """Acquire/ and release the provided lock if indicated by a flag"""
+    if lock_required:
+        lock.acquire()
     try:
-        yield write_lock
+        yield lock
     finally:
-        if not read_only:
-            write_lock.release()
+        if lock_required:
+            lock.release()
 
 
 @contextmanager

--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -21,15 +21,17 @@ __all__ = ['GitRepo']
 
 import logging
 import os
-from os import environ
-from os.path import lexists
 import re
 import threading
 import time
+from locale import getpreferredencoding
+from os import environ
+from os.path import lexists
 from weakref import (
     finalize,
     WeakValueDictionary
 )
+
 from datalad.cmd import (
     GitWitlessRunner,
     StdOutErrCapture,
@@ -39,6 +41,10 @@ from datalad.dataset.repo import (
     PathBasedFlyweight,
     RepoInterface,
     path_based_str_repr,
+)
+from datalad.runner.nonasyncrunner import (
+    STDERR_FILENO,
+    STDOUT_FILENO,
 )
 from datalad.runner.protocol import GeneratorMixIn
 from datalad.runner.utils import LineSplitter
@@ -55,6 +61,8 @@ from datalad.utils import (
 
 
 lgr = logging.getLogger('datalad.dataset.gitrepo')
+
+preferred_encoding = getpreferredencoding(do_setlocale=False)
 
 
 @path_based_str_repr
@@ -229,8 +237,106 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         return env
 
-    def _call_git(self, args, files=None, expect_stderr=False, expect_fail=False,
-                  env=None, read_only=False):
+    def _generator_call_git(self,
+                            args,
+                            files=None,
+                            env=None,
+                            sep=None):
+        """
+        Call git, yield stdout and stderr lines when available. Output lines
+        are split at line ends or `sep` if `sep` is not None.
+
+        Parameters
+        ----------
+        sep : str, optional
+          Use `sep` as line separator. Does not create an empty last line if
+          the input ends on sep.
+
+        All other parameters match those described for `call_git`.
+
+        Returns
+        -------
+        Generator that yields tuples of `(file_no, line)`, where `file_no` is
+        either:
+
+         - `datalad.runner.nonasyncrunner.STDOUT_FILENO` for stdout, or
+         - `datalad.runner.nonasyncrunner.STDERR_FILENO` for stderr,
+
+        and `line` is the next result line, split on `sep`, or on standard line
+        ends.
+
+        Raises
+        ------
+        CommandError if the call exits with a non-zero status.
+        """
+
+        class GeneratorStdOutErrCapture(GeneratorMixIn, StdOutErrCapture):
+            """
+            Generator-runner protocol that yields stdout and captures stderr
+            in the provided stderr_buffer.
+            """
+            def __init__(self):
+                GeneratorMixIn.__init__(self)
+                StdOutErrCapture.__init__(self)
+
+            def pipe_data_received(self, fd, data):
+                if fd in (1, 2):
+                    self.send_result((fd, data.decode(self.encoding)))
+                else:
+                    StdOutErrCapture.pipe_data_received(self, fd, data)
+
+        cmd = self._git_cmd_prefix + args
+
+        if files:
+            # only call the wrapper if needed (adds distraction logs
+            # otherwise, and also maintains the possibility to connect
+            # stdin in the future)
+            generator = self._git_runner.run_on_filelist_chunks_items_(
+                cmd,
+                files,
+                protocol=GeneratorStdOutErrCapture,
+                env=env)
+        else:
+            generator = self._git_runner.run(
+                cmd,
+                protocol=GeneratorStdOutErrCapture,
+                env=env)
+
+        line_splitter = {
+            STDOUT_FILENO: LineSplitter(sep),
+            STDERR_FILENO: LineSplitter(sep)
+        }
+
+        for file_no, content in generator:
+            if file_no in (STDOUT_FILENO, STDERR_FILENO):
+                for line in line_splitter[file_no].process(content):
+                    yield file_no, line + "\n"
+            else:
+                raise ValueError(f"unknown file number: {file_no}")
+
+        for file_no in (STDOUT_FILENO, STDERR_FILENO):
+            remaining_content = line_splitter[file_no].finish_processing()
+            if remaining_content is not None:
+                yield file_no, remaining_content
+
+    def _get_ignore_exception(self, exception):
+        ignored = re.search(GitIgnoreError.pattern, exception.stderr)
+        if ignored:
+            return GitIgnoreError(cmd=exception.cmd,
+                                  msg=exception.stderr,
+                                  code=exception.code,
+                                  stdout=exception.stdout,
+                                  stderr=exception.stderr,
+                                  paths=ignored.groups()[0].splitlines())
+        return None
+
+    def _call_git(self,
+                  args,
+                  files=None,
+                  expect_stderr=False,
+                  expect_fail=False,
+                  env=None,
+                  read_only=False):
         """Allows for calling arbitrary commands.
 
         Internal helper to the call_git*() methods.
@@ -241,50 +347,44 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         runner = self._git_runner
         stderr_log_level = {True: 5, False: 11}[expect_stderr]
 
-        cmd = self._git_cmd_prefix + args
-
         if not read_only and self._fake_dates_enabled:
             env = self.add_fake_dates_to_env(env if env else runner.env)
 
-        protocol = StdOutErrCapture
-        out = err = None
+        output = {
+            STDOUT_FILENO: [],
+            STDERR_FILENO: [],
+        }
+
         try:
             if not read_only:
                 self._write_lock.acquire()
-            if files:
-                # only call the wrapper if needed (adds distraction logs
-                # otherwise, and also maintains the possibility to connect
-                # stdin in the future)
-                res = runner.run_on_filelist_chunks(
-                    cmd,
-                    files,
-                    protocol=protocol,
-                    env=env)
-            else:
-                res = runner.run(
-                    cmd,
-                    protocol=protocol,
-                    env=env)
+
+            for file_no, line in self._generator_call_git(
+                                                  args,
+                                                  files=files,
+                                                  env=env):
+                output[file_no].append(line)
+
         except CommandError as e:
-            ignored = re.search(GitIgnoreError.pattern, e.stderr)
-            if ignored:
-                raise GitIgnoreError(cmd=e.cmd, msg=e.stderr,
-                                     code=e.code, stdout=e.stdout,
-                                     stderr=e.stderr,
-                                     paths=ignored.groups()[0].splitlines())
+            e.stdout = "".join(output[STDOUT_FILENO])
+            e.stderr = "".join(output[STDERR_FILENO])
+            ignore_exception = self._get_ignore_exception(e)
+            if ignore_exception:
+                raise ignore_exception
+
             lgr.log(5 if expect_fail else 11, str(e))
             raise
+
         finally:
             if not read_only:
                 self._write_lock.release()
 
-        out = res['stdout']
-        err = res['stderr']
-        if err:
-            for line in err.splitlines():
-                lgr.log(stderr_log_level,
-                        "stderr| " + line.rstrip('\n'))
-        return out, err
+        for line in output[STDERR_FILENO]:
+            lgr.log(stderr_log_level,
+                    "stderr| " + line.rstrip("\n"))
+        return (
+            "".join(output[STDOUT_FILENO]),
+            "".join(output[STDERR_FILENO]))
 
     def call_git(self, args, files=None,
                  expect_stderr=False, expect_fail=False, read_only=False):
@@ -320,106 +420,77 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ------
         CommandError if the call exits with a non-zero status.
         """
-        out, _ = self._call_git(args, files,
-                                expect_stderr=expect_stderr,
-                                expect_fail=expect_fail,
-                                read_only=read_only)
-        return out
+        return "\n".join(
+            self.call_git_items_(args,
+                                 files,
+                                 expect_stderr=expect_stderr,
+                                 expect_fail=expect_fail,
+                                 read_only=read_only))
 
     def call_git_items_(self,
                         args,
                         files=None,
                         expect_stderr=False,
-                        sep=None,
-                        read_only=False):
-        """Call git, splitting output on `sep`.
+                        expect_fail=False,
+                        env=None,
+                        read_only=False,
+                        sep=None):
+        """
+        Call git, yield output lines when available. Output lines are split
+        at line ends or `sep` if `sep` is not None.
 
         Parameters
         ----------
         sep : str, optional
-          Split the output by `str.split(sep)` rather than `str.splitlines`.
+          Use sep as line separator. Does not create an empty last line if
+          the input ends on sep.
 
         All other parameters match those described for `call_git`.
 
         Returns
         -------
-        Generator that yields output items.
+        Generator that yields stdout items.
 
         Raises
         ------
         CommandError if the call exits with a non-zero status.
         """
-        class GeneratorStdOutErrCapture(GeneratorMixIn, StdOutErrCapture):
-            def __init__(self):
-                GeneratorMixIn.__init__(self)
-                StdOutErrCapture.__init__(self)
-
-            def pipe_data_received(self, fd, data):
-                if fd == 1:
-                    self.send_result(("stdout", data.decode(self.encoding)))
-                    return
-                super().pipe_data_received(fd, data)
-
-        runner = self._git_runner
-        stderr_log_level = {True: 5, False: 11}[expect_stderr]
-
-        cmd = self._git_cmd_prefix + args
 
         if not read_only and self._fake_dates_enabled:
-            env = self.add_fake_dates_to_env(runner.env)
-        else:
-            env = None
+            env = self.add_fake_dates_to_env(
+                env if env else self._git_runner.env)
 
-        if not read_only:
-            self._write_lock.acquire()
-
-        if files:
-            # only call the wrapper if needed (adds distraction logs
-            # otherwise, and also maintains the possibility to connect
-            # stdin in the future)
-            generator = runner.run_on_filelist_chunks_items_(
-                cmd,
-                files,
-                protocol=GeneratorStdOutErrCapture,
-                env=env)
-        else:
-            generator = runner.run(
-                cmd,
-                protocol=GeneratorStdOutErrCapture,
-                env=env)
-        protocol = self._git_runner.threaded_runner.protocol
-
-        self._line_splitter = LineSplitter(sep)
+        stderr_lines = []
         try:
-            for source, content in generator:
-                if source == "stdout":
-                    yield from self._line_splitter.process(content)
+            if not read_only:
+                self._write_lock.acquire()
 
-            remaining_content = self._line_splitter.finish_processing()
-            if remaining_content is not None:
-                yield remaining_content
+            for file_no, line in self._generator_call_git(
+                                                    args,
+                                                    files=files,
+                                                    env=env,
+                                                    sep=sep):
+                if file_no == STDOUT_FILENO:
+                    yield line.rstrip("\n")
+                else:
+                    stderr_lines.append(line)
 
         except CommandError as e:
-            e.stderr = protocol.fd_infos[protocol.stderr_fileno][1].decode(protocol.encoding)
-            ignored = re.search(GitIgnoreError.pattern, e.stderr)
-            if ignored:
-                raise GitIgnoreError(cmd=e.cmd,
-                                     msg=e.stderr,
-                                     code=e.code,
-                                     stdout=e.stdout,
-                                     stderr=e.stderr,
-                                     paths=ignored.groups()[0].splitlines())
-            lgr.log(11, str(e))
+            e.stderr = "".join(stderr_lines)
+            ignore_exception = self._get_ignore_exception(e)
+            if ignore_exception:
+                raise ignore_exception
+
+            lgr.log(5 if expect_fail else 11, str(e))
             raise
+
         finally:
             if not read_only:
                 self._write_lock.release()
 
-        stderr = protocol.fd_infos[protocol.stderr_fileno][1]
-        if stderr:
-            for line in stderr.decode(protocol.encoding).splitlines():
-                lgr.log(stderr_log_level,
-                        "stderr| " + line.rstrip('\n'))
+        stderr_log_level = {True: 5, False: 11}[expect_stderr]
+        for line in stderr_lines:
+            lgr.log(stderr_log_level, "stderr| " + line.strip("\n"))
 
     def call_git_oneline(self, args, files=None, expect_stderr=False, read_only=False):
         """Call git for a single line of output.

--- a/datalad/dataset/tests/test_gitrepo.py
+++ b/datalad/dataset/tests/test_gitrepo.py
@@ -246,7 +246,7 @@ def test_gitrepo_call_git_methods(path):
     eq_(list(gr.call_git_items_(["ls-files", "-z"], sep="\0", read_only=True)),
         # Note: The custom separator has trailing empty item, but this is an
         # arbitrary command with unknown output it isn't safe to trim it.
-        ["bar", "foo.txt", ""])
+        ["bar", "foo.txt"])
 
     with assert_raises(AssertionError):
         gr.call_git_oneline(["ls-files"], read_only=True)

--- a/datalad/runner/utils.py
+++ b/datalad/runner/utils.py
@@ -80,7 +80,7 @@ class LineSplitter:
             detected_lines = self.remaining_data.split(self.separator)
 
             # If replaced data did not end with the separator, it contains an
-            # unterminated line. We save that for the next round. Otherwise
+            # unterminated line. We save that for the next round. Otherwise,
             # we mark that we do not have remaining data.
             if not data.endswith(self.separator):
                 self.remaining_data = detected_lines[-1]

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1246,7 +1246,7 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         remaining_content = line_splitter.finish_processing()
         if remaining_content is not None:
-            yield remaining_content + os.linesep
+            yield remaining_content
 
     def call_annex_oneline(self, args, files=None):
         """Call annex for a single line of output.

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -419,13 +419,13 @@ class GitProgress(WitlessProtocol):
             )
         super().process_exited()
 
-    def pipe_data_received(self, fd, byts):
+    def pipe_data_received(self, fd, bytes):
         # progress reports only come from stderr
         if fd != 2:
             # let the base class decide what to do with it
-            super().pipe_data_received(fd, byts)
+            super().pipe_data_received(fd, bytes)
             return
-        for line in byts.splitlines(keepends=True):
+        for line in bytes.splitlines(keepends=True):
             # put any unprocessed content back in front
             line = self._unprocessed + line if self._unprocessed else line
             self._unprocessed = None

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -419,13 +419,13 @@ class GitProgress(WitlessProtocol):
             )
         super().process_exited()
 
-    def pipe_data_received(self, fd, bytes):
+    def pipe_data_received(self, fd, byts):
         # progress reports only come from stderr
         if fd != 2:
             # let the base class decide what to do with it
-            super().pipe_data_received(fd, bytes)
+            super().pipe_data_received(fd, byts)
             return
-        for line in bytes.splitlines(keepends=True):
+        for line in byts.splitlines(keepends=True):
             # put any unprocessed content back in front
             line = self._unprocessed + line if self._unprocessed else line
             self._unprocessed = None

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -1518,9 +1518,7 @@ def test_gitrepo_call_git_methods(path):
     eq_(list(gr.call_git_items_(["ls-files"], read_only=True)),
         ["bar", "foo.txt"])
     eq_(list(gr.call_git_items_(["ls-files", "-z"], sep="\0", read_only=True)),
-        # Note: The custom separator has trailing empty item, but this is an
-        # arbitrary command with unknown output it isn't safe to trim it.
-        ["bar", "foo.txt", ""])
+        ["bar", "foo.txt"])
 
     with assert_raises(AssertionError):
         gr.call_git_oneline(["ls-files"], read_only=True)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1501,6 +1501,18 @@ def disable_logger(logger=None):
         [h.removeFilter(filter_) for h in logger.handlers]
 
 
+@contextmanager
+def lock_if_required(lock_required, lock):
+    """ Acquired and released the provided lock if indicated by a flag"""
+    if lock_required:
+        lock.acquire()
+    try:
+        yield lock
+    finally:
+        if lock_required:
+            lock.release()
+
+
 #
 # Additional handlers
 #


### PR DESCRIPTION
This PR uses a generator-based runner to, i.e. a runner with a `GeneratorMixIn`-Protocol subclass, to implement `GitRepo.call_git_items_()`.

This is a follow up to PR #6244, especially the following reviewer comment: https://github.com/datalad/datalad/pull/6244#discussion_r760831590

The interface of  `GitRepo.call_git_items_()` does not change, but results will be yielded as soon as they are available.
