### PR TITLE
`run` improvements towards #6401

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -710,7 +710,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 rerun_outputs=None,
                 inject=False,
                 parametric_record=False,
-                remove_outputs=False):
+                remove_outputs=False,
+                skip_dirtycheck=False):
     """Run `cmd` in `dataset` and record the results.
 
     `Run.__call__` is a simple wrapper over this function. Aside from backward
@@ -747,6 +748,11 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     remove_outputs : bool, optional
         If enabled, all declared outputs will be removed prior command
         execution, except for paths that are also declared inputs.
+    skip_dirtycheck : bool, optional
+        If enabled, a check for dataset modifications is unconditionally
+        disabled, even if other parameters would indicate otherwise. This
+        can be used by callers that already performed analog verififcations
+        to avoid duplicate processing.
 
     Yields
     ------
@@ -777,7 +783,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 
     lgr.debug('tracking command output underneath %s', ds)
 
-    if not (rerun_info or inject):
+    # skip for callers that already take care of this
+    if not (skip_dirtycheck or rerun_info or inject):
         # For explicit=True, we probably want to check whether any inputs have
         # modifications. However, we can't just do is_dirty(..., path=inputs)
         # because we need to consider subdatasets and untracked files.

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -11,58 +11,56 @@
 __docformat__ = 'restructuredtext'
 
 
-import logging
 import json
-import warnings
-
-from pathlib import Path
-
-from argparse import REMAINDER
+import logging
 import os
 import os.path as op
-from os.path import join as opj
-from os.path import normpath
-from os.path import relpath
+from pathlib import Path
+import warnings
+from argparse import REMAINDER
 from tempfile import mkdtemp
 
 import datalad
+import datalad.support.ansi_colors as ac
+from datalad.config import anything2bool
 from datalad.core.local.save import Save
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
 from datalad.distribution.get import Get
 from datalad.distribution.install import Install
-from datalad.local.unlock import Unlock
-
-from datalad.interface.base import Interface
-from datalad.interface.utils import generic_result_renderer
-from datalad.interface.utils import eval_results
-from datalad.interface.base import build_doc
-from datalad.interface.results import get_status_dict
-from datalad.interface.common_opts import (
-    save_message_opt,
-    jobs_opt
+from datalad.interface.base import (
+    Interface,
+    build_doc,
 )
-
-from datalad.config import anything2bool
-
-import datalad.support.ansi_colors as ac
-from datalad.support.constraints import EnsureChoice
-from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureBool
+from datalad.interface.common_opts import (
+    jobs_opt,
+    save_message_opt,
+)
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import (
+    eval_results,
+    generic_result_renderer,
+)
+from datalad.local.unlock import Unlock
+from datalad.support.constraints import (
+    EnsureBool,
+    EnsureChoice,
+    EnsureNone,
+)
 from datalad.support.exceptions import (
     CapturedException,
-    CommandError
+    CommandError,
 )
 from datalad.support.globbedpaths import GlobbedPaths
-from datalad.support.param import Parameter
 from datalad.support.json_py import dump2stream
-
-from datalad.distribution.dataset import Dataset
-from datalad.distribution.dataset import require_dataset
-from datalad.distribution.dataset import EnsureDataset
-from datalad.distribution.dataset import datasetmethod
-
+from datalad.support.param import Parameter
 from datalad.ui import ui
-
 from datalad.utils import (
+    SequenceFormatter,
     chpwd,
     ensure_list,
     ensure_unicode,
@@ -70,7 +68,6 @@ from datalad.utils import (
     getpwd,
     join_cmdline,
     quote_cmdlinearg,
-    SequenceFormatter,
 )
 
 lgr = logging.getLogger('datalad.core.local.run')
@@ -398,7 +395,7 @@ def get_command_pwds(dataset):
             dataset = get_dataset_root(pwd)
 
         if dataset:
-            rel_pwd = relpath(pwd, dataset)
+            rel_pwd = op.relpath(pwd, dataset)
         else:
             rel_pwd = pwd  # and leave handling to caller
     return pwd, rel_pwd
@@ -735,8 +732,8 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     rel_pwd = rerun_info.get('pwd') if rerun_info else None
     if rel_pwd and dataset:
         # recording is relative to the dataset
-        pwd = normpath(opj(dataset.path, rel_pwd))
-        rel_pwd = relpath(pwd, dataset.path)
+        pwd = op.normpath(op.join(dataset.path, rel_pwd))
+        rel_pwd = op.relpath(pwd, dataset.path)
     else:
         pwd, rel_pwd = get_command_pwds(dataset)
 

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -145,7 +145,7 @@ class Run(Interface):
 
       Add a placeholder "name" with the value "joe"::
 
-        % git config --file=.datalad/config datalad.run.substitutions.name joe
+        % datalad configuration --scope branch set datalad.run.substitutions.name=joe
         % datalad save -m "Configure name placeholder" .datalad/config
 
       Access the new placeholder in a command::

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -1021,6 +1021,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     # depending on the config/request
     record, record_path = _create_record(run_info, sidecar, ds)
 
+    # abbreviate version of the command for illustrative purposes
+    cmd_shorty = _format_cmd_shorty(cmd_expanded)
+
     # compose commit message
     msg = u"""\
 [DATALAD RUNCMD] {}
@@ -1030,7 +1033,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
 ^^^ Do not change lines above ^^^
 """
     msg = msg.format(
-        message if message is not None else _format_cmd_shorty(cmd_expanded),
+        message if message is not None else cmd_shorty,
         '"{}"'.format(record) if record_path else record)
 
     outputs_to_save = globbed['outputs'].expand_strict() if explicit else None
@@ -1056,7 +1059,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     run_result = get_status_dict(
         "run", ds=ds,
         status=status,
-        message="Executed command",
+        # use the abbrev. command as the message to give immediate clarity what
+        # completed/errors in the generic result rendering
+        message=cmd_shorty,
         run_info=run_info,
         # use the same key that `get_status_dict()` would/will use
         # to record the exit code in case of an exception

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -15,15 +15,16 @@ import json
 import logging
 import os
 import os.path as op
-from pathlib import Path
 import warnings
 from argparse import REMAINDER
+from pathlib import Path
 from tempfile import mkdtemp
 
 import datalad
 import datalad.support.ansi_colors as ac
 from datalad.config import anything2bool
 from datalad.core.local.save import Save
+from datalad.core.local.status import Status
 from datalad.distribution.dataset import (
     Dataset,
     EnsureDataset,
@@ -45,7 +46,6 @@ from datalad.interface.utils import (
     eval_results,
     generic_result_renderer,
 )
-from datalad.core.local.status import Status
 from datalad.local.unlock import Unlock
 from datalad.support.constraints import (
     EnsureBool,

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -45,6 +45,8 @@ from datalad.api import (
 from datalad.core.local.run import (
     format_command,
     run_command,
+    _format_iospecs,
+    _get_substitutions,
 )
 from datalad.tests.utils import (
     assert_false,
@@ -65,6 +67,7 @@ from datalad.tests.utils import (
     ok_,
     ok_exists,
     ok_file_has_content,
+    patch_config,
     swallow_logs,
     swallow_outputs,
     with_tempfile,
@@ -723,3 +726,56 @@ def test_dry_run(path):
         ds.run("blah {inputs}", dry_run="basic", inputs=["sub/b*"])
         assert_in("sub/b*", cmo.out)
         assert_not_in("baz", cmo.out)
+
+
+@with_tree(tree={OBSCURE_FILENAME + ".t": "obscure",
+                 "normal.txt": "normal"})
+def test_io_substitution(path):
+    files = [OBSCURE_FILENAME + ".t", "normal.txt"]
+    ds = Dataset(path).create(force=True)
+    ds.save()
+    # prefix the content of any given file with 'mod::'
+    cmd = "import sys; from pathlib import Path; t = [(Path(p), 'mod::' + Path(p).read_text()) for p in sys.argv[1:]]; [k.write_text(v) for k, v in t]"
+    cmd_str = "{} -c \"{}\" {{inputs}}".format(sys.executable, cmd)
+    # this should run and not crash with permission denied
+    ds.run(cmd_str, inputs=["{outputs}"], outputs=["*.t*"],
+           result_renderer='disabled')
+    # all filecontent got the prefix
+    for f in files:
+        ok_((ds.pathobj / f).read_text().startswith('mod::'))
+
+    # we could just ds.rerun() now, and it should work, but this would make
+    # rerun be a dependency of a core test
+
+
+def test_format_iospecs():
+    seq = ['one', 'two']
+    eq_(seq, _format_iospecs(['{dummy}'], dummy=seq))
+    # garbage when combined with longer spec-sequences
+    # but this is unavoidable without introducing a whitelist
+    # of supported value types -- which would limit flexibility
+    eq_(["['one', 'two']", 'other'],
+        _format_iospecs(['{dummy}', 'other'], dummy=seq))
+
+
+def test_substitution_config():
+    # use a shim to avoid having to create an actual dataset
+    # the tested function only needs a `ds.config` to be a ConfigManager
+    from datalad import cfg
+
+    class dset:
+        config = cfg
+
+    # empty be default
+    eq_(_get_substitutions(dset), {})
+    # basic access
+    with patch_config({"datalad.run.substitutions.dummy": 'ork'}):
+        eq_(_get_substitutions(dset), dict(dummy='ork'))
+    # can report multi-value
+    with patch_config({"datalad.run.substitutions.dummy": ['a', 'b']}):
+        eq_(_get_substitutions(dset), dict(dummy=['a', 'b']))
+
+        # verify combo with iospec formatting
+        eq_(_format_iospecs(['{dummy}'],
+                            **_get_substitutions(dset)),
+            ['a', 'b'])

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -746,6 +746,12 @@ def test_io_substitution(path):
 
     # we could just ds.rerun() now, and it should work, but this would make
     # rerun be a dependency of a core test
+    # instead just double-run, but with a non-list input-spec.
+    # should have same outcome
+    ds.run(cmd_str, inputs="{outputs}", outputs="*.t*",
+           result_renderer='disabled')
+    for f in files:
+        ok_((ds.pathobj / f).read_text().startswith('mod::mod::'))
 
 
 def test_format_iospecs():

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -14,41 +14,35 @@ Note: Tests of `run` that involve `rerun` are in interface.tests.test_run.
 __docformat__ = 'restructuredtext'
 
 import logging
-
 import os
 import os.path as op
+import sys
 from os import (
     mkdir,
     remove,
 )
-import sys
-
 from unittest.mock import patch
 
-from datalad.utils import (
-    chpwd,
-    ensure_unicode,
-    on_windows,
-)
-
-from datalad.cli.main import main
-from datalad.distribution.dataset import Dataset
-from datalad.support.exceptions import (
-    CommandError,
-    NoDatasetFound,
-    IncompleteResultsError,
-)
 from datalad.api import (
     clone,
     run,
 )
+from datalad.cli.main import main
 from datalad.core.local.run import (
-    format_command,
-    run_command,
     _format_iospecs,
     _get_substitutions,
+    format_command,
+    run_command,
+)
+from datalad.distribution.dataset import Dataset
+from datalad.support.exceptions import (
+    CommandError,
+    IncompleteResultsError,
+    NoDatasetFound,
 )
 from datalad.tests.utils import (
+    DEFAULT_BRANCH,
+    OBSCURE_FILENAME,
     assert_false,
     assert_in,
     assert_in_results,
@@ -59,11 +53,9 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_status,
     create_tree,
-    DEFAULT_BRANCH,
     eq_,
     known_failure_windows,
     neq_,
-    OBSCURE_FILENAME,
     ok_,
     ok_exists,
     ok_file_has_content,
@@ -73,7 +65,11 @@ from datalad.tests.utils import (
     with_tempfile,
     with_tree,
 )
-
+from datalad.utils import (
+    chpwd,
+    ensure_unicode,
+    on_windows,
+)
 
 cat_command = 'cat' if not on_windows else 'type'
 

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -14,6 +14,7 @@ subsystems in DataLad.
    :maxdepth: 2
 
    cli
+   provenance_capture
    application_vs_library_mode
    file_url_handling
    result_records

--- a/docs/source/design/provenance_capture.rst
+++ b/docs/source/design/provenance_capture.rst
@@ -1,0 +1,134 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_design_provenance_capture:
+
+******************
+Provenance capture
+******************
+
+.. topic:: Specification scope and status
+
+   This specification describes the current implementation.
+
+The ability to capture process provenance---the information what activity
+initiated by which entity yielded which outputs, given a set of parameters, a
+computational environment, and potential input data---is a core feature of
+DataLad.
+
+Provenance capture is supported for any computational process that can be
+expressed as a command line call. The simplest form of provenance tracking can
+be implemented by prefixing any such a command line call with ``datalad run
+...``.  When executed in the content of a dataset (with the current working
+directory typically being in the root of a dataset), DataLad will then:
+
+1. check the dataset for any unsaved modifications
+2. execute the given command, when no modifications were found
+3. save any changes to the dataset that exist after the command has exited without error
+
+The saved changes are annotated with a structured record that, at minimum,
+contains the executed command.
+
+This kind of usage is sufficient for building up an annotated history of a
+dataset, where all relevant modifications are clearly associated with the
+commands that caused them. By providing more, optional, information to the
+``run`` command, such as a declaration of inputs and outputs, provenance
+records can be further enriched. This enables additional functionality, such as
+the automated re-execution of captured processes.
+
+
+The provenance record
+=====================
+
+A DataLad provenance record is a key-value mapping comprising the following
+main items:
+
+- ``cmd``: executed command, which may contain placeholders
+- ``dsid``: DataLad ID of dataset in whose context the command execution took place
+- ``exit``: numeric exit code of the command
+- ``inputs``: a list of (relative) file paths for all declared inputs
+- ``outputs``: a list of (relative) file paths for all declared outputs
+- ``pwd``: relative path of the working directory for the command execution
+
+A provenance record is stored in a JSON-serialized form in one of two locations:
+
+1. In the body of the commit message created when saving caused the dataset modifications
+2. In a sidecar file underneath ``.datalad/runinfo`` in the root dataset
+
+Sidecar files have a filename (``record_id``) that is based on checksum of the
+provenance record content, and are stored as LZMA-compressed binary files.
+When a sidecar file is used, its ``record_id`` is added to the commit message,
+instead of the complete record.
+
+
+Declaration of inputs and outputs
+=================================
+
+While not strictly required, it is possible and recommended to declare all
+paths for process inputs and outputs of a command execution via the respective
+options of ``run``.
+
+For all declared inputs, ``run`` will ensure that their file content is present
+locally at the required version before executing the command.
+
+For all declared outputs, ``run`` will ensure that the respective locations are
+writeable.
+
+It is recommended to declare inputs and outputs both exhaustively and precise,
+in order to enable the provenance-based automated re-execution of a command. In
+case of a future re-execution the dataset content may have changed
+substantially, and a needlessly broad specification of inputs/outputs may lead
+to undesirable data transfers.
+
+
+Placeholders in commands and IO specifications
+==============================================
+
+Both command and input/output specification can employ placeholders that will
+be expanded before command execution. Placeholders use the syntax of the Python
+``format()`` specification. A number of standard placeholders are supported
+(see the ``run`` documentation for a complete list):
+
+- ``{pwd}`` will be replaced with the full path of the current working directory
+- ``{dspath}`` will be replaced with the full path of the dataset that run is invoked on
+- ``{inputs}`` and ``{outputs}`` expand a space-separated list of the declared input and output paths
+
+Additionally, custom placeholders can be defined as configuration variables
+under the prefix ``datalad.run.substitutions.``. For example, a configuration
+setting ``datalad.run.substitutions.myfile=data.txt`` will cause the
+placeholder ``{myfile}`` to expand to ``data.txt``.
+
+Selection of individual items for placeholders that expand to multiple values
+is possible via the standard Python ``format()`` syntax, for example
+``{inputs[0]}``.
+
+
+Result records emitted by ``run``
+=================================
+
+When performing a command execution ``run`` will emit results for:
+
+1. Input preparation (i.e. downloads)
+2. Output preparation (i.e. unlocks and removals)
+3. Command execution
+4. Dataset modification saving (i.e. additions, deletions, modifications)
+
+By default, ``run`` will stop on the first error. This means that, for example,
+any failure to download content will prevent command execution. A failing
+command will prevent saving a potential dataset modification. This behavior can
+be altered using the standard ``on_failure`` switch of the ``run`` command.
+
+The emitted result for the command execution contains the provenance record
+under the ``run_info`` key.
+
+
+Implementation details
+======================
+
+Most of the described functionality is implemented by the function
+:func:`datalad.core.local.run.run_command`. It is interfaced by the ``run``
+command, but also ``rerun``, a utility for automated re-execution based on
+provenance records, and ``containers-run`` (provided by the ``container``
+extension package) for command execution in DataLad-tracked containerized
+environments. This function has a more complex interface, and supports a wider
+range of use cases than described here.


### PR DESCRIPTION
Work towards

- #6401
- #2850

This adds a bunch of features to the internal `run`/`rerun` workhorse `run_command()` that are necessary to be able to implement a solution to #6401 efficiently, without reaching further into the guts of the machinery.

I will keep this open, until such a solution is fully implemented, and testable -- however, I am fairly confident at this point that this is pretty much the entire change. I am hoping to be able to add a design document on run records and `run`'s results at the very end. Reviews welcome now!

TODO:

- [x] rather than including just `declared_outputs` in the `run` result, I feel like we should also yield `declared_inputs`. With `remove_outpus=True`, a caller may need to know which files where actually generated (not inputs/outputs intersection). Yielding them would be negligible cost, because expansion was already done.
- [x] Design document on prov-capture

### Changelog
#### 💫 Enhancements and new features
- `run` now supports placeholders in input and output specifications. This includes all standard and custom placeholders, and enables use cases like `--inputs '{outputs}'` to conveniently declare all outputs to also be inputs for a command execution. Fixes #3075 
#### 📝 Documentation
- A design document with basic information on the provenance capture approach was added. Fixes #6100
#### 🏠 Internal
- The `run` and `rerun` workhorse function `run_command()` has gained additional flags. `parametric_record` prevents the expansion of any placeholder in a provenance record. This enables creating a single record that be parameterized to implement more than one (re)computation. `skip_dirtycheck` prevents any test for dataset modifications prior a command execution, regardless of other mode specifications. This aids callers that already need to perform analog checks before executing `run_command()`. The new option `yield_expanded` can be used to add lists of expanded inputs and outputs to the result record to avoid re-processing this information in callers. Lastly, `remove_outputs` alters the default, content availability dependent, output preparation. If enabled, all declared outputs that are not also declared inputs will be deleted prior a command execution. Files that are both input and output will be unlocked. This helps to avoid #6441
