### PR TITLE
MNT/RF: Retire get_refds_path and replace its usages with require_dataset()

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -849,17 +849,17 @@ class Get(Interface):
             reckless=None,
             jobs='auto',
     ):
-        refds_path = Interface.get_refds_path(dataset)
         if not (dataset or path):
             raise InsufficientArgumentsError(
                 "Neither dataset nor target path(s) provided")
-        if dataset and not path:
-            # act on the whole dataset if nothing else was specified
-            path = refds_path
-
         # we have to have a single dataset to operate on
         refds = require_dataset(
             dataset, check_installed=True, purpose='get content of %s' % shortened_repr(path))
+        # some functions downstream expect a str
+        refds_path = refds.path
+        if dataset and not path:
+            # act on the whole dataset if nothing else was specified
+            path = refds_path
 
         content_by_ds = {}
         # use subdatasets() to discover any relevant content that is not

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -219,7 +219,7 @@ class Install(Interface):
                                  purpose='install')
             common_kwargs['dataset'] = dataset
         # pre-compute for results below
-        refds_path = Interface.get_refds_path(ds)
+        refds_path = ds if ds is None else ds.path
 
         # switch into the two scenarios without --source:
         # 1. list of URLs

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -730,7 +730,6 @@ def test_missing_path_handling(path):
 
     with \
             patch("datalad.distribution.get._get_targetpaths") as get_target_path, \
-            patch("datalad.distribution.get.Interface.get_refds_path") as get_refds_path, \
             patch("datalad.distribution.get.require_dataset") as require_dataset, \
             patch("datalad.distribution.get._install_targetpath") as _install_targetpath, \
             patch("datalad.distribution.get.Subdatasets") as subdatasets:
@@ -738,7 +737,6 @@ def test_missing_path_handling(path):
         get_target_path.return_value = [{
             "status": "error"
         }]
-        get_refds_path.return_value = None
         require_dataset.return_value = refds
         _install_targetpath.return_value = [{
             "status": "notneeded",

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -838,7 +838,8 @@ class Interface(object):
 
     @classmethod
     def get_refds_path(cls, dataset):
-        """Return a resolved reference dataset path from a `dataset` argument"""
+        """Return a resolved reference dataset path from a `dataset` argument.
+        Deprecated - please use require_dataset() instead."""
         # theoretically a dataset could come in as a relative path -> resolve
         if dataset is None:
             return dataset

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -907,7 +907,7 @@ class AggregateMetaData(Interface):
             incremental=False,
             force_extraction=False,
             save=True):
-        refds_path = Interface.get_refds_path(dataset)
+        refds_path = require_dataset(dataset)
 
         # it really doesn't work without a dataset
         ds = require_dataset(

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -888,7 +888,8 @@ class Metadata(Interface):
             reporton='all',
             recursive=False):
         # prep results
-        refds_path = Interface.get_refds_path(dataset)
+        refds_path = dataset if dataset is None \
+            else require_dataset(dataset).path
         res_kwargs = dict(action='metadata', logger=lgr)
         if refds_path:
             res_kwargs['refds'] = refds_path


### PR DESCRIPTION
Here's an attempt at fixing #6376. It removes the Interface method ``get_refds_path()`` and replaces its remaining few usages with ``require_dataset()``. Not sure if this approach is too simplistic.