### PR TITLE
Migrate configuration command from mihextras extention

### DIFF
--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -79,6 +79,7 @@ _group_2metadata = (
 _group_3misc = (
     'Miscellaneous commands',
     [
+        ('datalad.local.configuration', 'Configuration'),
         ('datalad.local.wtf', 'WTF'),
         ('datalad.local.clean', 'Clean'),
         ('datalad.local.add_archive_content', 'AddArchiveContent'),

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -83,7 +83,7 @@ definitions = {
                'title': 'Crawler download caching',
                'text': 'Should the crawler cache downloaded files?'}),
         'destination': 'local',
-        'type': bool,
+        'type': EnsureBool(),
     },
     # this is actually used in downloaders, but kept cfg name original
     'datalad.credentials.force-ask': {
@@ -91,7 +91,7 @@ definitions = {
                'title': 'Force (re-)entry of credentials',
                'text': 'Should DataLad prompt for credential (re-)entry? This '
                        'can be used to update previously stored credentials.'}),
-        'type': bool,
+        'type': EnsureBool(),
         'default': False,
     },
     'datalad.externals.nda.dbserver': {

--- a/datalad/local/configuration.py
+++ b/datalad/local/configuration.py
@@ -84,13 +84,26 @@ class Configuration(Interface):
     hence can be used to ship (default and branch-specific) configuration with
     a dataset.
 
-    Any DATALAD_* environment variable is also mapped to a configuration item.
-    Their values take precedence over any other specification. In variable
-    names '_' encodes a '.' in the configuration name, and '__' encodes a '-',
-    such that 'DATALAD_SOME__VAR' is mapped to 'datalad.some-var'.
+    Besides storing configuration settings statically via this command or ``git
+    config``, DataLad also reads any :envvar:`DATALAD_*` environment on process
+    startup or import, and maps it to a configuration item.  Their values take
+    precedence over any other specification. In variable names ``_`` encodes a
+    ``.`` in the configuration name, and ``__`` encodes a ``-``, such that
+    ``DATALAD_SOME__VAR`` is mapped to ``datalad.some-var``.  Additionally, a
+    :envvar:`DATALAD_CONFIG_OVERRIDES_JSON` environment variable is
+    queried, which may contain configuration key-value mappings as a
+    JSON-formatted string of a JSON-object::
 
-    Recursive operation is supported for querying and modifying configuration
-    across a hierarchy of datasets.
+      DATALAD_CONFIG_OVERRIDES_JSON='{"datalad.credential.example_com.user": "jane", ...}'
+
+    This is useful when characters are part of the configuration key that
+    cannot be encoded into an environment variable name. If both individual
+    configuration variables *and* JSON-overrides are used, the former take
+    precedent over the latter, overriding the respective *individual* settings
+    from configurations declared in the JSON-overrides.
+
+    This command supports recursive operation for querying and modifying
+    configuration across a hierarchy of datasets.
     """
     _examples_ = [
         dict(text="Dump the effective configuration, including an annotation for common items",

--- a/datalad/local/configuration.py
+++ b/datalad/local/configuration.py
@@ -155,9 +155,6 @@ class Configuration(Interface):
         # - global and recursion makes no sense
 
         if action == 'dump':
-            if spec:
-                raise ValueError(
-                    'Configuration selection is not supported for dumping')
             if scope:
                 raise ValueError(
                     'Scope selection is not supported for dumping')
@@ -279,8 +276,9 @@ def configuration(action, scope, specs, res_kwargs, ds=None):
         raise ValueError("Unsupported action '{}'".format(action))
 
     if action == 'dump':
-        # dumping is querying for all known keys
-        specs = [(n,) for n in sorted(set(cfg_defs.keys()).union(cfg.keys()))]
+        if not specs:
+            # dumping is querying for all known keys
+            specs = [(n,) for n in sorted(set(cfg_defs.keys()).union(cfg.keys()))]
         scope = None
 
     for spec in specs:

--- a/datalad/local/configuration.py
+++ b/datalad/local/configuration.py
@@ -1,0 +1,391 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Frontend for the DataLad config"""
+
+__docformat__ = 'restructuredtext'
+
+
+import logging
+from textwrap import wrap
+
+import datalad.support.ansi_colors as ac
+from datalad import cfg as dlcfg
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.common_cfg import definitions as cfg_defs
+from datalad.interface.common_opts import (
+    recursion_flag,
+    recursion_limit,
+)
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import (
+    default_result_renderer,
+    eval_results,
+)
+from datalad.support.constraints import (
+    EnsureChoice,
+    EnsureNone,
+)
+from datalad.support.exceptions import (
+    CommandError,
+    NoDatasetFound,
+)
+from datalad.support.param import Parameter
+from datalad.utils import (
+    Path,
+    ensure_list,
+)
+
+lgr = logging.getLogger('datalad.local.configuration')
+
+config_actions = ('dump', 'get', 'set', 'unset')
+
+
+@build_doc
+class Configuration(Interface):
+    """Get and set dataset, dataset-clone-local, or global configuration
+
+    This command works similar to git-config, but some features are not
+    supported (e.g., modifying system configuration), while other features
+    are not available in git-config (e.g., multi-configuration queries).
+
+    Query and modification of three distinct configuration scopes is
+    supported:
+
+    - 'branch': the persistent configuration in .datalad/config of a dataset
+      branch
+    - 'local': a dataset clone's Git repository configuration in .git/config
+    - 'global': non-dataset-specific configuration (usually in $USER/.gitconfig)
+
+    Modifications of the persistent 'branch' configuration will not be saved
+    by this command, but have to be committed with a subsequent `save`
+    call.
+
+    Rules of precedence regarding different configuration scopes are the same
+    as in Git, with two exceptions: 1) environment variables can be used to
+    override any datalad configuration, and have precedence over any other
+    configuration scope (see below). 2) the 'branch' scope is considered in
+    addition to the standard git configuration scopes. Its content has lower
+    precedence than Git configuration scopes, but it is committed to a branch,
+    hence can be used to ship (default and branch-specific) configuration with
+    a dataset.
+
+    Any DATALAD_* environment variable is also mapped to a configuration item.
+    Their values take precedence over any other specification. In variable
+    names '_' encodes a '.' in the configuration name, and '__' encodes a '-',
+    such that 'DATALAD_SOME__VAR' is mapped to 'datalad.some-var'.
+
+    Recursive operation is supported for querying and modifying configuration
+    across a hierarchy of datasets.
+    """
+    _examples_ = [
+        dict(text="Dump the effective configuration, including an annotation for common items",
+             code_py="configuration()",
+             code_cmd="datalad configuration"),
+        dict(text="Query two configuration items",
+             code_py="configuration('get', ['user.name', 'user.email'])",
+             code_cmd="datalad configuration get user.name user.email"),
+        dict(text="Recursively set configuration in all (sub)dataset repositories",
+             code_py="configuration('set', [('my.config.name', 'value')], recursive=True)",
+             code_cmd="datalad configuration -r set my.config=value"),
+        dict(text="Modify the persistent branch configuration (changes are not committed)",
+             code_py="configuration('set', [('my.config.name', 'value')], scope='branch')",
+             code_cmd="datalad configuration --scope branch set my.config=value"),
+    ]
+
+    result_renderer = 'tailored'
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to query or to configure""",
+            constraints=EnsureDataset() | EnsureNone()),
+        action=Parameter(
+            args=("action",),
+            nargs='?',
+            doc="""which action to perform""",
+            constraints=EnsureChoice(*config_actions)),
+        scope=Parameter(
+            args=("--scope",),
+            doc="""scope for getting or setting
+            configuration. If no scope is declared for a query, all
+            configuration sources (including overrides via environment
+            variables) are considered according to the normal
+            rules of precedence. For action 'get' only 'branch' and 'local'
+            (with include 'global' here) are supported. For action 'dump',
+            a scope selection is ignored and all scopes are considered.""",
+            constraints=EnsureChoice('global', 'local', 'branch', None)),
+        spec=Parameter(
+            args=("spec",),
+            doc="""configuration name (for actions 'get' and 'unset'),
+            or name/value pair (for action 'set')""",
+            nargs='*',
+            metavar='name[=value]'),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+    )
+
+    @staticmethod
+    @datasetmethod(name='configuration')
+    @eval_results
+    def __call__(
+            action='dump',
+            spec=None,
+            *,
+            scope=None,
+            dataset=None,
+            recursive=False,
+            recursion_limit=None):
+
+        # check conditions
+        # - global and recursion makes no sense
+
+        if action == 'dump':
+            if spec:
+                raise ValueError(
+                    'Configuration selection is not supported for dumping')
+            if scope:
+                raise ValueError(
+                    'Scope selection is not supported for dumping')
+
+        # normalize variable specificatons
+        specs = []
+        for s in ensure_list(spec):
+            if isinstance(s, tuple):
+                specs.append((str(s[0]), str(s[1])))
+            elif '=' not in s:
+                specs.append((str(s),))
+            else:
+                specs.append(tuple(s.split('=', 1)))
+
+        if action == 'set':
+            missing_values = [s[0] for s in specs if len(s) < 2]
+            if missing_values:
+                raise ValueError(
+                    'Values must be provided for all configuration '
+                    'settings. Missing: {}'.format(missing_values))
+            invalid_names = [s[0] for s in specs if '.' not in s[0]]
+            if invalid_names:
+                raise ValueError(
+                    'Name must contain a section (i.e. "section.name"). '
+                    'Invalid: {}'.format(invalid_names))
+
+        ds = None
+        if scope != 'global' or recursive:
+            try:
+                ds = require_dataset(
+                    dataset,
+                    check_installed=True,
+                    purpose='configuration')
+            except NoDatasetFound:
+                if action != 'dump' or dataset:
+                    raise
+
+        res_kwargs = dict(
+            action='configuration',
+            logger=lgr,
+        )
+        if ds:
+            res_kwargs['refds'] = ds.path
+        yield from configuration(action, scope, specs, res_kwargs, ds)
+
+        if not recursive:
+            return
+
+        for subds in ds.subdatasets(
+                fulfilled=True,
+                recursive=True,
+                recursion_limit=recursion_limit,
+                on_failure='ignore',
+                result_renderer='disabled'):
+            yield from configuration(
+                action, scope, specs, res_kwargs, Dataset(subds['path']))
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        if (res['status'] != 'ok' or
+                res['action'] not in ('get_configuration',
+                                      'dump_configuration')):
+            if 'message' not in res and 'name' in res:
+                suffix = '={}'.format(res['value']) if 'value' in res else ''
+                res['message'] = '{}{}'.format(
+                    res['name'],
+                    suffix)
+            default_result_renderer(res)
+            return
+        # TODO source
+        from datalad.ui import ui
+        name = res['name']
+        if res['action'] == 'dump_configuration':
+            for key in ('purpose', 'description'):
+                s = res.get(key)
+                if s:
+                    ui.message('\n'.join(wrap(
+                        s,
+                        initial_indent='# ',
+                        subsequent_indent='# ',
+                    )))
+
+        if kwargs.get('recursive', False):
+            have_subds = res['path'] != res['refds']
+            # we need to mark up from which dataset results are reported
+            prefix = '<ds>{}{}:'.format(
+                '/' if have_subds else '',
+                Path(res['path']).relative_to(res['refds']).as_posix()
+                if have_subds else '',
+            )
+        else:
+            prefix = ''
+
+        if kwargs.get('action', None) == 'dump':
+            ui.message('{}{}={}'.format(
+                prefix,
+                ac.color_word(name, ac.BOLD),
+                res['value'] if res['value'] is not None else '',
+            ))
+        else:
+            ui.message('{}{}'.format(
+                prefix,
+                res['value'] if res['value'] is not None else '',
+            ))
+
+
+def configuration(action, scope, specs, res_kwargs, ds=None):
+    if scope == 'global' or (action == 'dump' and ds is None):
+        cfg = dlcfg
+    else:
+        cfg = ds.config
+
+    # TODO for now we map to the old name, until ConfigManager
+    # is adjusted
+    if scope == 'branch':
+        scope = 'dataset'
+
+    if action not in config_actions:
+        raise ValueError("Unsupported action '{}'".format(action))
+
+    if action == 'dump':
+        # dumping is querying for all known keys
+        specs = [(n,) for n in sorted(set(cfg_defs.keys()).union(cfg.keys()))]
+        scope = None
+
+    for spec in specs:
+        if '.' not in spec[0]:
+            yield get_status_dict(
+                ds=ds,
+                status='error',
+                message=(
+                    "Configuration key without a section: '%s'",
+                    spec[0],
+                ),
+                **res_kwargs)
+            continue
+        # TODO without get-all there is little sense in having add
+        #if action == 'add':
+        #    res = _add(cfg, scope, spec)
+        if action == 'get':
+            res = _get(cfg, scope, spec[0])
+        elif action == 'dump':
+            res = _dump(cfg, spec[0])
+        # TODO this should be there, if we want to be comprehensive
+        # however, we turned this off by default in the config manager
+        # because we hardly use it, and the handling in ConfigManager
+        # is not really well done.
+        #elif action == 'get-all':
+        #    res = _get_all(cfg, scope, spec)
+        elif action == 'set':
+            res = _set(cfg, scope, *spec)
+        elif action == 'unset':
+            res = _unset(cfg, scope, spec[0])
+
+        if ds:
+            res['path'] = ds.path
+
+        if 'status' not in res:
+            res['status'] = 'ok'
+
+        yield dict(res_kwargs, **res)
+
+    if action in ('add', 'set', 'unset'):
+        # we perform a single reload, rather than one for each modification
+        # TODO: can we detect a call from cmdline? We could skip the reload.
+        cfg.reload(force=True)
+
+
+def _dump(cfg, name):
+    value = cfg.get(
+        name,
+        # pull a default from the config definitions
+        # if we have no value, but a key
+        cfg_defs.get(name, {}).get('default', None))
+
+    res = dict(
+        action='dump_configuration',
+        name=name,
+        value=value,
+    )
+    if name in cfg_defs:
+        ui_def = cfg_defs[name].get('ui', [None, {}])[1]
+        for s, key in ((ui_def.get('title'), 'purpose'),
+                  (ui_def.get('text'), 'description')):
+            if s:
+                res[key] = s
+    return res
+
+
+def _get(cfg, scope, name):
+    value = cfg.get_from_source(scope, name) \
+        if scope else cfg.get(
+            name,
+            # pull a default from the config definitions
+            # if we have no value, but a key (i.e. in dump mode)
+            cfg_defs.get(name, {}).get('default', None))
+    return dict(
+        action='get_configuration',
+        name=name,
+        value=value,
+    )
+
+
+def _set(cfg, scope, name, value):
+    cfg.set(name, value, where=scope, force=True, reload=False)
+    return dict(
+        action='set_configuration',
+        name=name,
+        value=value,
+    )
+
+
+def _unset(cfg, scope, name):
+    try:
+        cfg.unset(name, where=scope, reload=False)
+    except CommandError as e:
+        # we could also check if the option exists in the merged/effective
+        # config first, but then we would have to make sure that there could
+        # be no valid way of overriding a setting in a particular scope.
+        # seems safer to do it this way
+        if e.code == 5:
+            return dict(
+                status='error',
+                action='unset_configuration',
+                name=name,
+                message=("configuration '%s' does not exist (%s)", name, e),
+            )
+    return dict(
+        action='unset_configuration',
+        name=name,
+    )

--- a/datalad/local/tests/test_configuration.py
+++ b/datalad/local/tests/test_configuration.py
@@ -56,7 +56,6 @@ def test_something(path, new_home):
     ds.save()
 
     # catches unsupported argument combinations
-    assert_raises(ValueError, ds.configuration, 'dump', spec='some')
     assert_raises(ValueError, ds.configuration, 'dump', scope='branch')
     assert_raises(ValueError, ds.configuration, 'set', spec=('onlyname',))
     assert_raises(ValueError, ds.configuration, 'set', spec='nosection=value')

--- a/datalad/local/tests/test_configuration.py
+++ b/datalad/local/tests/test_configuration.py
@@ -1,0 +1,150 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# -*- coding: utf-8 -*-
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+
+"""
+
+from packaging.version import Version
+from os.path import join as opj
+
+import datalad
+from datalad.distribution.dataset import Dataset
+from datalad.tests.utils import (
+    assert_in,
+    assert_in_results,
+    assert_not_in,
+    assert_raises,
+    assert_result_count,
+    swallow_outputs,
+    with_tempfile,
+    with_tree,
+)
+
+# before 0.14 ui.message() (used in dump) was not friendly to unicode
+complicated_str = 'complicated {} beast with.dot'.format(
+    "の" if Version(datalad.__version__) >= Version('0.14.0') else 'blob'
+)
+
+_config_file_content = """\
+[something "user"]
+name = Jane Doe
+email = jd@example.com
+novalue
+empty =
+myint = 3
+
+[onemore "{}"]
+findme = 5.0
+""".format(complicated_str)
+
+_dataset_config_template = {
+    'ds': {
+        '.datalad': {
+            'config': _config_file_content}}}
+
+
+@with_tree(tree=_dataset_config_template)
+@with_tempfile(mkdir=True)
+def test_something(path, new_home):
+    ds = Dataset(opj(path, 'ds')).create(force=True)
+    ds.save()
+
+    # catches unsupported argument combinations
+    assert_raises(ValueError, ds.configuration, 'dump', spec='some')
+    assert_raises(ValueError, ds.configuration, 'dump', scope='branch')
+    assert_raises(ValueError, ds.configuration, 'set', spec=('onlyname',))
+    assert_raises(ValueError, ds.configuration, 'set', spec='nosection=value')
+    # we also get that from the internal helper
+    from datalad.local.configuration import configuration as cfghelper
+    assert_in_results(
+        cfghelper('set', 'global', [('nosection', 'value')], {}),
+        status='error',
+    )
+    assert_raises(ValueError, ds.configuration, 'invalid')
+    res = ds.configuration(result_renderer='disabled')
+
+    assert_in_results(
+        res,
+        name='something.user.name',
+        value='Jane Doe')
+    # UTF handling
+    assert_in_results(
+        res,
+        name=u'onemore.{}.findme'.format(complicated_str),
+        value='5.0')
+
+    res = ds.configuration(
+        'set',
+        spec='some.more=test',
+        result_renderer='disabled',
+    )
+    assert_in_results(
+        res,
+        name='some.more',
+        value='test')
+    # Python tuple specs
+    # swallow outputs to be able to execise the result renderer
+    with swallow_outputs():
+        res = ds.configuration(
+            'set',
+            spec=[
+                ('some.more.still', 'test2'),
+                # value is non-str -- will be converted
+                ('lonely.val', 4)],
+        )
+    assert_in_results(
+        res,
+        name='some.more.still',
+        value='test2')
+    assert_in_results(
+        res,
+        name='lonely.val',
+        value='4')
+
+    assert_in_results(
+        ds.configuration('get', spec='lonely.val'),
+        status='ok',
+        name='lonely.val',
+        value='4',
+    )
+
+    # remove something that does not exist in the specified scope
+    assert_in_results(
+        ds.configuration('unset', scope='branch', spec='lonely.val',
+                         result_renderer='disabled', on_failure='ignore'),
+        status='error')
+    # remove something that does not exist in the specified scope
+    assert_in_results(
+        ds.configuration('unset', spec='lonely.val',
+                         result_renderer='disabled'),
+        status='ok')
+    assert_not_in('lonely.val', ds.config)
+    # errors if done again
+    assert_in_results(
+        ds.configuration('unset', spec='lonely.val',
+                         result_renderer='disabled', on_failure='ignore'),
+        status='error')
+
+    # add a subdataset to test recursive operation
+    subds = ds.create('subds')
+
+    with swallow_outputs():
+        res = ds.configuration('set', spec='rec.test=done', recursive=True)
+    assert_result_count(
+        res,
+        2,
+        name='rec.test',
+        value='done',
+    )
+
+    # exercise the result renderer
+    with swallow_outputs() as cml:
+        ds.configuration(recursive=True)
+        # we get something on the subds with the desired markup
+        assert_in('<ds>/subds:rec.test=done', cml.out)

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -117,6 +117,7 @@ Helpers and support utilities
    datalad add-archive-content: Extract and add the content of an archive to a dataset <generated/man/datalad-add-archive-content>
    datalad clean: Remove temporary left-overs of DataLad operations <generated/man/datalad-clean>
    datalad check-dates: Scan a dataset for dates and timestamps <generated/man/datalad-check-dates>
+   datalad configuration: Get and set configuration <generated/man/datalad-configuration>
    datalad create-test-dataset: Test helper <generated/man/datalad-create-test-dataset>
    datalad download-url: Download helper with support for DataLad's credential system <generated/man/datalad-download-url>
    datalad foreach-dataset: Run a command or Python code on the dataset and/or each of its sub-datasets <generated/man/datalad-foreach-dataset>

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -94,6 +94,7 @@ Miscellaneous commands
    api.add_readme
    api.addurls
    api.check_dates
+   api.configuration
    api.export_archive
    api.export_to_figshare
    api.no_annex


### PR DESCRIPTION
Fixes datalad/datalad#5489

The individual commits following the first one are improvements over the extension version.

### Changelog

#### 💫 Enhancements and new features

- A new `configuration`command provides an interface to manipulate and query the DataLad configuration.
  - Unlike the global Python-only `datalad.cfg` or dataset-specific `Dataset.config` configuration managers, this command offers a uniform API across the Python and the command line interfaces.
  - This command was previously available in the `mihextras` extension as `x-configuration`, and has been merged into the core package in an improved version. [#5489](https://github.com/datalad/datalad/pull/5489) (by @mih)
  - In its default `dump` mode, the command provides an annotated list of the effective configuration after considering all configuration sources, including hints on additional configuration settings and their supported values.

#### 📝 Documentation

- The documentation of the `configuration` command now details all locations DataLad is reading configuration items from, and their respective rules of precedence (by @mih)
