### PR TITLE
BF: add positional args delimiter to `foreach_dataset`

### DIFF
--- a/datalad/local/foreach_dataset.py
+++ b/datalad/local/foreach_dataset.py
@@ -197,9 +197,7 @@ class ForEachDataset(Interface):
     @eval_results
     def __call__(
             cmd,
-            # TODO: uncomment
-            # *,
-            # after https://github.com/datalad/datalad/pull/6176 is merged
+            *,
             cmd_type="auto",
             dataset=None,
             state='present',


### PR DESCRIPTION
This PR fixes issue #6302 

The merged `foreach_dataset` was missing the positional argument delimiter, i.e. `*`, in its argument list
