### PR TITLE
Fix fallout from CLI update

### DIFF
--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -116,6 +116,15 @@ def setup_parser(
         completing,
     ) if not (return_subparsers or help_ignore_extensions) else None
 
+    if target_subparser_name is None:
+        # we cannot be lean, we must built the full parser
+        # and for that must load all extensions too, e.g., to
+        # be able to list extension command in --help output
+        # (in case of a help request, the extension loading will not
+        #  have happened yet in single_subparser_possible())
+        from .helpers import add_entrypoints_to_interface_groups
+        add_entrypoints_to_interface_groups(interface_groups)
+
     # --help specification was delayed since it causes immediate printout of
     # --help output before we setup --help for each command
     parser_add_common_opt(parser, 'help')

--- a/datalad/cmdline/main.py
+++ b/datalad/cmdline/main.py
@@ -1,0 +1,20 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+.. deprecated:: 0.16
+   datalad.cmdline.main was replaced by datalad.cli.main
+"""
+
+import warnings
+warnings.warn("datalad.cmdline.main was replaced by datalad.cli.main in "
+              "datalad 0.16. Please update and reinstall extensions.",
+              DeprecationWarning)
+
+from datalad.cli.main import main
+from datalad.cli.parser import setup_parser


### PR DESCRIPTION
- Fixes #6404
- Add compact-shims for old CLI entrypoints (needed for extension doc builds)

Does not need to appear in a release changelog.