### PR TITLE
Stop swallowing to-be-rendered results based on prior logging assumption

### DIFF
--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -31,7 +31,10 @@ from datalad.interface.common_opts import (
     recursion_limit,
     recursion_flag,
 )
-from datalad.interface.utils import eval_results
+from datalad.interface.utils import (
+    eval_results,
+    generic_result_renderer,
+)
 import datalad.support.ansi_colors as ac
 from datalad.support.param import Parameter
 from datalad.support.constraints import (
@@ -418,10 +421,13 @@ class Status(Interface):
 
     @staticmethod
     def custom_result_renderer(res, **kwargs):  # pragma: more cover
-        if not (res['status'] == 'ok'
-                and res['action'] in ('status', 'diff')
-                and res.get('state', None) != 'clean'):
-            # logging reported already
+        if (res['status'] == 'ok' and res['action'] in ('status', 'diff')
+                and res.get('state') == 'clean'):
+            # this renderer will be silent for clean status|diff results
+            return
+        if res['status'] != 'ok' or res['action'] not in ('status', 'diff'):
+            # whatever this renderer cannot account for, send to generic
+            generic_result_renderer(res)
             return
         from datalad.ui import ui
         # when to render relative paths:

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -482,11 +482,7 @@ class RunProcedure(Interface):
         from datalad.interface.utils import generic_result_renderer
         from datalad.ui import ui
 
-        if res['status'] != 'ok':
-            # logging complained about this already
-            return
-
-        if 'procedure' not in res.get('action', ''):
+        if res['status'] != 'ok' or 'procedure' not in res.get('action', ''):
             # it's not our business
             generic_result_renderer(res)
             return

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -24,7 +24,10 @@ from datalad import cfg
 from datalad.interface.annotate_paths import _minimal_annotate_paths
 from datalad.interface.base import Interface
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
+from datalad.interface.utils import (
+    eval_results,
+    generic_result_renderer,
+)
 from datalad.interface.base import build_doc
 from datalad.metadata.definitions import version as vocabulary_version
 from datalad.support.collections import ReadOnlyDict, _val2hashable
@@ -1001,7 +1004,7 @@ class Metadata(Interface):
     @staticmethod
     def custom_result_renderer(res, **kwargs):
         if res['status'] != 'ok' or not res.get('action', None) == 'metadata':
-            # logging complained about this already
+            generic_result_renderer(res)
             return
         # list the path, available metadata keys, and tags
         path = op.relpath(res['path'],


### PR DESCRIPTION
Unless when assuming a default configuration (and no code changes over
time), it is not reliable to count on a result-related message to reach
a user via a logging channel vs. a result record.

Commands already *must* emit results to make outside-control possible,
and connect to features, such as result-hooks. Therefore, results have
to be considered to primary mode of reporting.

Taken together, all results must be processed, also by result renderers
-- whether or not a log message corresponding to them was also emitted.

Eventual double-reporting must be addressed by other means than
swallowing results in renderers.

This change addresses this demand for three commands, by falling back on
the generic result renderer, whenever their tailored one would have
rejected a result before.

Fixes datalad/datalad#3953