### PR TITLE
Simplify result rendering, and fix #6393

### DIFF
--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -123,20 +123,12 @@ def main(args=sys.argv):
         sys.exit(2)
 
     # execute the command, either with a debugger catching
-    # a crash, or with a simplistic exception handler
+    # a crash, or with a simplistic exception handler.
+    # note that result rendering is happening in the
+    # execution handler, when the command-generator is unwound
     ret = _run_with_debugger(cmdlineargs) \
         if cmdlineargs.common_debug or cmdlineargs.common_idebug \
         else _run_with_exception_handler(cmdlineargs)
-
-    # render any result, but guard it, because also result renderer could crash
-    try:
-        if hasattr(cmdlineargs, 'result_renderer'):
-            cmdlineargs.result_renderer(ret, cmdlineargs)
-    except Exception as exc:
-        from datalad.support.exceptions import CapturedException
-        ce = CapturedException(exc)
-        lgr.error("Failed to render results due to %s", ce)
-        sys.exit(1)
 
     # all good, not strictly needed, but makes internal testing easier
     sys.exit(0)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -585,6 +585,12 @@ def _process_results(
                and dlcfg.obtain('datalad.ui.suppress-similar-results') \
             else float("inf")
 
+    if result_renderer == 'tailored' and not hasattr(cmd_class,
+                                                     'custom_result_renderer'):
+        # a tailored result renderer is requested, but the class
+        # does not provide any, fall back to the generic one
+        result_renderer = 'generic'
+
     for res in results:
         if not res or 'action' not in res:
             # XXX Yarik has to no clue on how to track the origin of the
@@ -667,9 +673,8 @@ def _process_results(
                 sort_keys=True,
                 indent=2 if result_renderer.endswith('_pp') else None,
                 default=str))
-        elif result_renderer in ('tailored', 'generic', 'default'):
-            if hasattr(cmd_class, 'custom_result_renderer'):
-                cmd_class.custom_result_renderer(res, **allkwargs)
+        elif result_renderer == 'tailored':
+            cmd_class.custom_result_renderer(res, **allkwargs)
         elif hasattr(result_renderer, '__call__'):
             try:
                 result_renderer(res, **allkwargs)


### PR DESCRIPTION
### Changelog
#### 🐛 Bug Fixes
- Restore default result rendering behavior broken by #6391. Fixes #6393
#### 🪓 Deprecations and removals
- An unused code path for result rendering was removed from the CLI `main()`
#### 🏠 Internal
- Simplified the decision making for result rendering, and reduced code complexity.
