### PR TITLE
Key interface documentation

### DIFF
--- a/datalad/cli/common_args.py
+++ b/datalad/cli/common_args.py
@@ -17,10 +17,7 @@ from .helpers import (
     HelpAction,
     LogLevelAction,
 )
-from datalad.interface.base import (
-    eval_defaults,
-    eval_params,
-)
+from datalad.interface.base import eval_params
 from datalad.utils import ensure_unicode
 
 
@@ -80,7 +77,7 @@ common_args = dict(
     on_failure=(
         ('--on-failure',),
         dict(dest='common_on_failure',
-             default=eval_defaults['on_failure'],
+             default=eval_params['on_failure'].cmd_kwargs['default'],
              choices=['ignore', 'continue', 'stop'],
              help="""when an operation fails: 'ignore' and continue with remaining
         operations, the error is logged but does not lead to a non-zero exit

--- a/datalad/cli/tests/test_exec.py
+++ b/datalad/cli/tests/test_exec.py
@@ -91,7 +91,7 @@ def test_call_from_parser_default_args():
             eq_(kwargs['common_result_renderer'], "generic")
             # with dissolution of _OLD_STYLE_COMMANDS yoh yet to find
             # a real interface which had return_type (defined in
-            # eval_defaults and eval_params) but no @eval_results
+            # eval_params) but no @eval_results
             # eq_(kwargs['return_type'], "generator")
             eq_(arg, "nothing")
             yield "nothing is"

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -26,7 +26,6 @@ import warnings
 
 import datalad
 from datalad.interface.common_opts import eval_params
-from datalad.interface.common_opts import eval_defaults
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import resolve_path
 from datalad.support.exceptions import CapturedException
@@ -412,7 +411,9 @@ def build_doc(cls, **kwargs):
     if not _has_eval_results_call(cls):
         add_args = None
     else:
-        add_args = {k: getattr(cls, k, v) for k, v in eval_defaults.items()}
+        # defaults for all common parameters are guaranteed to be available
+        # from the class
+        add_args = {k: getattr(cls, k) for k in eval_params}
 
     # ATTN: An important consequence of this update() call is that it
     # fulfills the docstring's promise of overriding any existing

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -390,3 +390,9 @@ eval_defaults = {
     k: p.cmd_kwargs.get('default', None)
     for k, p in eval_params.items()
 }
+"""\
+.. deprecated:: 0.16
+   This variable will be removed in a future release. The default values for
+   all Parameters (possibly overriding by command-specific settings) are now
+   available as :class:`Interface` attributes.
+"""

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -55,7 +55,6 @@ import datalad.support.ansi_colors as ac
 from datalad.interface.base import default_logchannels
 from datalad.interface.base import get_allargs_as_kwargs
 from datalad.interface.common_opts import eval_params
-from datalad.interface.common_opts import eval_defaults
 from .results import known_result_xfms
 from datalad.core.local.resulthooks import (
     get_jsonhooks_from_config,
@@ -342,11 +341,7 @@ def eval_results(wrapped):
                 p_name,
                 # otherwise determine the command class and pull any
                 # default set in that class
-                getattr(
-                    wrapped_class,
-                    p_name,
-                    # or the common default
-                    eval_defaults[p_name]))
+                getattr(wrapped_class, p_name))
             for p_name in eval_params}
 
         # short cuts and configured setup for common options

--- a/docs/source/design/cli.rst
+++ b/docs/source/design/cli.rst
@@ -9,7 +9,7 @@ Command line interface
 
 .. topic:: Specification scope and status
 
-   This is incomplete specification describes the current implementation.
+   This incomplete specification describes the current implementation.
 
 The command line interface (CLI) implementation is located at ``datalad.cli``.
 It provides a console entry point that automatically constructs an
@@ -91,7 +91,7 @@ extensions) are constructed. This can take a considerable amount of time
 that grows with the number of installed extensions.
 
 The information necessary to configure a subparser for a DataLad command is
-determine by inspecting the respective
+determined by inspecting the respective
 :class:`~datalad.interface.base.Interface` class for that command, and reusing
 individual components for the parser. This includes:
 
@@ -118,7 +118,7 @@ Once the main command line entry point determine that a command shall be
 executed, it triggers a handler function that was assigned and parameterized
 with the underlying command :class:`~datalad.interface.base.Interface` during
 parser construction. At the time of execution, this handler is given the result
-of ``argparsed``-based command line argument parsing (i.e., a ``Namespace``
+of ``argparse``-based command line argument parsing (i.e., a ``Namespace``
 instance).
 
 From this parser result, the handler constructs positional and keyword
@@ -128,6 +128,6 @@ such as those for result filtering and rendering, which influence the central
 processing of result recorded yielded by a command.
 
 If an underlying command returns a Python generator it is unwound to trigger
-the respective underlying processing. The handler before no error handling.
+the respective underlying processing. The handler performs no error handling.
 This is left to the main command line entry point.
 

--- a/docs/source/design/cli.rst
+++ b/docs/source/design/cli.rst
@@ -18,7 +18,7 @@ parameterized calls to the targeted command implementations. It also performs
 error handling. The CLI automatically supports all commands, regardless of
 whether they are provided by the core package, or by extensions. It only
 requires them to be discoverable via the respective extension entry points,
-and to implement the standard ``Interface``.
+and to implement the standard :class:`datalad.interface.base.Interface`.
 
 
 Basic workflow of a command line based command execution
@@ -91,8 +91,9 @@ extensions) are constructed. This can take a considerable amount of time
 that grows with the number of installed extensions.
 
 The information necessary to configure a subparser for a DataLad command is
-determine by inspecting the respective ``Interface`` class for that command,
-and reusing individual components for the parser. This includes:
+determine by inspecting the respective
+:class:`~datalad.interface.base.Interface` class for that command, and reusing
+individual components for the parser. This includes:
 
 - the class docstring
 
@@ -115,9 +116,10 @@ The execution handler described here is implemented in ``datalad.cli.exec``.
 
 Once the main command line entry point determine that a command shall be
 executed, it triggers a handler function that was assigned and parameterized
-with the underlying command ``Interface`` during parser construction. At the
-time of execution, this handler is given the result of ``argparsed``-based
-command line argument parsing (i.e., a ``Namespace`` instance).
+with the underlying command :class:`~datalad.interface.base.Interface` during
+parser construction. At the time of execution, this handler is given the result
+of ``argparsed``-based command line argument parsing (i.e., a ``Namespace``
+instance).
 
 From this parser result, the handler constructs positional and keyword
 arguments for the respective ``Interface.__call__()`` execution. It does

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -138,6 +138,15 @@ Test infrastructure
    tests.utils_testrepos
    tests.heavyoutput
 
+Command interface
+=================
+
+.. currentmodule:: datalad
+.. autosummary::
+   :toctree: generated
+
+   interface.base
+
 Command line interface infrastructure
 =====================================
 


### PR DESCRIPTION
- Fixes #6377

### Changelog

#### 📝 Documentation

-  The `datalad.interface.base.Interface` class, the basis of all DataLad command implementations, has been extensively documented to provide an overview of basic principles and customization possibilities (by @mih)

#### 🪓 Deprecations and removals

- `datalad.interface.common_opts.eval_default` has been deprecated. All (command-specific) defaults for common interface parameters can be read from `Interface` class attributes (by @mih)

#### 🏠 Internal

- `datalad.interface.base.Interface` is now an abstract class [#6391](https://github.com/datalad/datalad/pull/6391) (by @mih)

