### PR TITLE
MNT: remove deprecated mktemp from add-archive-content

### DIFF
--- a/datalad/local/add_archive_content.py
+++ b/datalad/local/add_archive_content.py
@@ -413,11 +413,10 @@ class AddArchiveContent(Interface):
         if annex_options:
             if isinstance(annex_options, str):
                 annex_options = split_cmdline(annex_options)
-
         delete_after_rpath = None
 
-        prefix_dir = basename(tempfile.mktemp(prefix=".datalad",
-                                              dir=annex.path)) \
+        prefix_dir = basename(tempfile.mkdtemp(prefix=".datalad",
+                                               dir=annex.path)) \
             if delete_after \
             else None
 
@@ -692,7 +691,9 @@ class AddArchiveContent(Interface):
             annex.always_commit = old_always_commit
             # remove what is left and/or everything upon failure
             earchive.clean(force=True)
-
+            # remove tempfile directories (not cleaned up automatically):
+            if prefix_dir is not None and lexists(prefix_dir):
+                os.rmdir(prefix_dir)
         yield get_status_dict(
             ds=ds,
             status='ok',


### PR DESCRIPTION
This function bears a potential security risk and has been deprecated
since Python version 2.3. This change replaces its use with mkdtemp,
which creates a temporary directory in a more secure manner

As mkdtemp does not clean the temporary directory up afterwards, this
change also adds a removal of any leftover empty temporary directories.

### Changelog
#### 🏠 Internal
- ``add-archive-content`` does not rely on the deprecated ``tempfile.mktemp`` anymore, but uses the more secure ``tempfile.mkdtemp``

