### PR TITLE
Bump the python version used for mac os tests

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -22,10 +22,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     
     - name: Install git-annex
       run: |
@@ -33,7 +33,6 @@ jobs:
         datalad-installer --sudo ok -E new.env git-annex -m ${{ matrix.install_scenario }}
         . new.env
         echo "PATH=$PATH" >> "$GITHUB_ENV"
-
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Use python 3.7 on Mac OS tests, since python 3.6. is no longer supported