### PR TITLE
RF: use parse_known_args instead of _parse_known_args

### DIFF
--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -98,7 +98,11 @@ def setup_parser(
         description=help_gist,
         epilog='"Be happy!"',
         formatter_class=formatter_class,
-        add_help=False)
+        add_help=False,
+        # set to False so parse_known_args does not add its error handling
+        # Added while RFing from using _parse_known_args to parse_known_args.
+        exit_on_error=False,
+    )
 
     # common options
     parser_add_common_options(parser)
@@ -291,7 +295,7 @@ def single_subparser_possible(cmdlineargs, parser, interface_groups,
     # Before doing anything additional and possibly expensive see may be that
     # we have got the command already
     try:
-        parsed_args, unparsed_args = parser._parse_known_args(
+        parsed_args, unparsed_args = parser.parse_known_args(
             cmdlineargs[1:], argparse.Namespace())
         # before anything handle possible datalad --version
         if not unparsed_args and getattr(parsed_args, 'version', None):

--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -99,9 +99,11 @@ def setup_parser(
         epilog='"Be happy!"',
         formatter_class=formatter_class,
         add_help=False,
-        # set to False so parse_known_args does not add its error handling
-        # Added while RFing from using _parse_known_args to parse_known_args.
-        exit_on_error=False,
+        # TODO: when dropping support for Python 3.8: uncomment below
+        # and use parse_known_args instead of _parse_known_args:
+        # # set to False so parse_known_args does not add its error handling
+        # # Added while RFing from using _parse_known_args to parse_known_args.
+        # exit_on_error=False,
     )
 
     # common options
@@ -295,7 +297,7 @@ def single_subparser_possible(cmdlineargs, parser, interface_groups,
     # Before doing anything additional and possibly expensive see may be that
     # we have got the command already
     try:
-        parsed_args, unparsed_args = parser.parse_known_args(
+        parsed_args, unparsed_args = parser._parse_known_args(
             cmdlineargs[1:], argparse.Namespace())
         # before anything handle possible datalad --version
         if not unparsed_args and getattr(parsed_args, 'version', None):


### PR DESCRIPTION
parse_known_args seems to be doing some processing which we did not
apparently needed. @mih raised concern/question on why we use protected
method and there were no comment/rationale left in the code.

I have set exit_on_error to False since we do not want to add that
error handling behavior since we did not rely on it before

Timing on my laptop on this commit

	$> multitime -n 5 datalad --help-np 1>/dev/null
	===> multitime results
	1: datalad --help-np
				Mean        Std.Dev.    Min         Median      Max
	real        1.304       0.026       1.276       1.294       1.353
	user        1.232       0.035       1.197       1.221       1.300
	sys         0.076       0.010       0.057       0.080       0.085

and on master

	$> multitime -n 5 datalad --help-np 1>/dev/null
	===> multitime results
	1: datalad --help-np
				Mean        Std.Dev.    Min         Median      Max
	real        1.312       0.037       1.270       1.315       1.365
	user        1.229       0.032       1.184       1.228       1.265
	sys         0.087       0.012       0.072       0.090       0.106

so no notable negative impact (good).

#### 🏠 Internal
- Use public `ArgumentParser.parse_known_args` instead of protected `_parse_known_args`
