### PR TITLE
Remove an unnecessary warning from the runner

### DIFF
--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -317,6 +317,8 @@ class ThreadedRunner:
 
         self.protocol = self.protocol_class(**self.protocol_kwargs)
 
+        # The following command is generated internally by datalad
+        # and trusted. Security check is therefore skipped.
         kwargs = {
             **self.popen_kwargs,
             **dict(
@@ -324,19 +326,23 @@ class ThreadedRunner:
                 stdin=subprocess.PIPE if self.write_stdin else self.stdin,
                 stdout=subprocess.PIPE if self.catch_stdout else None,
                 stderr=subprocess.PIPE if self.catch_stderr else None,
-                shell=True if isinstance(self.cmd, str) else False
+                shell=True if isinstance(self.cmd, str) else False      # nosec
             )
         }
 
         try:
-            self.process = subprocess.Popen(self.cmd, **kwargs)
+            # The following command is generated internally by datalad
+            # and trusted. Security check is therefore skipped.
+            self.process = subprocess.Popen(self.cmd, **kwargs)         # nosec
+
         except OSError as e:
             if not on_windows and "argument list too long" in str(e).lower():
                 lgr.error(
                     "Caught exception suggesting too large stack size limits. "
                     "Hint: use 'ulimit -s' command to see current limit and "
-                    "e.g. 'ulimit -s 8192' to reduce it to avoid this exception. "
-                    "See https://github.com/datalad/datalad/issues/6106 for more "
+                    "e.g. 'ulimit -s 8192' to reduce it to avoid this "
+                    "exception. See "
+                    "https://github.com/datalad/datalad/issues/6106 for more "
                     "information."
                 )
             raise

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -292,10 +292,9 @@ class ThreadedRunner:
                result = gen.return_code
         """
         if isinstance(self.stdin, (int, IO, type(None))):
-            # indicate that we will not write anything to stdin, that
-            # means the user can pass None, or he can pass a
-            # file-like and write to it from a different thread.
-            self.write_stdin = False  # the caller will write to the parameter
+            # We will not write anything to stdin. If the caller passed a
+            # file-like he can write to it from a different thread.
+            self.write_stdin = False
 
         elif isinstance(self.stdin, (str, bytes)):
             # Establish a queue to write to the process and
@@ -304,18 +303,16 @@ class ThreadedRunner:
             self.stdin_queue = Queue()
             self.stdin_queue.put(self.stdin)
             self.stdin_queue.put(None)
+
         elif isinstance(self.stdin, Queue):
             # Establish a queue to write to the process.
             self.write_stdin = True
             self.stdin_queue = self.stdin
+
         else:
-            # indicate that we will not write anything to stdin, that
-            # means the user can pass None, or he can pass a
-            # file-like and write to it from a different thread.
-            lgr.warning(f"Unknown instance class: {type(self.stdin)}, "
-                        f"assuming file-like input: {self.stdin}")
-            # We assume that the caller will write to the given
-            # file descriptor.
+            # We do not recognize the input class will and just pass is through
+            # to Popen(). We assume that the caller handles any writing if
+            # desired.
             self.write_stdin = False
 
         self.protocol = self.protocol_class(**self.protocol_kwargs)

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -505,14 +505,15 @@ class ThreadedRunner:
             ) if thread is not None]
         return not any(live_threads) and self.output_queue.empty()
 
-    def check_for_stall(self):
+    def check_for_stall(self) -> bool:
         if self.stall_check_interval == 0:
             self.stall_check_interval = 11
             if self.is_stalled():
                 lgr.warning(
                     "ThreadedRunner.process_queue(): stall detected")
-                return
+                return True
         self.stall_check_interval -= 1
+        return False
 
     def process_queue(self):
         """
@@ -535,7 +536,8 @@ class ThreadedRunner:
                     timeout=ThreadedRunner.timeout_resolution)
                 break
             except Empty:
-                self.check_for_stall()
+                if self.check_for_stall() is True:
+                    return
                 self.process_timeouts()
                 continue
 


### PR DESCRIPTION
Remove an unnecessary warning from the runner in the case where `stdin` is provided, but does not fit any of our specially handled cases.

Fixes #6395 


### Changelog
#### 🐛 Bug Fixes
- Fixes #6395   remove an unnecessary and misleading warning
