### PR TITLE
BF: ORA over HTTP tried to check archive

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1286,6 +1286,12 @@ class RIARemote(SpecialRemote):
         try:
             self.io.get(abs_key_path, filename, self.annex.progress)
         except Exception as e1:
+            if isinstance(self.io, HTTPRemoteIO):
+                # no client-side archive access over HTTP
+                # Note: This is intentional, as it would mean one additional
+                # request per key. However, server response to the GET can
+                # consider archives on their end.
+                raise
             # catch anything and keep it around for a potential re-raise
             try:
                 self.io.get_from_archive(archive_path, key_path, filename,
@@ -1304,6 +1310,9 @@ class RIARemote(SpecialRemote):
         if self.io.exists(abs_key_path):
             # we have an actual file for this key
             return True
+        if isinstance(self.io, HTTPRemoteIO):
+            # no client-side archive access over HTTP
+            return False
         # do not make a careful check whether an archive exists, because at
         # present this requires an additional SSH call for remote operations
         # which may be rather slow. Instead just try to run 7z on it and let

--- a/datalad/distributed/tests/test_ora_http.py
+++ b/datalad/distributed/tests/test_ora_http.py
@@ -115,7 +115,17 @@ def test_read_access(store_path, store_url, ds_path):
     create_store(io, store_path, '1')
     create_ds_in_store(io, store_path, ds.id, '2', '1')
     ds.repo.init_remote('ora-remote', options=init_opts)
-    ds.repo.fsck(remote='ora-remote', fast=True)
+    fsck_results = ds.repo.fsck(remote='ora-remote', fast=True)
+    # Note: Failures in the special remote will show up as a success=False
+    # result for fsck -> the call itself would not fail.
+    for r in fsck_results:
+        if "note" in r:
+            # we could simply assert "note" to not be in r, but we want proper
+            # error reporting - content of note, not just its unexpected
+            # existence.
+            assert_equal(r["success"], "true",
+                         msg="git-annex-fsck failed with ORA over HTTP: %s" % r)
+        assert_equal(r["error-messages"], [])
     store_uuid = ds.siblings(name='ora-remote',
                              return_type='item-or-list',
                              result_renderer='disabled')['annex-uuid']

--- a/tools/coverage-bin/git-annex-remote-ora
+++ b/tools/coverage-bin/git-annex-remote-ora
@@ -1,0 +1,1 @@
+datalad


### PR DESCRIPTION
Commit a4b87f0c58047c9337e0cd1604f2b3eaeaae99a7 broke this
by removing to much. CHECKPRESENT and TRANSFER-RETRIEVE would
try to address a potential archive if key couldn't be
found in annex object tree.

This is wrong. In opposition to remote execution variants
(SSH and local access), HTTP is supposed to only send one request
per key - archives have to be dealt with server-side.

(Closes #6354)