### PR TITLE
BF(workaround,TST): mark two tests as @known_failure_githubci_win

### DIFF
--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -511,6 +511,7 @@ def test_force_checkdatapresent(srcpath, dstpath):
                       message='Slated for transport, but no content present')
 
 
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 @with_tree(tree={'ria-layout-version': '1\n'})
 def test_ria_push(srcpath, dstpath):

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -241,6 +241,7 @@ def test_install_simple_local(src, path):
         eq_(uuid_before, ds.repo.uuid)
 
 
+@known_failure_githubci_win
 @with_testrepos(flavors=['local-url', 'network', 'local'])
 @with_tempfile
 def test_install_dataset_from_just_source(url, path):


### PR DESCRIPTION
Those had been failing for a while, see
https://github.com/datalad/datalad/issues/6333
https://github.com/datalad/datalad/issues/6237
ruining the baseline testing of datalad/git-annex.  Unfortunately I have no
sufficient foo or time to track them down.
