### PR TITLE
ConfigManager supports bare repos

### DIFF
--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -636,7 +636,14 @@ def test_bare(src, path):
     ds = Dataset(src).create()
     dlconfig_sha = ds.repo.call_git(['rev-parse', 'HEAD:.datalad/config'])
     # can we handle a bare repo version of it?
-    gr = AnnexRepo.clone(src, path, clone_options=['--bare'])
+    gr = AnnexRepo.clone(
+        src, path, clone_options=['--bare', '-b', DEFAULT_BRANCH])
+    # we had to specifically checkout the standard branch, because on crippled
+    # FS, HEAD will point to an adjusted branch by default, and the test logic
+    # below does not account for this case.
+    # this should just make sure the bare repo has the expected setup,
+    # but it should still be bare. Let's check that to be sure
+    assert_true(gr.bare)
     # do we read the correct local config?
     assert_in(gr.pathobj / 'config', gr.config._stores['git']['files'])
     # do we pick up the default branch config too?


### PR DESCRIPTION
### Changelog
#### 🐛 Bug Fixes
- Fix a broken check for file presence in the `ConfigManager` that could have caused a crash in rare cases when a config file is removed during the process runtime. Fixes #6327
- `ConfigManager.get_from_source()` now accesses the correct information when using the documented `source='local'`, avoiding a crash. Fixes #6331
#### 💫 Enhancements and new features
- `ConfigManager` now supports reading committed dataset configuration in bare repositories. Analog to reading `.datalad/config` from a worktree, `blob:HEAD:.datalad/config` is read (e.g., the config committed in the default branch). The support includes `reload()` change detection using the gitsha of this file. The behavior for non-bare repositories is unchanged. Fixes #6264
