### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -14,28 +14,14 @@ from io import StringIO
 from unittest.mock import patch
 
 import datalad
-from ..main import (
-    _fix_datalad_ri,
-    main,
-)
-from ..helpers import fail_with_short_help
 from datalad import __version__
-from datalad.cmd import (
-    WitlessRunner as Runner,
-    StdOutErrCapture,
-)
-from datalad.ui.utils import (
-    get_console_width,
-    get_terminal_size,
-)
 from datalad.api import (
-    create,
     Dataset,
+    create,
 )
-from datalad.utils import (
-    chpwd,
-    Path,
-)
+from datalad.cmd import StdOutErrCapture
+from datalad.cmd import WitlessRunner as Runner
+from datalad.support.exceptions import CommandError
 from datalad.tests.utils import (
     SkipTest,
     assert_equal,
@@ -50,7 +36,20 @@ from datalad.tests.utils import (
     slow,
     with_tempfile,
 )
-from datalad.support.exceptions import CommandError
+from datalad.ui.utils import (
+    get_console_width,
+    get_terminal_size,
+)
+from datalad.utils import (
+    Path,
+    chpwd,
+)
+
+from ..helpers import fail_with_short_help
+from ..main import (
+    _fix_datalad_ri,
+    main,
+)
 
 
 def run_main(args, exit_code=0, expect_stderr=False):
@@ -116,7 +115,7 @@ def test_help_np():
     # enough of bin/datalad and .tox/py27/bin/datalad -- guarantee consistency! ;)
     ok_startswith(stdout, 'Usage: datalad')
     # Sections start/end with * if ran under DATALAD_HELP2MAN mode
-    sections = [l[1:-1] for l in filter(re.compile('^\*.*\*$').match, stdout.split('\n'))]
+    sections = [l[1:-1] for l in filter(re.compile(r'^\*.*\*$').match, stdout.split('\n'))]
     # but order is still not guaranteed (dict somewhere)! TODO
     # see https://travis-ci.org/datalad/datalad/jobs/80519004
     # thus testing sets

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -12,10 +12,11 @@
 from os.path import isabs
 
 from datalad.api import (
-    clone,
     Dataset,
+    clone,
 )
 from datalad.consts import DATALAD_SPECIAL_REMOTE
+from datalad.support.annexrepo import AnnexRepo
 from datalad.tests.utils import (
     assert_false,
     assert_in,
@@ -26,13 +27,12 @@ from datalad.tests.utils import (
     with_tempfile,
     with_tree,
 )
-from datalad.support.annexrepo import AnnexRepo
 from datalad.utils import Path
 
 from ..base import (
-    AnnexCustomRemote,
     DEFAULT_AVAILABILITY,
     DEFAULT_COST,
+    AnnexCustomRemote,
     ensure_datalad_remote,
     init_datalad_remote,
 )
@@ -127,7 +127,8 @@ def check_interaction_scenario(remote_class, tdir, scenario):
 
 
 import re
-ERROR_ARGS = re.compile('ERROR .*(missing|takes) .*\d+ .*argument')
+
+ERROR_ARGS = re.compile(r'ERROR .*(missing|takes) .*\d+ .*argument')
 BASE_INTERACTION_SCENARIOS = [
     [],  # default of doing nothing
     [  # support of EXPORT which by default is not supported

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -8,13 +8,12 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for the universal datalad's annex customremote"""
 
-from ...support.annexrepo import AnnexRepo
 from ...consts import DATALAD_SPECIAL_REMOTE
-from ...tests.utils import *
-from ...support.external_versions import external_versions
-
-from ...support.exceptions import CommandError
 from ...downloaders.tests.utils import get_test_providers
+from ...support.annexrepo import AnnexRepo
+from ...support.exceptions import CommandError
+from ...support.external_versions import external_versions
+from ...tests.utils import *
 from ..datalad import DataladAnnexCustomRemote
 
 
@@ -76,7 +75,10 @@ def test_basic_scenario_s3():
 
 
 
-from .test_base import BASE_INTERACTION_SCENARIOS, check_interaction_scenario
+from .test_base import (
+    BASE_INTERACTION_SCENARIOS,
+    check_interaction_scenario,
+)
 
 
 @with_tree(tree={}) #'archive.tar.gz': {'f1.txt': 'content'}})
@@ -92,7 +94,7 @@ def test_interactions(tdir):
     fetch_scenarios.append(
         ('VALUE',
          re.compile(
-             'TRANSFER-FAILURE RETRIEVE somekey RuntimeError\(Failed to download from any')))
+             r'TRANSFER-FAILURE RETRIEVE somekey RuntimeError\(Failed to download from any')))
 
     for scenario in BASE_INTERACTION_SCENARIOS + [
         [

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -8,15 +8,21 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for http downloader"""
 
+import builtins
+import os
+import re
 import time
 from calendar import timegm
-import re
-
-import os
-import builtins
 from os.path import join as opj
 
 from datalad.downloaders.tests.utils import get_test_providers
+from datalad.support.network import (
+    download_url,
+    get_url_straight_filename,
+)
+from datalad.utils import ensure_unicode
+
+from ...support.exceptions import AccessFailedError
 from ..base import (
     BaseDownloader,
     DownloadError,
@@ -31,17 +37,9 @@ from ..credentials import (
 from ..http import (
     HTMLFormAuthenticator,
     HTTPBaseAuthenticator,
-    HTTPDownloader,
     HTTPBearerTokenAuthenticator,
+    HTTPDownloader,
     process_www_authenticate,
-)
-from ...support.exceptions import AccessFailedError
-from datalad.support.network import (
-    download_url,
-    get_url_straight_filename,
-)
-from datalad.utils import (
-    ensure_unicode,
 )
 
 # BTW -- mock_open is not in mock on wheezy (Debian 7.x)
@@ -56,6 +54,13 @@ except (ImportError, AttributeError):
     httpretty = NoHTTPPretty()
 
 from unittest.mock import patch
+
+from ...support.exceptions import (
+    AccessDeniedError,
+    AnonymousAccessDeniedError,
+)
+from ...support.network import get_url_disposition_filename
+from ...support.status import FileStatus
 from ...tests.utils import (
     SkipTest,
     assert_equal,
@@ -66,7 +71,7 @@ from ...tests.utils import (
     assert_raises,
     known_failure_githubci_win,
     ok_file_has_content,
-    serve_path_via_http, with_tree,
+    serve_path_via_http,
     skip_if,
     skip_if_no_network,
     swallow_logs,
@@ -76,14 +81,9 @@ from ...tests.utils import (
     with_memory_keyring,
     with_tempfile,
     with_testsui,
+    with_tree,
     without_http_proxy,
 )
-from ...support.exceptions import (
-    AccessDeniedError,
-    AnonymousAccessDeniedError,
-)
-from ...support.status import FileStatus
-from ...support.network import get_url_disposition_filename
 from ...utils import read_file
 
 
@@ -170,7 +170,7 @@ def test_HTTPDownloader_basic(toppath, topurl):
     # and it still results in some warning being spit out
     # Note: we need to avoid mocking opening of the lock file!
     with swallow_logs(), \
-         patch.object(builtins, 'open', fake_open(write_=_raise_IOError, skip_regex='.*\.lck$')):
+         patch.object(builtins, 'open', fake_open(write_=_raise_IOError, skip_regex=r'.*\.lck$')):
         assert_raises(DownloadError, download, furl, tfpath, overwrite=True)
 
     # incomplete download scenario - should have 3 tries

--- a/datalad/downloaders/tests/test_providers.py
+++ b/datalad/downloaders/tests/test_providers.py
@@ -8,29 +8,32 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for data providers"""
 
-import os.path as op
-
 import logging
-
+import os.path as op
 from unittest.mock import patch
 
-from ..providers import Provider
-from ..providers import Providers
-from ..providers import HTTPDownloader
-from ...utils import chpwd
-from ...utils import create_tree
-from ...tests.utils import assert_in
-from ...tests.utils import assert_false
-from ...tests.utils import assert_greater
-from ...tests.utils import assert_equal
-from ...tests.utils import assert_raises
-from ...tests.utils import ok_exists
-from ...tests.utils import swallow_logs
-from ...tests.utils import with_tempfile
-from ...tests.utils import with_tree
-from ...tests.utils import with_testsui
-
 from ...support.external_versions import external_versions
+from ...tests.utils import (
+    assert_equal,
+    assert_false,
+    assert_greater,
+    assert_in,
+    assert_raises,
+    ok_exists,
+    swallow_logs,
+    with_tempfile,
+    with_testsui,
+    with_tree,
+)
+from ...utils import (
+    chpwd,
+    create_tree,
+)
+from ..providers import (
+    HTTPDownloader,
+    Provider,
+    Providers,
+)
 
 
 def test_Providers_OnStockConfiguration():
@@ -103,19 +106,19 @@ def test_get_downloader_class():
 @with_tree(tree={
   'providers': {'atest.cfg':"""\
 [provider:syscrcns]
-url_re = https?://crcns\.org/.*
+url_re = https?://crcns\\.org/.*
 authentication_type = none
 """}})
 @with_tree(tree={
   'providers': {'atestwithothername.cfg':"""\
 [provider:usercrcns]
-url_re = https?://crcns\.org/.*
+url_re = https?://crcns\\.org/.*
 authentication_type = none
 """}})
 @with_tree(tree={
   '.datalad': {'providers': {'atest.cfg':"""\
 [provider:dscrcns]
-url_re = https?://crcns\.org/.*
+url_re = https?://crcns\\.org/.*
 authentication_type = none
 """}},
    '.git': { "HEAD" : ""}})
@@ -164,7 +167,7 @@ def test_providers_enter_new(path):
         providers = Providers.from_config_files(reload=True)
 
         url = "blah://thing"
-        url_re = "blah:\/\/.*"
+        url_re = r"blah:\/\/.*"
         auth_type = "http_auth"
         creds = "user_password"
 
@@ -212,11 +215,11 @@ def test_providers_enter_new(path):
 
 @with_tree(tree={'providers.cfg': """\
 [provider:foo0]
-url_re = https?://foo\.org/.*
+url_re = https?://foo\\.org/.*
 authentication_type = none
 
 [provider:foo1]
-url_re = https?://foo\.org/.*
+url_re = https?://foo\\.org/.*
 authentication_type = none
 """})
 def test_providers_multiple_matches(path):
@@ -232,11 +235,11 @@ def test_providers_multiple_matches(path):
 
 @with_tree(tree={'providers.cfg': """\
 [provider:foo0]
-url_re = https?://[foo-a\.org]/.*
+url_re = https?://[foo-a\\.org]/.*
 authentication_type = none
 
 [provider:foo1]
-url_re = https?://foo\.org/.*
+url_re = https?://foo\\.org/.*
 authentication_type = none
 """})
 def test_providers_badre(path):

--- a/datalad/interface/tests/test_add_archive_content.py
+++ b/datalad/interface/tests/test_add_archive_content.py
@@ -13,16 +13,31 @@
 __docformat__ = 'restructuredtext'
 
 import os
+from glob import glob
 from os import unlink
 from os.path import (
     basename,
     exists,
-    join as opj,
+)
+from os.path import join as opj
+from os.path import (
     lexists,
     pardir,
 )
-from glob import glob
 
+from datalad.api import (
+    add_archive_content,
+    clean,
+)
+from datalad.consts import (
+    ARCHIVES_SPECIAL_REMOTE,
+    DATALAD_SPECIAL_REMOTES_UUIDS,
+)
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import (
+    CommandError,
+    FileNotInRepositoryError,
+)
 from datalad.tests.utils import (
     assert_cwd_unchanged,
     assert_equal,
@@ -47,12 +62,6 @@ from datalad.tests.utils import (
     with_tempfile,
     with_tree,
 )
-
-from datalad.support.annexrepo import AnnexRepo
-from datalad.support.exceptions import (
-    CommandError,
-    FileNotInRepositoryError,
-)
 from datalad.utils import (
     chpwd,
     find_files,
@@ -60,15 +69,6 @@ from datalad.utils import (
     on_windows,
     rmtemp,
 )
-from datalad.api import (
-    add_archive_content,
-    clean,
-)
-from datalad.consts import (
-    ARCHIVES_SPECIAL_REMOTE,
-    DATALAD_SPECIAL_REMOTES_UUIDS,
-)
-
 
 treeargs = dict(
     tree=(
@@ -563,7 +563,7 @@ class TestAddArchiveOptions():
 
     def assert_no_trash_left_behind(self):
         assert_equal(
-            list(find_files('\.datalad..*', self.annex.path, dirs=True)),
+            list(find_files(r'\.datalad..*', self.annex.path, dirs=True)),
             []
         )
 

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -10,49 +10,50 @@
 """Some additional tests for search command (some are within test_base)"""
 
 import logging
-from shutil import copy
-from unittest.mock import patch, MagicMock
 import os
 from os import makedirs
-from os.path import (
-    dirname,
-    join as opj,
+from os.path import dirname
+from os.path import join as opj
+from shutil import copy
+from unittest.mock import (
+    MagicMock,
+    patch,
 )
 
 from pkg_resources import EntryPoint
 
-from datalad.api import Dataset
-from datalad.utils import (
-    chpwd,
-    swallow_logs,
-    swallow_outputs,
+from datalad.api import (
+    Dataset,
+    search,
 )
+from datalad.support.exceptions import NoDatasetFound
 from datalad.tests.utils import (
+    SkipTest,
     assert_equal,
     assert_in,
-    assert_re_in,
     assert_is_generator,
     assert_raises,
+    assert_re_in,
     assert_repo_status,
     assert_result_count,
     eq_,
     known_failure_githubci_win,
     ok_file_under_git,
     patch_config,
-    SkipTest,
     with_tempfile,
     with_testsui,
 )
-from datalad.support.exceptions import NoDatasetFound
+from datalad.utils import (
+    chpwd,
+    swallow_logs,
+    swallow_outputs,
+)
 
-from datalad.api import search
-
+from ..indexers.base import MetadataIndexer
 from ..search import (
     _listdict2dictlist,
     _meta2autofield_dict,
 )
-
-from ..indexers.base import MetadataIndexer
 
 
 @with_testsui(interactive=False)
@@ -235,7 +236,7 @@ type
 
     # test default behavior while limiting set of keys reported
     with swallow_outputs() as cmo:
-        ds.search(['\.id', 'artist$'], show_keys='short')
+        ds.search([r'\.id', 'artist$'], show_keys='short')
         out_lines = [l for l in cmo.out.split(os.linesep) if l]
         # test that only the ones matching were returned
         assert_equal(
@@ -291,7 +292,7 @@ type
          {'audio.format': 'mp3'}),
         # field selection by expression
         ('egrep',
-         'audio\.+:mp3',
+         r'audio\.+:mp3',
          opj('stim', 'stim1.mp3'),
          {'audio.format': 'mp3'}),
         # random keyword query

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -1,8 +1,13 @@
 from unittest.mock import patch
-from nose.tools import assert_equal, assert_true
+
+from nose.tools import (
+    assert_equal,
+    assert_true,
+)
+
+from datalad import cfg
 from datalad.support.exceptions import CapturedException
 from datalad.tests.utils import assert_re_in
-from datalad import cfg
 
 
 def test_CapturedException():
@@ -12,15 +17,15 @@ def test_CapturedException():
     except Exception as e:
         captured_exc = CapturedException(e)
 
-    assert_re_in("BOOM \[test_captured_exception.py:test_CapturedException:[0-9]+\]", captured_exc.format_oneline_tb())
-    assert_re_in("^\[.*\]", captured_exc.format_oneline_tb(include_str=False))  # only traceback
+    assert_re_in(r"BOOM \[test_captured_exception.py:test_CapturedException:[0-9]+\]", captured_exc.format_oneline_tb())
+    assert_re_in(r"^\[.*\]", captured_exc.format_oneline_tb(include_str=False))  # only traceback
 
     try:
         raise NotImplementedError
     except Exception as e:
         captured_exc = CapturedException(e)
 
-    assert_re_in("NotImplementedError \[test_captured_exception.py:test_CapturedException:[0-9]+\]", captured_exc.format_oneline_tb())
+    assert_re_in(r"NotImplementedError \[test_captured_exception.py:test_CapturedException:[0-9]+\]", captured_exc.format_oneline_tb())
 
     def f():
         def f2():
@@ -52,10 +57,10 @@ def test_CapturedException():
 
     estr_full = captured_exc.format_oneline_tb(10)
 
-    assert_re_in("new message \[test_captured_exception.py:test_CapturedException:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr_full)
-    assert_re_in("new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr3)
-    assert_re_in("new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr2)
-    assert_re_in("new message \[test_captured_exception.py:f2:[0-9]+\]", estr1)
+    assert_re_in(r"new message \[test_captured_exception.py:test_CapturedException:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr_full)
+    assert_re_in(r"new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr3)
+    assert_re_in(r"new message \[test_captured_exception.py:f:[0-9]+,test_captured_exception.py:f2:[0-9]+\]", estr2)
+    assert_re_in(r"new message \[test_captured_exception.py:f2:[0-9]+\]", estr1)
     # default: no limit:
     assert_equal(estr_, estr_full)
 

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -300,8 +300,8 @@ def test_url_samples():
     _check_ri('weird_url:/', SSHRI, hostname='weird_url', path='/')
     _check_ri('example.com:/', SSHRI, hostname='example.com', path='/')
     _check_ri('example.com:path/sp1', SSHRI, hostname='example.com', path='path/sp1')
-    _check_ri('example.com/path/sp1\:fname', PathRI, localpath='example.com/path/sp1\:fname',
-              path='example.com/path/sp1\:fname')
+    _check_ri('example.com/path/sp1\\:fname', PathRI, localpath='example.com/path/sp1\\:fname',
+              path='example.com/path/sp1\\:fname')
     # ssh is as stupid as us, so we will stay "Consistently" dumb
     """
     $> ssh example.com/path/sp1:fname

--- a/datalad/support/tests/test_versions.py
+++ b/datalad/support/tests/test_versions.py
@@ -7,54 +7,56 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from ..versions import get_versions
+from collections import OrderedDict as od
+
+from datalad.support.status import FileStatus
 from datalad.tests.utils import (
     assert_equal,
     assert_raises,
 )
-from datalad.support.status import FileStatus
-from collections import OrderedDict as od
+
+from ..versions import get_versions
 
 
 def test_get_versions_regex():
     # test matching of the version
     fn = 'f_r1.0_buga'
     # no versioneer, so version is left as the full match
-    assert_equal(get_versions([fn], '_r\d+[.\d]*_'), od([('_r1.0_', {'fbuga': fn})]))
+    assert_equal(get_versions([fn], r'_r\d+[.\d]*_'), od([('_r1.0_', {'fbuga': fn})]))
     # use versioneer to tune it up
-    assert_equal(get_versions([fn], '_r\d+[.\d]*_', versioneer=lambda f, v, *args: v.strip('_r')), od([('1.0', {'fbuga': fn})]))
+    assert_equal(get_versions([fn], r'_r\d+[.\d]*_', versioneer=lambda f, v, *args: v.strip('_r')), od([('1.0', {'fbuga': fn})]))
     # use group
-    assert_equal(get_versions([fn], '_r(\d+[.\d]*)_'), od([('1.0', {'fbuga': fn})]))
+    assert_equal(get_versions([fn], r'_r(\d+[.\d]*)_'), od([('1.0', {'fbuga': fn})]))
     # and now non memorizing lookup for the trailing _ which then would leave it for the fpath
-    assert_equal(get_versions([fn], '_r(\d+[.\d]*)(?=_)'), od([('1.0', {'f_buga': fn})]))
+    assert_equal(get_versions([fn], r'_r(\d+[.\d]*)(?=_)'), od([('1.0', {'f_buga': fn})]))
     # multiple groups
     # if no version group -- fail!
     with assert_raises(ValueError):
-        assert_equal(get_versions([fn], '(_r(\d+[.\d]*))(?=_)'), od([('1.0', {'f_buga': fn})]))
-    assert_equal(get_versions([fn], '(_r(?P<version>\d+[.\d]*))(?=_)'), od([('1.0', {'f_buga': fn})]))
+        assert_equal(get_versions([fn], r'(_r(\d+[.\d]*))(?=_)'), od([('1.0', {'f_buga': fn})]))
+    assert_equal(get_versions([fn], r'(_r(?P<version>\d+[.\d]*))(?=_)'), od([('1.0', {'f_buga': fn})]))
     # add subdirectory
-    assert_equal(get_versions(['d1/d2/' + fn], '(_r(?P<version>\d+[.\d]*))(?=_)'), od([('1.0', {'d1/d2/f_buga': 'd1/d2/'+fn})]))
+    assert_equal(get_versions(['d1/d2/' + fn], r'(_r(?P<version>\d+[.\d]*))(?=_)'), od([('1.0', {'d1/d2/f_buga': 'd1/d2/'+fn})]))
 
 
 def test_get_versions():
-    assert_equal(get_versions(['f1'], '\d+'), od([('1', {'f': 'f1'})]))
-    assert_equal(get_versions(['f1', 'f2'], '\d+'), od([('1', {'f': 'f1'}), ('2', {'f': 'f2'})]))
+    assert_equal(get_versions(['f1'], r'\d+'), od([('1', {'f': 'f1'})]))
+    assert_equal(get_versions(['f1', 'f2'], r'\d+'), od([('1', {'f': 'f1'}), ('2', {'f': 'f2'})]))
     # with default overlay=True, we should get both versions of two similar files in different subdirs
     # since we operate at the level of the entire path.  note lookbehind assertion in regex to avoid matching d
-    assert_equal(get_versions(['d1/f1', 'd2/f2'], '(?<=f)\d+'), od([('1', {'d1/f': 'd1/f1'}), ('2', {'d2/f': 'd2/f2'})]))
+    assert_equal(get_versions(['d1/f1', 'd2/f2'], r'(?<=f)\d+'), od([('1', {'d1/f': 'd1/f1'}), ('2', {'d2/f': 'd2/f2'})]))
 
     # lets make a complex one with non versioned etc
-    assert_equal(get_versions(['un', 'd1/f1', 'd1/f2', 'd2/f2'], '(?<=f)\d+'),
+    assert_equal(get_versions(['un', 'd1/f1', 'd1/f2', 'd2/f2'], r'(?<=f)\d+'),
                  od([(None, {'un': 'un'}), ('1', {'d1/f': 'd1/f1'}), ('2', {'d1/f': 'd1/f2', 'd2/f': 'd2/f2'})]))
 
     # but if there is a conflict with unversioned -- fail!
     with assert_raises(ValueError):
-        get_versions(['d1/f', 'd1/f1', 'd1/f2', 'd2/f2'], '(?<=f)\d+')
+        get_versions(['d1/f', 'd1/f1', 'd1/f2', 'd2/f2'], r'(?<=f)\d+')
 
     # it should all work as fine if we give statuses although they aren't used atm
     # but they all should be returned back within entries
-    assert_equal(get_versions([('f1', None)], '\d+'), od([('1', {'f': ('f1', None)})]))
-    assert_equal(get_versions(['un', ('d1/f1', None), 'd1/f2', 'd2/f2'], '(?<=f)\d+'),
+    assert_equal(get_versions([('f1', None)], r'\d+'), od([('1', {'f': ('f1', None)})]))
+    assert_equal(get_versions(['un', ('d1/f1', None), 'd1/f2', 'd2/f2'], r'(?<=f)\d+'),
                  od([(None, {'un': 'un'}), ('1', {'d1/f': ('d1/f1', None)}), ('2', {'d1/f': 'd1/f2', 'd2/f': 'd2/f2'})]))
 
 
@@ -65,7 +67,7 @@ def test_get_versions_openfmri_dropped_models():
               'ds017A_R1.1.0_raw.tgz',
               'ds017A_models.tgz', 'ds017A_raw.tgz']
     versions = get_versions(
-        staged, regex='_R(?P<version>\d+[\.\d]*)(?=[\._])',
+        staged, regex=r'_R(?P<version>\d+[\.\d]*)(?=[\._])',
         always_versioned='ds0.*',
         unversioned='default', default='1.0.0')
     target_versions = od([
@@ -81,30 +83,30 @@ def test_get_versions_openfmri_dropped_models():
 
 def test_get_versions_default_version():
     # by default we raise exception if conflict was detected
-    assert_raises(ValueError, get_versions, ['f1', 'f'], '\d+')
+    assert_raises(ValueError, get_versions, ['f1', 'f'], r'\d+')
     # but for default default_version we would need mtime, so raising another one again
-    assert_raises(ValueError, get_versions, ['f1', 'f'], '\d+', unversioned='default')
+    assert_raises(ValueError, get_versions, ['f1', 'f'], r'\d+', unversioned='default')
     fstatus = FileStatus(mtime=1456495187)
-    assert_equal(get_versions(['f1', ('f', fstatus)], '\d+', unversioned='default'),
+    assert_equal(get_versions(['f1', ('f', fstatus)], r'\d+', unversioned='default'),
                  od([('0.0.20160226', {'f': ('f', fstatus)}), ('1', {'f': 'f1'})]))
-    assert_equal(get_versions(['f1', ('f', fstatus)], '\d+', unversioned='default', default='1.0.0'),
+    assert_equal(get_versions(['f1', ('f', fstatus)], r'\d+', unversioned='default', default='1.0.0'),
                  od([('1', {'f': 'f1'}), ('1.0.0', {'f': ('f', fstatus)})]))
     # and we should be able to assign default one which has no % in its default
     # even without mtime
-    assert_equal(get_versions(['f1', 'f'], '\d+', unversioned='default', default='0.0.1'),
+    assert_equal(get_versions(['f1', 'f'], r'\d+', unversioned='default', default='0.0.1'),
                  od([('0.0.1', {'f': 'f'}), ('1', {'f': 'f1'})]))
 
     # if default is specified but not unversioned -- the same
-    assert_equal(get_versions(['f1', 'f'], '\d+', default='0.0.1'),
+    assert_equal(get_versions(['f1', 'f'], r'\d+', default='0.0.1'),
              od([('0.0.1', {'f': 'f'}), ('1', {'f': 'f1'})]))
 
     # and what about always versioned and some which do not have to be versioned?
     # test run without forcing
-    assert_equal(get_versions(['README', 'f1', 'f', ('ds', fstatus)], '\d+', default='%Y'),
+    assert_equal(get_versions(['README', 'f1', 'f', ('ds', fstatus)], r'\d+', default='%Y'),
                  od([(None, {'README': 'README', 'ds': ('ds', fstatus)}),
                      ('1', {'f': 'f1'}),
                      ('2016', {'f': 'f'})]))
-    assert_equal(get_versions(['README', 'f1', 'f', ('ds', fstatus)], '\d+', default='%Y', always_versioned='^ds.*'),
+    assert_equal(get_versions(['README', 'f1', 'f', ('ds', fstatus)], r'\d+', default='%Y', always_versioned='^ds.*'),
              od([(None, {'README': 'README'}),
                  ('1', {'f': 'f1'}),
                  ('2016', {'f': 'f', 'ds': ('ds', fstatus)})]))

--- a/datalad/tests/test_archives.py
+++ b/datalad/tests/test_archives.py
@@ -9,39 +9,40 @@
 
 import os
 from unittest.mock import patch
-from datalad.tests.utils import (
-    assert_true,
-    assert_false,
-    assert_raises,
-    eq_,
-    with_tree,
-    with_tempfile,
-    swallow_outputs,
-    on_windows,
-    ok_file_has_content,
-    ok_generator,
-    OBSCURE_FILENAME,
-    SkipTest,
-    skip_if,
-)
 
+from datalad import cfg as dl_cfg
+from datalad.support import path as op
+from datalad.support.archive_utils_patool import unixify_path
 from datalad.support.archives import (
     ArchivesCache,
+    ExtractedArchive,
     compress_files,
     decompress_file,
-    ExtractedArchive,
 )
-from datalad.support.archive_utils_patool import unixify_path
 from datalad.support.exceptions import MissingExternalDependency
 from datalad.support.external_versions import external_versions
-from datalad.support import path as op
-from datalad import cfg as dl_cfg
+from datalad.tests.utils import (
+    OBSCURE_FILENAME,
+    SkipTest,
+    assert_false,
+    assert_raises,
+    assert_true,
+    eq_,
+    ok_file_has_content,
+    ok_generator,
+    on_windows,
+    skip_if,
+    swallow_outputs,
+    with_tempfile,
+    with_tree,
+)
 
 fn_in_archive_obscure = OBSCURE_FILENAME
 fn_archive_obscure = fn_in_archive_obscure.replace('a', 'b')
 # Debian sid version of python (3.7.5rc1) introduced a bug in mimetypes
 # Reported to cPython: https://bugs.python.org/issue38449
 import mimetypes
+
 mimedb = mimetypes.MimeTypes(strict=False)
 if None in mimedb.guess_type(fn_archive_obscure + '.tar.gz'):
     from . import lgr
@@ -249,6 +250,6 @@ def test_get_leading_directory():
     yield _test_get_leading_directory, ea, [op.join('d', 'd2', 'f'), op.join('d', 'd2', 'f2')], op.join('d', 'd2')
     yield _test_get_leading_directory, ea, [op.join('d', 'd2', 'f'), op.join('d', 'd2', 'f2')], 'd', {'depth': 1}
     # with some parasitic files
-    yield _test_get_leading_directory, ea, [op.join('d', 'f'), op.join('._d')], 'd', {'exclude': ['\._.*']}
-    yield _test_get_leading_directory, ea, [op.join('d', 'd1', 'f'), op.join('d', '._d'), '._x'], op.join('d', 'd1'), {'exclude': ['\._.*']}
+    yield _test_get_leading_directory, ea, [op.join('d', 'f'), op.join('._d')], 'd', {'exclude': [r'\._.*']}
+    yield _test_get_leading_directory, ea, [op.join('d', 'd1', 'f'), op.join('d', '._d'), '._x'], op.join('d', 'd1'), {'exclude': [r'\._.*']}
 

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -11,25 +11,23 @@
 import inspect
 import logging
 import os.path
-from os.path import exists
-
 from logging import makeLogRecord
-
+from os.path import exists
 from unittest.mock import patch
 
+from datalad import cfg as dl_cfg
 from datalad.log import (
     ColorFormatter,
     LoggerHelper,
-    log_progress,
     TraceBack,
+    log_progress,
     with_progress,
     with_result_progress,
 )
-from datalad import cfg as dl_cfg
-from datalad.support.constraints import EnsureBool
 from datalad.support import ansi_colors as colors
-
+from datalad.support.constraints import EnsureBool
 from datalad.tests.utils import (
+    SkipTest,
     assert_equal,
     assert_in,
     assert_no_open_files,
@@ -41,7 +39,6 @@ from datalad.tests.utils import (
     ok_generator,
     swallow_logs,
     with_tempfile,
-    SkipTest,
 )
 from datalad.utils import on_windows
 
@@ -69,12 +66,12 @@ def test_logging_to_a_file(dst):
     # do not want to rely on not having race conditions around date/time changes
     # so matching just with regexp
     # (...)? is added to swallow possible traceback logs
-    regex = "\[ERROR\]"
+    regex = r"\[ERROR\]"
     if EnsureBool()(dl_cfg.get('datalad.log.timestamp', False)):
-        regex = "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} " + regex
+        regex = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} " + regex
     if EnsureBool()(dl_cfg.get('datalad.log.vmem', False)):
-        regex += ' RSS/VMS: \S+/\S+( \S+)?\s*'
-    regex += "(\s+\S+\s*)? " + msg
+        regex += r' RSS/VMS: \S+/\S+( \S+)?\s*'
+    regex += r"(\s+\S+\s*)? " + msg
     assert_re_in(regex, line, match=True)
 
     # Python's logger is ok (although not documented as supported) to accept
@@ -150,7 +147,11 @@ def test_filters():
 
 
 def test_traceback():
-    from inspect import currentframe, getframeinfo
+    from inspect import (
+        currentframe,
+        getframeinfo,
+    )
+
     # do not move lines below among themselves -- we rely on consistent line numbers ;)
     tb_line = getframeinfo(currentframe()).lineno + 2
     def rec(tb, n):


### PR DESCRIPTION
The code currently contains a number of invalid escape sequences (mostly escapes of special characters in regexes).  These result in Python emitting DeprecationWarnings, and some future Python version will instead treat them as syntax errors.  This PR fixes them.