### PR TITLE
Fix AnnexRepo.whereis key=True mode operation, and add batch mode support

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -566,6 +566,8 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         ver = cls.git_annex_version
         kludges["fromkey-supports-unlocked"] = ver > "8.20210428"
+        # applies to get, drop, move, copy, whereis
+        kludges["grp1-supports-batch-keys"] = ver >= "8.20210903"
         cls._version_kludges = kludges
         return kludges[key]
 
@@ -2316,10 +2318,15 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         options = ensure_list(options, copy=True)
         if batch:
+            # TODO: --batch-keys was added to 8.20210903
             if key:
-                raise ValueError("batch=True is incompatible with `key`")
+                if not self._check_version_kludges("grp1-supports-batch-keys"):
+                    raise ValueError("batch=True for `key=True` requires git-annex >= 8.20210903")
+                bkw = {'batch_opt': '--batch-keys'}
+            else:
+                bkw = {}
             bcmd = self._batched.get('whereis', annex_options=options,
-                                     json=True, path=self.path)
+                                     json=True, path=self.path, **bkw)
             json_objects = bcmd(files)
         else:
             cmd = ['whereis'] + options
@@ -3761,7 +3768,7 @@ class BatchedAnnex(BatchedCommand):
     """
 
     def __init__(self, annex_cmd, git_options=None, annex_options=None, path=None,
-                 json=False, output_proc=None):
+                 json=False, output_proc=None, batch_opt='--batch'):
         if not isinstance(annex_cmd, list):
             annex_cmd = [annex_cmd]
         cmd = \
@@ -3771,7 +3778,7 @@ class BatchedAnnex(BatchedCommand):
             annex_cmd + \
             (annex_options if annex_options else []) + \
             (['--json', '--json-error-messages'] if json else []) + \
-            ['--batch'] + \
+            [batch_opt] + \
             (['--debug'] if lgr.getEffectiveLevel() <= 8 else [])
         output_proc = \
             output_proc if output_proc else readline_json if json else None

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -415,7 +415,7 @@ def test_AnnexRepo_web_remote(sitepath, siteurl, dst):
     assert_equal(lfull[WEB_SPECIAL_REMOTE_UUID]['description'], 'web')
 
     # --all and --key are incompatible
-    assert_raises(CommandError, ar.whereis, [], options='--all', output='full', key=True)
+    assert_raises(CommandError, ar.whereis, [testfile], options='--all', output='full', key=True)
 
     # output='descriptions'
     ldesc = ar.whereis(testfile, output='descriptions')
@@ -2567,9 +2567,19 @@ def test_whereis_batch_eqv(path):
     repo_b.drop(["baz"], options=["--from=" + DEFAULT_REMOTE, "--force"])
 
     files = ["foo", "bar", "baz"]
+    keys = repo_b.get_file_key(files)
     for output in "full", "uuids", "descriptions":
-        assert_equal(repo_b.whereis(files=files, batch=False, output=output),
+        out_non_batch = repo_b.whereis(files=files, batch=False, output=output)
+        assert_equal(out_non_batch,
                      repo_b.whereis(files=files, batch=True, output=output))
+        out_non_batch_keys = repo_b.whereis(files=keys, batch=False, key=True, output=output)
+        # should be identical
+        if output == 'full':
+            # we need to map files to keys though
+            assert_equal(out_non_batch_keys,
+                         {k: out_non_batch[f] for f, k in zip(files, keys)})
+        else:
+            assert_equal(out_non_batch, out_non_batch_keys)
 
     # --key= and --batch are incompatible.
     with assert_raises(ValueError):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2581,9 +2581,15 @@ def test_whereis_batch_eqv(path):
         else:
             assert_equal(out_non_batch, out_non_batch_keys)
 
-    # --key= and --batch are incompatible.
-    with assert_raises(ValueError):
-        repo_b.whereis(files=files, batch=True, key=True)
+        if external_versions['cmd:annex'] >= '8.20210903':
+            # --batch-keys support was introduced
+            assert_equal(out_non_batch_keys,
+                         repo_b.whereis(files=keys, batch=True, key=True, output=output))
+
+    if external_versions['cmd:annex'] < '8.20210903':
+        # --key= and --batch are incompatible.
+        with assert_raises(ValueError):
+            repo_b.whereis(files=files, batch=True, key=True)
 
 
 def test_done_deprecation():


### PR DESCRIPTION
First commit is truly a BF and destined to `maint`. The 2nd addresses the limitation (we were just raising a ValueError, not even NotImplementedError) if asked to perform in batch mode on keys.  Support for that functionality was added only recently to git-annex, and since change is small, I have decided to bundle it within the same PR against `maint`. But I would be ok to split it into `master`.  Motivation -- a need for datalad-fuse development.

attn @jwodder (I will provide more context in datalad-fuse later)

### Changelog
#### 🐛 Bug Fixes
- Fixes `AnnexRepo.whereis` operation in `key=True` mode whenever multiple keys are provided.
#### 💫 Enhancements and new features
- Adds support  for batch mode operation to `AnnexRepo.whereis` in `key=True` mode (requires git-annex 8.20210903 or later) 