### PR TITLE
Make CLI autocompletion snappy

### DIFF
--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -153,7 +153,7 @@ def add_entrypoints_to_interface_groups(interface_groups):
             interface_groups.append((ep.name, spec[0], spec[1]))
             lgr.debug('Loaded entrypoint %s', ep.name)
         except Exception as e:
-            ce = CapturedException(ce)
+            ce = CapturedException(e)
             lgr.warning('Failed to load entrypoint %s: %s', ep.name, ce)
             continue
 

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -46,48 +46,9 @@ class HelpAction(argparse.Action):
         if interactive \
                 and option_string == '--help' \
                 and ' ' in parser.prog:  # subcommand
-            try:
-                import subprocess
-                # get the datalad manpage to use
-                manfile = os.environ.get('MANPATH', '/usr/share/man') \
-                    + '/man1/{0}.1.gz'.format(parser.prog.replace(' ', '-'))
-                # extract version field from the manpage
-                if not os.path.exists(manfile):
-                    raise IOError("manfile is not found")
-                with gzip.open(manfile) as f:
-                    man_th = [line for line in f if line.startswith(b".TH")][0]
-                man_version = man_th.split(b' ')[-1].strip(b" '\"\t\n").decode('utf-8')
-
-                # don't show manpage if man_version not equal to current datalad_version
-                if __version__ != man_version:
-                    raise ValueError
-                subprocess.check_call(
-                    'man %s 2> /dev/null' % manfile,
-                    shell=True)
-                sys.exit(0)
-            except (subprocess.CalledProcessError, IOError, OSError, IndexError, ValueError) as e:
-                ce = CapturedException(e)
-                lgr.debug("Did not use manpage since %s", ce)
+            self._try_manpage(parser)
         if option_string == '-h':
-            usage = parser.format_usage()
-            ucomps = re.match(
-                r'(?P<pre>.*){(?P<cmds>.*)}(?P<post>....*)',
-                usage,
-                re.DOTALL)
-            if ucomps:
-                ucomps = ucomps.groupdict()
-                indent_level = len(ucomps['post']) - len(ucomps['post'].lstrip())
-                usage = '{pre}{{{cmds}}}{post}'.format(
-                    pre=ucomps['pre'],
-                    cmds='\n'.join(wrap(
-                        ', '.join(sorted(c.strip() for c in ucomps['cmds'].split(','))),
-                        break_on_hyphens=False,
-                        subsequent_indent=' ' * indent_level)),
-                    post=ucomps['post'],
-                )
-            helpstr = "%s\n%s" % (
-                usage,
-                "Use '--help' to get more comprehensive information.")
+            helpstr = self._get_short_help(parser)
         else:
             helpstr = parser.format_help()
         # better for help2man
@@ -117,6 +78,51 @@ class HelpAction(argparse.Action):
         else:
             print(helpstr)
         sys.exit(0)
+
+    def _get_short_help(self, parser):
+        usage = parser.format_usage()
+        ucomps = re.match(
+            r'(?P<pre>.*){(?P<cmds>.*)}(?P<post>....*)',
+            usage,
+            re.DOTALL)
+        if ucomps:
+            ucomps = ucomps.groupdict()
+            indent_level = len(ucomps['post']) - len(ucomps['post'].lstrip())
+            usage = '{pre}{{{cmds}}}{post}'.format(
+                pre=ucomps['pre'],
+                cmds='\n'.join(wrap(
+                    ', '.join(sorted(c.strip() for c in ucomps['cmds'].split(','))),
+                    break_on_hyphens=False,
+                    subsequent_indent=' ' * indent_level)),
+                post=ucomps['post'],
+            )
+        return "%s\n%s" % (
+            usage,
+            "Use '--help' to get more comprehensive information.")
+
+    def _try_manpage(self, parser):
+        try:
+            import subprocess
+            # get the datalad manpage to use
+            manfile = os.environ.get('MANPATH', '/usr/share/man') \
+                + '/man1/{0}.1.gz'.format(parser.prog.replace(' ', '-'))
+            # extract version field from the manpage
+            if not os.path.exists(manfile):
+                raise IOError("manfile is not found")
+            with gzip.open(manfile) as f:
+                man_th = [line for line in f if line.startswith(b".TH")][0]
+            man_version = man_th.split(b' ')[-1].strip(b" '\"\t\n").decode('utf-8')
+
+            # don't show manpage if man_version not equal to current datalad_version
+            if __version__ != man_version:
+                raise ValueError
+            subprocess.check_call(
+                'man %s 2> /dev/null' % manfile,
+                shell=True)
+            sys.exit(0)
+        except (subprocess.CalledProcessError, IOError, OSError, IndexError, ValueError) as e:
+            ce = CapturedException(e)
+            lgr.debug("Did not use manpage since %s", ce)
 
 
 class LogLevelAction(argparse.Action):

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -50,27 +50,7 @@ class HelpAction(argparse.Action):
         if option_string == '-h':
             helpstr = self._get_short_help(parser)
         else:
-            helpstr = parser.format_help()
-        # better for help2man
-        # for main command -- should be different sections. And since we are in
-        # heavy output massaging mode...
-        if "essential commands" in helpstr.lower():
-            opt_args_str = '*Global options*'
-            pos_args_str = '*Commands*'
-            # tune up usage -- default one is way too heavy
-            helpstr = re.sub(r'^[uU]sage: .*?\n\s*\n',
-                             'Usage: datalad [global-opts] command [command-opts]\n\n',
-                             helpstr,
-                             flags=re.MULTILINE | re.DOTALL)
-            # and altogether remove sections with long list of commands
-            helpstr = re.sub(r'positional arguments:\s*\n\s*{.*}\n', '', helpstr)
-        else:
-            opt_args_str = "*Options*"
-            pos_args_str = "*Arguments*"
-        helpstr = re.sub(r'optional arguments:', opt_args_str, helpstr)
-        helpstr = re.sub(r'positional arguments:', pos_args_str, helpstr)
-        # usage is on the same line
-        helpstr = re.sub(r'^usage:', 'Usage:', helpstr)
+            helpstr = self._get_long_help(parser)
 
         if interactive and option_string == '--help':
             import pydoc
@@ -79,22 +59,74 @@ class HelpAction(argparse.Action):
             print(helpstr)
         sys.exit(0)
 
+    def _get_long_help(self, parser):
+        helpstr = parser.format_help()
+        helpstr = re.sub(
+            r'^[uU]sage: .*?\n\s*\n',
+            'Usage: datalad [global-opts] command [command-opts]\n\n',
+            helpstr,
+            flags=re.MULTILINE | re.DOTALL)
+        # split into preamble and options
+        preamble = []
+        options = []
+        in_options = False
+        for line in helpstr.splitlines():
+            if line == 'optional arguments:':
+                in_options = True
+                continue
+            (options if in_options else preamble).append(line)
+
+        intf = self._get_all_interfaces()
+        from datalad.interface.base import (
+            get_cmd_doc,
+            load_interface,
+        )
+        from .interface import (
+            get_cmdline_command_name,
+            alter_interface_docs_for_cmdline,
+        )
+        preamble = get_description_with_cmd_summary(
+            # produce a mapping of command groups to
+            # [(cmdname, description), ...]
+            {
+                i[0]: [(
+                    get_cmdline_command_name(c),
+                    # alter_interface_docs_for_cmdline is only needed, because
+                    # some commands use sphinx markup in their summary line
+                    # stripping that takes 10-30ms for a typical datalad
+                    # installation with some extensions
+                    alter_interface_docs_for_cmdline(
+                        # we only take the first line
+                        get_cmd_doc(
+                            # we must import the interface class
+                            # this will engage @build_doc -- unavoidable right
+                            # now
+                            load_interface(c)
+                        ).split('\n', maxsplit=1)[0]))
+                    for c in i[2]]
+                for i in intf
+            },
+            intf,
+            '\n'.join(preamble),
+        )
+        return '{}\n\n*Global options*\n{}\n'.format(
+            preamble,
+            '\n'.join(options),
+        )
+
     def _get_short_help(self, parser):
         usage = parser.format_usage()
+        # normalize capitalization to what we "always" had
+        usage = f'Usage:{usage[6:]}'
         hint = "Use '--help' to get more comprehensive information."
         if ' ' in parser.prog:  # subcommand
             # in case of a subcommand there is no need to pull the
             # list of top-level subcommands
             return f"{usage}\n{hint}"
 
-        # load all extensions and command specs
-        # this does not fully tune all the command docs
-        from datalad.interface.base import get_interface_groups
-        interface_groups = get_interface_groups()
-        add_entrypoints_to_interface_groups(interface_groups)
         # get the list of commands and format them like
         # argparse would present subcommands
-        commands = get_commands_from_groups(interface_groups).keys()
+        commands = get_commands_from_groups(self._get_all_interfaces())
         indent = usage.splitlines()[-1]
         indent = indent[:-len(indent.lstrip())] + ' '
         usage += f'{indent[1:]}{{'
@@ -104,6 +136,14 @@ class HelpAction(argparse.Action):
             subsequent_indent=indent))
         usage += f'}}\n{indent[1:]}...\n'
         return f"{usage}\n{hint}"
+
+    def _get_all_interfaces(self):
+        # load all extensions and command specs
+        # this does not fully tune all the command docs
+        from datalad.interface.base import get_interface_groups
+        interface_groups = get_interface_groups()
+        add_entrypoints_to_interface_groups(interface_groups)
+        return interface_groups
 
     def _try_manpage(self, parser):
         try:
@@ -200,16 +240,16 @@ def get_description_with_cmd_summary(grp_short_descriptions, interface_groups,
     # we need one last formal section to not have the trailed be
     # confused with the last command group
     cmd_summary.append('\n*General information*\n')
-    detailed_description = '%s\n%s\n\n%s' \
-                           % (parser_description,
-                              '\n'.join(cmd_summary),
-                              textwrap.fill(dedent_docstring("""\
+    detailed_description = '{}{}\n{}\n'.format(
+        parser_description,
+        '\n'.join(cmd_summary),
+        textwrap.fill(dedent_docstring("""\
     Detailed usage information for individual commands is
     available via command-specific --help, i.e.:
     datalad <command> --help"""),
-                                            console_width - 5,
-                                            initial_indent='',
-                                            subsequent_indent=''))
+                      console_width - 5,
+                      initial_indent='',
+                      subsequent_indent=''))
     return detailed_description
 
 

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -141,7 +141,7 @@ def add_entrypoints_to_interface_groups(interface_groups):
     from pkg_resources import iter_entry_points  # delay expensive import
     for ep in iter_entry_points('datalad.extensions'):
         lgr.debug(
-            'Loading entrypoint %s from datalad.extensions for docs building',
+            'Loading entrypoint %s from datalad.extensions',
             ep.name)
         try:
             spec = ep.load()

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -52,6 +52,9 @@ class HelpAction(argparse.Action):
         else:
             helpstr = self._get_long_help(parser)
 
+        # normalize capitalization to what we "always" had
+        helpstr = f'Usage:{helpstr[6:]}'
+
         if interactive and option_string == '--help':
             import pydoc
             pydoc.pager(helpstr)
@@ -61,6 +64,10 @@ class HelpAction(argparse.Action):
 
     def _get_long_help(self, parser):
         helpstr = parser.format_help()
+        if ' ' in parser.prog:  # subcommand
+            # in case of a subcommand there is no need to pull the
+            # list of top-level subcommands
+            return helpstr
         helpstr = re.sub(
             r'^[uU]sage: .*?\n\s*\n',
             'Usage: datalad [global-opts] command [command-opts]\n\n',
@@ -116,8 +123,6 @@ class HelpAction(argparse.Action):
 
     def _get_short_help(self, parser):
         usage = parser.format_usage()
-        # normalize capitalization to what we "always" had
-        usage = f'Usage:{usage[6:]}'
         hint = "Use '--help' to get more comprehensive information."
         if ' ' in parser.prog:  # subcommand
             # in case of a subcommand there is no need to pull the

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -62,6 +62,11 @@ def main(args=sys.argv):
     lgr.log(5, "Starting main(%r)", args)
     # record that we came in via the cmdline
     datalad.__api = 'cmdline'
+    completing = "_ARGCOMPLETE" in os.environ
+    if completing:
+        import shlex
+        # TODO support posix=False too?
+        args = shlex.split(os.environ.get('COMP_LINE')) or args
 
     if _on_msys_tainted_paths():
         # Possibly present DataLadRIs were stripped of a leading /
@@ -71,7 +76,7 @@ def main(args=sys.argv):
     # PYTHON_ARGCOMPLETE_OK
     # TODO possibly construct a dedicated parser just for autocompletion
     # rather than lobotomizing the normal one
-    parser = setup_parser(args, completing="_ARGCOMPLETE" in os.environ)
+    parser = setup_parser(args, completing=completing)
     try:
         import argcomplete
         argcomplete.autocomplete(parser)

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -63,10 +63,10 @@ def main(args=sys.argv):
     # record that we came in via the cmdline
     datalad.__api = 'cmdline'
     completing = "_ARGCOMPLETE" in os.environ
-    if completing:
+    if completing and 'COMP_LINE' in os.environ:
         import shlex
         # TODO support posix=False too?
-        args = shlex.split(os.environ.get('COMP_LINE')) or args
+        args = shlex.split(os.environ['COMP_LINE']) or args
 
     if _on_msys_tainted_paths():
         # Possibly present DataLadRIs were stripped of a leading /

--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -117,9 +117,8 @@ def setup_parser(
 
     command_provider = 'core'
 
-    if status == 'help' and not help_ignore_extensions or (
-        status == 'subcommand' and parseinfo not in
-            get_commands_from_groups(interface_groups)):
+    if status == 'subcommand' and parseinfo not in \
+            get_commands_from_groups(interface_groups):
         # we know the command is not in the core package
         # still a chance it could be in an extension
         command_provider = 'extension'
@@ -151,7 +150,7 @@ def setup_parser(
 
     all_parsers = {}  # name: (sub)parser
 
-    if status == 'help' or status == 'subcommand':
+    if status == 'subcommand':
         # parseinfo could be None here, when we could not identify
         # a subcommand, but need to locate matching ones for
         # completion
@@ -162,16 +161,15 @@ def setup_parser(
                 in sorted(interface_groups, key=lambda x: x[1]):
             for _intfspec in _interfaces:
                 cmd_name = get_cmdline_command_name(_intfspec)
-                if status != 'help':
-                    if command_provider and cmd_name != parseinfo:
-                        # a known command, but know what we are looking for
-                        continue
-                    if command_provider is None and not cmd_name.startswith(
-                            parseinfo):
-                        # an unknown command, and has no common prefix with
-                        # the current command candidate, not even good
-                        # for completion
-                        continue
+                if command_provider and cmd_name != parseinfo:
+                    # a known command, but know what we are looking for
+                    continue
+                if command_provider is None and not cmd_name.startswith(
+                        parseinfo):
+                    # an unknown command, and has no common prefix with
+                    # the current command candidate, not even good
+                    # for completion
+                    continue
                 subparser = add_subparser(
                     _intfspec,
                     subparsers,
@@ -182,15 +180,6 @@ def setup_parser(
                 )
                 if subparser:  # interface can fail to load
                     all_parsers[cmd_name] = subparser
-
-    # create command summary
-    if not completing and status == 'help' and (
-            '--help' in cmdlineargs or '--help-np' in cmdlineargs):
-        from .helpers import get_description_with_cmd_summary
-        parser.description = get_description_with_cmd_summary(
-            grp_short_descriptions,
-            interface_groups,
-            parser.description)
 
     # "main" parser is under "datalad" name
     all_parsers['datalad'] = parser

--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -265,6 +265,11 @@ def setup_parserarg_for_interface(parser, param_name, param, defaults_idx,
         parser_kwargs['type'] = param.constraints
     if completing:
         help = None
+        # if possible, define choices to enable their completion
+        if 'choices' not in parser_kwargs and \
+                isinstance(param.constraints, EnsureChoice):
+            parser_kwargs['choices'] = [
+                c for c in param.constraints._allowed if c is not None]
     else:
         help = _amend_param_parser_kwargs_for_help(
             parser_kwargs, param,

--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -94,6 +94,7 @@ def setup_parser(
     # main parser
     parser = ArgumentParserDisableAbbrev(
         fromfile_prefix_chars=None,
+        prog='datalad',
         # usage="%(prog)s ...",
         description=help_gist,
         epilog='"Be happy!"',

--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -122,8 +122,11 @@ def setup_parser(
         from .helpers import add_entrypoints_to_interface_groups
         add_entrypoints_to_interface_groups(interface_groups)
 
-    if status == 'subcommand' and parseinfo not in \
-            get_commands_from_groups(interface_groups):
+    # when completing and we have no incomplete option or parameter
+    # we still need to offer all commands for completion
+    if (completing and status == 'allknown') or (
+            status == 'subcommand' and parseinfo not in
+            get_commands_from_groups(interface_groups)):
         # we know the command is not in the core package
         # still a chance it could be in an extension
         command_provider = 'extension'
@@ -155,7 +158,8 @@ def setup_parser(
 
     all_parsers = {}  # name: (sub)parser
 
-    if status in ('allparsers', 'subcommand'):
+    if (completing and status == 'allknown') or status \
+            in ('allparsers', 'subcommand'):
         # parseinfo could be None here, when we could not identify
         # a subcommand, but need to locate matching ones for
         # completion

--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -92,7 +92,7 @@ def run_main(args, exit_code=0, expect_stderr=False):
     return stdout, stderr
 
 
-def get_all_commands() -> list[str]:
+def get_all_commands() -> list:
     return list(get_commands_from_groups(get_interface_groups()))
 
 
@@ -322,7 +322,7 @@ def test_completion(out_fn):
     from datalad.cmd import WitlessRunner
     runner = WitlessRunner()
 
-    def get_completions(s: str, expected) -> list[str]:
+    def get_completions(s: str, expected) -> list:
         """Run 'datalad' external command and collect completions
 
         Parameters

--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -91,10 +91,14 @@ def run_main(args, exit_code=0, expect_stderr=False):
     return stdout, stderr
 
 
+def get_all_commands() -> list[str]:
+    return list(get_commands_from_groups(get_interface_groups()))
+
+
 def assert_all_commands_present(out):
     """Helper to reuse to assert that all known commands are present in output
     """
-    for cmd in get_commands_from_groups(get_interface_groups()):
+    for cmd in get_all_commands():
         assert_re_in(fr"\b{cmd}\b", out, match=False)
 
 
@@ -308,3 +312,58 @@ def test_librarymode(path):
         # restore pre-test behavior
         datalad.__runtime_mode = was_mode
         datalad.cfg.overrides.pop('datalad.runtime.librarymode')
+
+
+@with_tempfile
+def test_completion(out_fn):
+
+    def get_completions(s: str, expected, exit_code=2) -> list[str]:
+        """
+
+        Parameters
+        ----------
+        s: str
+          what to append to 'datalad ' invocation
+        expected: iterable of str
+          What entries to expect - would raise AssertionError if any is
+          not present in output
+        exit_code: int, optional
+          If incomplete/malformed we seems to get 2, most frequently used
+          so default
+
+        Returns
+        -------
+        list of str
+          Entries output
+        """
+        if os.path.exists(out_fn):  # reuse but ensure it is gone
+            os.unlink(out_fn)
+        comp_line = f'datalad {s}'
+        with patch.dict('os.environ',
+                {
+                    '_ARGCOMPLETE': '1',
+                    '_ARGCOMPLETE_STDOUT_FILENAME': out_fn,
+                    'COMP_LINE': comp_line,
+                    # without -1 seems to get "finished completion", someone can investigate more
+                    'COMP_POINT': str(len(comp_line)-1),  # always at the end ATM
+                 }), \
+            patch.object(os, '_exit', print):
+            run_main([], exit_code=exit_code, expect_stderr=True)
+        with open(out_fn, 'rb') as f:
+            entries = f.read().split(b'\x0b')
+            entries = [e.decode() for e in entries]
+        diff = set(expected).difference(entries)
+        if diff:
+            raise AssertionError(
+                f"Entries {sorted(diff)} were expected but not found in the completion output: {entries}"
+            )
+        return entries  # for extra analyzes if so desired
+
+    all_commands = get_all_commands()
+    get_completions('i', {'install'})
+    get_completions(' ', ['--dbg', '-c'] + all_commands)
+    # if command already matches -- we get only that hit ATM, not others which begin with it
+    get_completions('create', ['create '], exit_code=1)
+    get_completions('create -', ['--dataset'], exit_code=1)
+    # but for incomplete one we do get all create* commands
+    get_completions('creat', [c for c in all_commands if c.startswith('create')])


### PR DESCRIPTION
It basically inspects the incomplete argument list now, and
based on that can make more clever decisions what to load.

There are more possibilities for making things faster. For
example, we could load the extensions one by one, while searching
for unknown commands. But already now it feels great.

This change should have no impact on the full help generation. But it
breaks the interal operations needed to build manpages and docs.
This needs fixing, but was always ugly anyways.

Closes #6407 

TODO:

- [x] subcommand `-h` no longer displays choices (works for `--help-np`). For example, compare: `datalad run -h`
- [x] support auto-completion of parameter value choices

### Changelog
#### 💫 Enhancements and new features
- The CLI help generation has been sped up, and now also supports the completion of parameter values for a fixed set of choices.

