### PR TITLE
DOC: Update examples in create_sibling_gin

### DIFF
--- a/datalad/distributed/create_sibling_gin.py
+++ b/datalad/distributed/create_sibling_gin.py
@@ -91,12 +91,16 @@ class CreateSiblingGin(Interface):
              code_py="""\
                  > ds = Dataset('.')
                  > ds.create_sibling_gin('myrepo', name='gin')
+                 # first push creates git-annex branch remotely and obtains annex UUID
+                 > ds.push(to='gin')
                  > ds.siblings('configure', name='gin', as_common_datasrc='gin-storage')
                  # announce availability (redo for other siblings)
                  > ds.push(to='gin')
                  """,
              code_cmd="""\
                  % datalad create-sibling-gin myrepo -s gin
+                 # first push creates git-annex branch remotely and obtains annex UUID
+                 % datalad push --to gin
                  % datalad siblings configure -s gin --as-common-datasrc gin-storage
                  # announce availability (redo for other siblings)
                  % datalad push --to gin


### PR DESCRIPTION
This is a small change. The example demonstrating how to create a sibling repo on GIN and register it as a common data source now suggests `push` as an additional step before `configure` to create git-annex branch remotely and obtain annex UUID. Otherwise, configuration would not happen properly. Addresses part of #6269