### PR TITLE
TST: mark test_source_candidate_subdataset as @slow

### DIFF
--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -753,6 +753,7 @@ def test_missing_path_handling(path):
         ds.get("foo")
 
 
+@slow  # started to >~30sec. https://github.com/datalad/datalad/issues/6412
 @known_failure_windows  # create-sibling-ria + ORA not fit for windows
 @with_tempfile
 @with_tempfile


### PR DESCRIPTION
See https://github.com/datalad/datalad/issues/6412 for more background.
The actual reason was not discovered, but the test became slower in late Jan,
crossing the line of 30seconds.  We are marking it as slow to mitigate
false positive CI fails on PRs.