### PR TITLE
ENH: Add parallel jobs options for `run` and `rerun` (applies to get, save)

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -266,6 +266,10 @@ class Run(Interface):
             constraints=EnsureChoice(None, "basic", "command")),
         jobs=jobs_opt
     )
+    _params_['jobs']._doc += """\
+        NOTE: This option can only parallelize input retrieval (get) and output
+        recording (save). DataLad does NOT parallelize your scripts for you.
+    """
 
     @staticmethod
     @datasetmethod(name='run')

--- a/datalad/local/rerun.py
+++ b/datalad/local/rerun.py
@@ -38,6 +38,8 @@ from datalad.interface.base import (
 )
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
+from datalad.interface.common_opts import jobs_opt
+
 from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,
@@ -168,6 +170,7 @@ class Rerun(Interface):
             every one. Care should also be taken when using [CMD: --onto
             CMD][PY: `onto` PY] because checking out a new HEAD can easily fail
             when the working tree has modifications."""),
+        jobs=jobs_opt
     )
 
     _examples_ = [
@@ -204,7 +207,8 @@ class Rerun(Interface):
             script=None,
             report=False,
             assume_ready=None,
-            explicit=False):
+            explicit=False,
+            jobs=None):
 
         ds = require_dataset(
             dataset, check_installed=True,
@@ -268,7 +272,7 @@ class Rerun(Interface):
             handler = _report
         else:
             handler = partial(_rerun, assume_ready=assume_ready,
-                              explicit=explicit)
+                              explicit=explicit, jobs=jobs)
 
         for res in handler(ds, results):
             yield res
@@ -390,7 +394,7 @@ def _mark_nonrun_result(result, which):
     return result
 
 
-def _rerun(dset, results, assume_ready=None, explicit=False):
+def _rerun(dset, results, assume_ready=None, explicit=False, jobs=None):
     ds_repo = dset.repo
     # Keep a map from an original hexsha to a new hexsha created by the rerun
     # (i.e. a reran, cherry-picked, or merged commit).
@@ -517,6 +521,7 @@ def _rerun(dset, results, assume_ready=None, explicit=False):
                                  explicit=explicit,
                                  rerun_outputs=auto_outputs,
                                  message=message,
+                                 jobs=jobs,
                                  rerun_info=run_info):
                 yield r
         new_head = ds_repo.get_hexsha()


### PR DESCRIPTION
Implements #6118 . I have 2 questions.

- [x] How do I edit the docstring for `jobs_opt`? I think we need to make it clear that the parallelization only applies to input `get` and output `save`, or some people might get the idea that datalad can parallelize scripts for them.
- [ ] How do we test this option? It seems like the `ProducerConsumer` class for general parallelization is tested, but not the specific parallel options for `get` and `save`.