### PR TITLE
BF(Q&D): do not crash - issue warning - if template fails to format

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -47,6 +47,7 @@ from datalad.support.gitrepo import (
     _fixup_submodule_dotgit_setup,
 )
 from datalad.support.exceptions import (
+    CapturedException,
     CommandError,
     InsufficientArgumentsError,
 )
@@ -245,7 +246,15 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
                 f"candidate '{name}', but only one is allowed. "
                 f"Check datalad.get.subdataset-source-candidate-* configuration!"
             )
-        url = tmpl.format(**sm_candidate_props)
+        try:
+            url = tmpl.format(**sm_candidate_props)
+        except KeyError as e:
+            ce = CapturedException(e)
+            lgr.warning(
+                "Failed to format template %r for a submodule clone. "
+                "Error: %s", tmpl, ce
+            )
+            continue
         # we don't want "flexible_source_candidates" here, this is
         # configuration that can be made arbitrarily precise from the
         # outside. Additional guesswork can only make it slower

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -185,6 +185,13 @@ def test_get_flexible_source_candidates_for_submodule(t, t2, t3):
     )
     assert_raises(ValueError, clone3.get, 'sub')
 
+    # smoke test to check for #5631: We shouldn't crash with a KeyError when a
+    # template can not be matched. Origin: https://github.com/datalad/datalad/pull/5644/files
+    with patch.dict(
+            'os.environ',
+            {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'pre-{not-a-key}-post'}):
+        f(clone, clone.subdatasets(return_type='item-or-list'))
+
     # TODO: check that http:// urls for the dataset itself get resolved
     # TODO: many more!!
 


### PR DESCRIPTION
This is to address an elderly https://github.com/datalad/datalad/issues/5631
which I keep running into over and over again.  Unfortunately a more thorough
fix attempt in https://github.com/datalad/datalad/pull/5644 was not finalized.
Since I keep running into this issue over and over again leading to process
crash, I decided that a "crude" fix with issuing a warning would be
better than just crashing entirely (thus possibly leaving other many subdatasets not even be attempted to be installed).

