### PR TITLE
BF(TST): add another condition to skip under http_proxy set

### DIFF
--- a/datalad/local/tests/test_download_url.py
+++ b/datalad/local/tests/test_download_url.py
@@ -65,6 +65,8 @@ def test_download_url_exceptions():
         'Temporary failure in name resolution' in msg
         or
         'Name or service not known' in msg  # nd80
+        or
+        'Failed to establish a new session' in msg  # Debian sid @ 20220121
     ):
         assert_in('http://example.com/bogus', msg)
 


### PR DESCRIPTION
compare with http_proxy set:

    root@smaug:/tmp/buildd/datalad-0.15.4+git528.g4ea21cb32# http_proxy=http://127.0.0.1:9/ PYTHONPATH=$PWD bin/datalad download-url http://example.com/bogus
    It is highly recommended to configure Git before using DataLad. Set both 'user.name' and 'user.email' configuration variables.
    [INFO   ] Downloading 'http://example.com/bogus' into '/tmp/buildd/datalad-0.15.4+git528.g4ea21cb32/'
    download_url(error): /tmp/buildd/datalad-0.15.4+git528.g4ea21cb32/ (file) [AccessFailedError(Failed to establish a new session 1 times. )]

to without (when we should do that assert):

    root@smaug:/tmp/buildd/datalad-0.15.4+git528.g4ea21cb32# PYTHONPATH=$PWD bin/datalad download-url http://example.com/bogus
    It is highly recommended to configure Git before using DataLad. Set both 'user.name' and 'user.email' configuration variables.
    [INFO   ] Downloading 'http://example.com/bogus' into '/tmp/buildd/datalad-0.15.4+git528.g4ea21cb32/'
    download_url(error): /tmp/buildd/datalad-0.15.4+git528.g4ea21cb32/ (file) [DownloadError(Access to http://example.com/bogus has failed: not found)]

dependencies:

	- dependencies: cmd:git=2.34.1 cmd:annex=8.20211123 cmd:bundled-git=UNKNOWN cmd:system-git=2.34.1 cmd:system-ssh=8.7p1 cmd:7z=16.02 annexremote=1.6.0 platformdirs=2.4.1 exifread=2.3.2 humanize=0.0.0 iso8601=0.1.16 keyring=23.5.0 keyrings.alt=UNKNOWN msgpack=1.0.2 mutagen=1.45.1 requests=2.25.1

	root@smaug:/tmp/buildd/datalad-0.15.4+git528.g4ea21cb32# python3 --version
	Python 3.9.10

Didn't investigate if applicable to `maint` so will add label just in case