### PR TITLE
MNT: Deprecate annexstatus

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -309,7 +309,7 @@ class Save(Interface):
                         # calls
                         paths=None,
                         # prevent whining of GitRepo
-                        git=True if not hasattr(ds.repo, 'annexstatus')
+                        git=True if not hasattr(ds.repo, 'uuid')
                         else to_git,
                         # we are supplying the full status already, do not
                         # detect anything else

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -397,7 +397,7 @@ def test_add_files(path):
         # special case 4: give the dir:
         if arg[0] == test_list_4:
             result = ds.save('dir', to_git=arg[1])
-            status = ds.repo.annexstatus(['dir'])
+            status = ds.repo.get_content_annexinfo(['dir'])
         else:
             result = ds.save(arg[0], to_git=arg[1])
             for a in ensure_list(arg[0]):
@@ -505,7 +505,7 @@ def test_gh1597(path):
     # must not come under annex management
     assert_not_in(
         'key',
-        ds.repo.annexstatus(paths=['.gitmodules']).popitem()[1])
+        ds.repo.get_content_annexinfo(paths=['.gitmodules']).popitem()[1])
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3334,6 +3334,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         return info
 
     def annexstatus(self, paths=None, untracked='all'):
+        """
+        .. deprecated:: 0.16
+
+        Use get_content_annexinfo() or the test helper
+        datalad/utils/get_annexstatus() instead.
+        """
         info = self.get_content_annexinfo(
             paths=paths,
             eval_availability=False,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3336,9 +3336,8 @@ class AnnexRepo(GitRepo, RepoInterface):
     def annexstatus(self, paths=None, untracked='all'):
         """
         .. deprecated:: 0.16
-
-        Use get_content_annexinfo() or the test helper
-        datalad/utils/get_annexstatus() instead.
+            Use get_content_annexinfo() or the test helper
+            datalad/utils/get_annexstatus() instead.
         """
         info = self.get_content_annexinfo(
             paths=paths,

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3405,7 +3405,7 @@ class GitRepo(CoreGitRepo):
             # need to include .gitmodules in what needs saving
             status[self.pathobj.joinpath('.gitmodules')] = dict(
                 type='file', state='modified')
-            if hasattr(self, 'annexstatus') and not kwargs.get('git', False):
+            if hasattr(self, 'uuid') and not kwargs.get('git', False):
                 # we cannot simply hook into the coming add-call
                 # as this would go to annex, so make a dedicted git-add
                 # call to ensure .gitmodules is not annexed
@@ -3431,7 +3431,7 @@ class GitRepo(CoreGitRepo):
                     to_add,
                     git_opts=None,
                     **{k: kwargs[k] for k in kwargs
-                       if k in (('git',) if hasattr(self, 'annexstatus')
+                       if k in (('git',) if hasattr(self, 'uuid')
                                 else tuple())}):
                 yield r
 

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -19,6 +19,7 @@ from datalad.tests.utils import (
     assert_in,
     assert_not_in,
     assert_raises,
+    get_annexstatus,
     known_failure_githubci_win,
     slow,
     with_tempfile,
@@ -58,7 +59,7 @@ def test_get_content_info(path):
     # - git ls-files
     # - git annex findref HEAD
     # - git annex find --include '*'
-    for f, r in ds.repo.annexstatus().items():
+    for f, r in get_annexstatus(ds.repo).items():
         if f.match('*_untracked'):
             assert(r.get('gitshasum', None) is None)
         if f.match('*_deleted'):
@@ -116,7 +117,7 @@ def test_get_content_info(path):
                     assert_in(status[p]['type'], ('file', 'symlink'), p)
 
     # git annex status integrity
-    annexstatus = ds.repo.annexstatus()
+    annexstatus = get_annexstatus(ds.repo)
     for t in ('file',):
         for s in ('untracked', 'added', 'deleted', 'clean',
                   'ingit_clean', 'dropped_clean', 'modified',

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -22,6 +22,7 @@ from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.tests.utils import (
     assert_repo_status,
+    get_annexstatus,
     get_convoluted_situation,
     slow,
 )
@@ -92,7 +93,7 @@ def test_save_to_git(path):
     ds.repo.save(paths=['file_ingit'], git=True)
     ds.repo.save(paths=['file_inannex'])
     assert_repo_status(ds.repo)
-    for f, p in ds.repo.annexstatus().items():
+    for f, p in get_annexstatus(ds.repo).items():
         eq_(p['state'], 'clean')
         if f.match('*ingit'):
             assert_not_in('key', p, f)

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -396,6 +396,30 @@ def _prep_file_under_git(path, filename):
         ds.repo
 
 
+def get_annexstatus(ds, paths=None):
+    """Report a status for annexed contents.
+    Assembles states for git content info, amended with annex info on 'HEAD'
+    (to get the last committed stage and with it possibly vanished content),
+    and lastly annex info wrt to the present worktree, to also get info on
+    added/staged content this fuses the info reported from
+    - git ls-files
+    - git annex findref HEAD
+    - git annex find --include '*'"""
+    info = ds.get_content_annexinfo(
+        paths=paths,
+        eval_availability=False,
+        init=ds.get_content_annexinfo(
+            paths=paths,
+            ref='HEAD',
+            eval_availability=False,
+            init=ds.status(
+                paths=paths,
+                eval_submodule_state='full')
+        )
+    )
+    ds._mark_content_availability(info)
+    return info
+
 #
 # Helpers to test symlinks
 #


### PR DESCRIPTION
This PR works towards #6076, which calls out the ``AnnexRepo``'s ``annexstatus`` method is undocumented and mostly unused with the exception of tests. 

Its remaining usecases are addressed as follows:
- A few spots (in ``save`` and ``GitRepo``) rely on the existence of this method in ``ds.repo`` to assert whether or not we're dealing with an AnnexRepo. These spots were changed to instead check for a ``uuid`` property, which should exist in AnnexRepos but not in GitRepos
- A few tests were using ``annexstatus``. Some were able to change to use ``get_content_annexinfo``. For those that didn't, I moved ``annexstatus`` into ``tests/utils`` as a new test helper ``get_annexstatus``.

#### 🏠 Internal
- AnnexRepo's internal ``annexstatus`` is deprecated. In its place, a new test helper assists the few tests that rely on it. 
