### PR TITLE
DOC: run - adjust description for -i/-o to mention that it could be a directory

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -200,7 +200,7 @@ class Run(Interface):
             metavar=("PATH"),
             action='append',
             doc="""A dependency for the run. Before running the command, the
-            content of this file will be retrieved. A value of "." means "run
+            content of this file (or directory) will be retrieved. A value of "." means "run
             :command:`datalad get .`". The value can also be a glob. [CMD: This
             option can be given more than once. CMD]"""),
         outputs=Parameter(
@@ -208,7 +208,7 @@ class Run(Interface):
             dest="outputs",
             metavar=("PATH"),
             action='append',
-            doc="""Prepare this file to be an output file of the command. A
+            doc="""Prepare this file (or directory) to be an output file of the command. A
             value of "." means "run :command:`datalad unlock .`" (and will fail
             if some content isn't present). For any other value, if the content
             of this file is present, unlock the file. Otherwise, remove it. The

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -200,7 +200,7 @@ class Run(Interface):
             metavar=("PATH"),
             action='append',
             doc="""A dependency for the run. Before running the command, the
-            content of this file (or directory) will be retrieved. A value of "." means "run
+            content for this relative path will be retrieved. A value of "." means "run
             :command:`datalad get .`". The value can also be a glob. [CMD: This
             option can be given more than once. CMD]"""),
         outputs=Parameter(
@@ -208,7 +208,7 @@ class Run(Interface):
             dest="outputs",
             metavar=("PATH"),
             action='append',
-            doc="""Prepare this file (or directory) to be an output file of the command. A
+            doc="""Prepare this relative path to be an output file of the command. A
             value of "." means "run :command:`datalad unlock .`" (and will fail
             if some content isn't present). For any other value, if the content
             of this file is present, unlock the file. Otherwise, remove it. The


### PR DESCRIPTION
AFAIK, those could point to directories since otherwise such option
would not scale for many realistic scenarios.  But @djarecka mentioned
that docs explicitly mention file only, not directories, which led her
to believe that it must point to a file.

May be wording could be adjusted, I was aiming for the shortest way to express myself.  Or should we switch to use `path` instead of `file`?
