### PR TITLE
Prevent double-rendering of save results by run.

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -842,5 +842,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                     recursive=True,
                     message=msg,
                     jobs=jobs,
-                    return_type='generator'):
+                    return_type='generator',
+                    # we want this command and its parameterization to be in full
+                    # control about the rendering of results, hence we must turn
+                    # off internal rendering
+                    result_renderer='disabled'):
                 yield r


### PR DESCRIPTION
This should have been done from the very beginning, but it was not
necessary to achieve the desired behavior due to a series of
side-effects of the complexity of determining the effective result
renderer (see #6394 for an entry point into the series of changes).

### Changelog
#### 🐛 Bug Fixes
- `run` no longer let's the internal call to `save` render its results unconditionally, but the parameterization of `run` determines the effective rendering format. Fixes #6420
