### PR TITLE
Reimplement _get_dot_git() to be more efficient

### DIFF
--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -671,7 +671,9 @@ def _get_dot_git(pathobj, *, ok_missing=False, resolved=False):
     Returns
     -------
     Path
-      Absolute path to the (resolved) .git directory
+      Path to the (resolved) .git directory. If `resolved` is False, and
+      the given `pathobj` is not an absolute path, the returned path will
+      also be relative.
     """
     dot_git = pathobj / '.git'
     if dot_git.is_dir():

--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -651,8 +651,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 #
 # Internal helpers
 #
-def _get_dot_git(pathobj, *, ok_missing=False):
-    """Given a pathobj to a repository return path to .git/ directory
+def _get_dot_git(pathobj, *, ok_missing=False, resolved=False):
+    """Given a pathobj to a repository return path to the .git directory
 
     Parameters
     ----------
@@ -660,6 +660,8 @@ def _get_dot_git(pathobj, *, ok_missing=False):
     ok_missing: bool, optional
       Allow for .git to be missing (useful while sensing before repo is
       initialized)
+    resolved : bool, optional
+      Whether to resolve any symlinks in the path, at a performance cost.
 
     Raises
     ------
@@ -669,23 +671,28 @@ def _get_dot_git(pathobj, *, ok_missing=False):
     Returns
     -------
     Path
-      Absolute path to resolved .git/ directory
+      Absolute path to the (resolved) .git directory
     """
     dot_git = pathobj / '.git'
-    if dot_git.is_file():
+    if dot_git.is_dir():
+        # deal with the common case immediately, an existing dir
+        return dot_git.resolve() if resolved else dot_git
+    elif not dot_git.exists():
+        # missing or bare
+        if (pathobj / 'HEAD').exists() and (pathobj / 'config').exists():
+            return pathobj.resolve() if resolved else pathobj
+        elif not ok_missing:
+            raise RuntimeError("Missing .git in %s." % pathobj)
+        else:
+            # resolve to the degree possible
+            return dot_git.resolve(strict=False)
+    # continue with more special cases
+    elif dot_git.is_file():
         with dot_git.open() as f:
             line = f.readline()
             if line.startswith("gitdir: "):
                 dot_git = pathobj / line[7:].strip()
+                return dot_git.resolve() if resolved else dot_git
             else:
                 raise InvalidGitRepositoryError("Invalid .git file")
-    elif dot_git.is_symlink():
-        dot_git = dot_git.resolve()
-    elif not dot_git.exists() and \
-            (pathobj / 'HEAD').exists() and \
-            (pathobj / 'config').exists():
-        # looks like a bare repo
-        dot_git = pathobj
-    elif not (ok_missing or dot_git.exists()):
-        raise RuntimeError("Missing .git in %s." % pathobj)
-    return dot_git
+    raise RuntimeError("Unaccounted condition")

--- a/datalad/dataset/tests/test_gitrepo.py
+++ b/datalad/dataset/tests/test_gitrepo.py
@@ -317,8 +317,11 @@ def test_get_dot_git(emptycase, gitdircase, barecase, gitfilecase):
         eq_(_get_dot_git(emptycase, ok_missing=True, resolved=r),
             emptycase / '.git')
 
-        eq_(_get_dot_git(gitdircase, resolved=r), gitdircase / '.git')
+        eq_(_get_dot_git(gitdircase, resolved=r),
+            (gitdircase.resolve() if r else gitdircase) / '.git')
 
-        eq_(_get_dot_git(barecase, resolved=r), barecase)
+        eq_(_get_dot_git(barecase, resolved=r),
+            barecase.resolve() if r else barecase)
 
-        eq_(_get_dot_git(gitfilecase, resolved=r), gitfilecase / 'subdir')
+        eq_(_get_dot_git(gitfilecase, resolved=r),
+            (gitfilecase.resolve() if r else gitfilecase) / 'subdir')

--- a/datalad/dataset/tests/test_gitrepo.py
+++ b/datalad/dataset/tests/test_gitrepo.py
@@ -39,7 +39,10 @@ from datalad.tests.utils import (
     SkipTest,
 )
 
-from datalad.dataset.gitrepo import GitRepo
+from datalad.dataset.gitrepo import (
+    GitRepo,
+    _get_dot_git,
+)
 
 from datalad.support.exceptions import (
     CommandError,
@@ -294,3 +297,28 @@ def test_fake_dates(path):
     eq_(gr.get_active_branch(), "other")
     eq_(seconds_initial + 3,
         int(gr.format_commit('%at')))
+
+
+@with_tempfile(mkdir=True)
+@with_tree(tree={".git": {}})
+@with_tree(tree={"HEAD": "",
+                 "config": ""})
+@with_tree(tree={".git": "gitdir: subdir"})
+def test_get_dot_git(emptycase, gitdircase, barecase, gitfilecase):
+    emptycase = Path(emptycase)
+    gitdircase = Path(gitdircase)
+    barecase = Path(barecase)
+    gitfilecase = Path(gitfilecase)
+
+    # the test is not actually testing resolving (we can trust that)
+    # but it is exercising the internal code paths involved in it
+    for r in (True, False):
+        assert_raises(RuntimeError, _get_dot_git, emptycase, resolved=r)
+        eq_(_get_dot_git(emptycase, ok_missing=True, resolved=r),
+            emptycase / '.git')
+
+        eq_(_get_dot_git(gitdircase, resolved=r), gitdircase / '.git')
+
+        eq_(_get_dot_git(barecase, resolved=r), barecase)
+
+        eq_(_get_dot_git(gitfilecase, resolved=r), gitfilecase / 'subdir')

--- a/datalad/distribution/tests/test_utils.py
+++ b/datalad/distribution/tests/test_utils.py
@@ -60,24 +60,3 @@ def test_get_flexible_source_candidates():
     # when source is not relative, but base_url is specified as just the destination path,
     # not really a "base url" as name was suggesting, then it should be ignored
     eq_(f('http://e.c/p', '/path'), ['http://e.c/p', 'http://e.c/p/.git'])
-
-
-@with_tempfile
-def test_get_git_dir(path):
-    # minimal, only missing coverage
-    assert_raises(RuntimeError, GitRepo.get_git_dir, path)
-
-    srcpath = opj(path, 'src')
-    targetpath = opj(path, 'target')
-    targetgitpath = opj(targetpath, '.git')
-    os.makedirs(srcpath)
-    os.makedirs(targetpath)
-    if not on_windows:
-        # with PY3 would also work with Windows 6+
-        os.symlink(srcpath, targetgitpath)
-        eq_(srcpath, GitRepo.get_git_dir(targetpath))
-        # cleanup for following test
-        unlink(targetgitpath)
-    with open(targetgitpath, 'w') as f:
-        f.write('gitdir: {}'.format(srcpath))
-    eq_(srcpath, GitRepo.get_git_dir(targetpath))


### PR DESCRIPTION
It now tests the common scenarios first, rather then leaving them for last.

Moreover, it introduces an explicit `resolved` flag for result path reporting, and applies it consistently when enabled -- rather than just for symlinked directories, but not files, or gitdirs specified in .git files. Searching through the code, I did not spot a case where this features is needed, nor desirable.

Fixes datalad/datalad#6321
Fixes datalad/datalad#6324