### PR TITLE
Update PR template with changelog template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,24 @@
-### Instructions
+### PR checklist
 
-Please go through the following checklist before submitting the PR:
-
-- [ ] Provide an overview of the changes you're making and explain why you're proposing them.
-
-- [ ] Include `Fixes #NNN` or `Closes #NNN` somewhere in the description if this PR addresses an existing issue.
-
+- [ ] Provide an overview of the changes you're making and explain why you're proposing them, ideally in the form of a changelog (template below)
+- [ ] Include `Fixes #NNN` somewhere in the description if this PR addresses an existing issue.
 - [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
-
   Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
-
 - [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
-
 - [ ] **Delete these instructions**. :-)
 
 Thanks for contributing!
+
+### Changelog
+#### 🐛 Bug Fixes
+- Description... Fixes #issue
+#### 💫 Enhancements and new features
+-
+#### 🪓 Deprecations and removals
+-
+#### 📝 Documentation
+-
+#### 🏠 Internal
+-
+#### 🛡 Tests
+-


### PR DESCRIPTION
Re #6388 and example is available at https://github.com/datalad/datalad/pull/6394

Importantly, the changelog template focuses on what is being fixed, rather than by which PR and by whom. The latter will almost always be the proposer (available via API), and the PR number can be auto-added to any harvested changelog entry.