### PR TITLE
BF: python 3.10 compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ matrix:
     env:
     - NOSE_SELECTION=
     - NOSE_SELECTION_OP=not
+  - python: '3.10'
+    dist: focal
+    env:
+      - NOSE_SELECTION=
+      - NOSE_SELECTION_OP=not
   - if: type = cron
     python: 3.6
     # Single run for Python 3.6

--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -117,7 +117,8 @@ class HelpAction(argparse.Action):
         else:
             opt_args_str = "*Options*"
             pos_args_str = "*Arguments*"
-        helpstr = re.sub(r'optional arguments:', opt_args_str, helpstr)
+        # in python 3.10 it switched from "optional arguments" to "options"
+        helpstr = re.sub(r'(optional arguments|options):', opt_args_str, helpstr)
         helpstr = re.sub(r'positional arguments:', pos_args_str, helpstr)
         # usage is on the same line
         helpstr = re.sub(r'^usage:', 'Usage:', helpstr)

--- a/datalad/cmdline/tests/test_main.py
+++ b/datalad/cmdline/tests/test_main.py
@@ -127,6 +127,8 @@ def test_help_np():
               'Plumbing commands',
               }:
         assert_in(s, sections)
+        # should be present only one time!
+        eq_(stdout.count(s), 1)
 
     if not get_terminal_size()[0] or 0:
         raise SkipTest(

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -928,7 +928,7 @@ def test_AnnexRepo_get(src, dst):
 
     annex.drop(testfile)
     with patch.object(GitWitlessRunner, 'run_on_filelist_chunks',
-                      side_effect=check_run, auto_spec=True), \
+                      side_effect=check_run), \
             swallow_outputs():
         annex.get(testfile, jobs=5)
     eq_(called, ['find', 'get'])
@@ -1586,7 +1586,6 @@ def test_annex_add_no_dotfiles(path):
 def test_annex_version_handling_at_min_version(path):
     with set_annex_version(AnnexRepo.GIT_ANNEX_MIN_VERSION):
         po = patch.object(AnnexRepo, '_check_git_annex_version',
-                          auto_spec=True,
                           side_effect=AnnexRepo._check_git_annex_version)
         with po as cmpc:
             eq_(AnnexRepo.git_annex_version, None)


### PR DESCRIPTION
Fix for the failing tests in #6362 and add 3.10 testing for travis (more radical CI changes to be added to `master` after this PR gets merged into `maint` and then into `master`)