### PR TITLE
BF(?WIN): provide relpath relative to dataset not default CWD

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -819,7 +819,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     if not rerun_info and cmd_exitcode:
         if do_save:
             repo = ds.repo
-            msg_path = relpath(opj(str(repo.dot_git), "COMMIT_EDITMSG"))
+            msg_path = opj(str(repo.dot_git), "COMMIT_EDITMSG")
+            # shorten to the relative path for a more concise message
+            msg_path = relpath(msg_path, ds_path)
             with open(msg_path, "wb") as ofh:
                 ofh.write(ensure_bytes(msg))
             lgr.info("The command had a non-zero exit code. "


### PR DESCRIPTION
Trying to address the `#2` fail listed in https://github.com/datalad/datalad/issues/6237 and happening somehow only on master . Due to absent comments I assume that `relpath` was used to provide a shortened path to the message file.  Given that `dataset` could point somewhere else (including another drive on windows) and `os.curdir` is used by relpath if source is not specified , I decided to just provide `start` to be the dataset path explicitly.  
I failed to reproduce #6237 locally, so it is somewhat a wild shot, but what could go wrong?  only reporting could be effected. 