### PR TITLE
Add a missing import of CapturedException

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -53,6 +53,7 @@ from datalad.runner.protocol import GeneratorMixIn
 from datalad.runner.utils import LineSplitter
 # must not be loads, because this one would log, and we need to log ourselves
 from datalad.support.json_py import json_loads
+from datalad.support.exceptions import CapturedException
 from datalad.ui import ui
 import datalad.utils as ut
 from datalad.utils import (

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2597,3 +2597,14 @@ def test_generator_annex_json_protocol():
             break
         count += 1
         stdin_queue.put(json_object(count=count))
+
+
+def test_captured_exception():
+    class RaiseMock:
+        def add_(self, *args, **kwargs):
+            raise CommandError("RaiseMock.add_")
+
+    with patch("datalad.support.annexrepo.super") as repl_super:
+        repl_super.return_value = RaiseMock()
+        gen = AnnexRepo.add_(object(), [])
+        assert_raises(CommandError, gen.send, None)


### PR DESCRIPTION
Fix an issue where a missing import would break exception handling during AnnexRepo.add_()

- [X] add import of CapturedException
- [X] add regression test to ensure correct exception path
