### PR TITLE
BF: RIARemote - set UI backend to annex to make it interactive

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1425,7 +1425,9 @@ def _sanitize_key(key):
 def main():
     """cmdline entry point"""
     from annexremote import Master
+    from datalad.ui import ui
     master = Master()
     remote = RIARemote(master)
+    ui.set_backend('annex')  # interactive, stdin/stdout will be used for interactions with annex
     master.LinkRemote(remote)
     master.Listen()


### PR DESCRIPTION
Otherwise our UI would consider session non interactive and would not
prompt for credentials etc.

Closes #5790

This replaces #5825, as I could confirm (and understand) that this change is sufficient.
`set_specialremote` as mentioned in https://github.com/datalad/datalad/pull/5825#discussion_r676778558 seems to only be relevant for progressbars, which is of no concern for ORA ATM, since we simply report to annex.
Rebased,  and filed this PR from my fork, since I can't push to @yarikoptic's.