### PR TITLE
Docs, infra: Attempt to fix missing bullet points by pinning Sphinx and RTD theme versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,8 @@ requires.update({
         # used for converting README.md -> .rst for long_description
         'pypandoc',
         # Documentation
-        'sphinx>=2, !=4.0.0',
-        'sphinx-rtd-theme',
+        'sphinx>=4.3.0',
+        'sphinx-rtd-theme>=0.5.1"',
     ],
     'devel-utils': [
         'asv',        # benchmarks


### PR DESCRIPTION
We've lost bullet points in our docs (#6313). https://github.com/readthedocs/sphinx_rtd_theme/issues/1115 suggests to pin the readthedocs theme and sphinx. This PR is a test to see if it would work (hopefully I can get a preview by RTD as I am opening this PR not from a fork)