### PR TITLE
Enable custom "on-failure" settings and employ for `run` with `on_failure='stop'` by default

### DIFF
--- a/datalad/cli/common_args.py
+++ b/datalad/cli/common_args.py
@@ -77,14 +77,27 @@ common_args = dict(
     on_failure=(
         ('--on-failure',),
         dict(dest='common_on_failure',
-             default=eval_params['on_failure'].cmd_kwargs['default'],
+             # setting the default to None here has the following implications
+             # - the global default is solely defined in
+             #   datalad.interface.common_opts.eval_params and is in-effect for
+             #   Python API and CLI
+             # - this global default is written to each command Interface class
+             #   and can be overridden there on a per-command basis, with such
+             #   override being honored by both APIs
+             # - the CLI continues to advertise the choices defined below as
+             #   the possible values for '--on-failure'
+             # - the Python docstring reflects a possibly command-specific
+             #   default
+             default=None,
              choices=['ignore', 'continue', 'stop'],
-             help="""when an operation fails: 'ignore' and continue with remaining
-        operations, the error is logged but does not lead to a non-zero exit
-        code of the command; 'continue' works like 'ignore', but an error
-        causes a non-zero exit code; 'stop' halts on first failure and yields
-        non-zero exit code. A failure is any result with status 'impossible'
-        or 'error'. [Default: '%(default)s']""")),
+             help="""when an operation fails: 'ignore' and continue with
+             remaining operations, the error is logged but does not lead to a
+             non-zero exit code of the command; 'continue' works like 'ignore',
+             but an error causes a non-zero exit code; 'stop' halts on first
+             failure and yields non-zero exit code. A failure is any result
+             with status 'impossible' or 'error'. [Default: '%s', but
+             individual commands may define an alternative default]"""
+             % eval_params['on_failure'].cmd_kwargs['default'])),
     report_status=(
         ('--report-status',),
         dict(dest='common_report_status',

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -104,7 +104,10 @@ class Run(Interface):
     the command execution is made.
 
     If the given command errors, a `CommandError` exception with the same exit
-    code will be raised, and no modifications will be saved.
+    code will be raised, and no modifications will be saved. A command
+    execution will not be attempted, by default, when an error occurred during
+    input or output preparation. This default ``stop`` behavior can be
+    overridden via [CMD: --on-failure ... CMD][PY: `on_failure=...` PY].
 
     *Command format*
 
@@ -191,6 +194,11 @@ class Run(Interface):
     ]
 
     result_renderer = "tailored"
+    # make run stop immediately on non-success results.
+    # this prevents command execution after failure to obtain inputs of prepare
+    # outputs. but it can be overriding via the common 'on_failure' parameter
+    # if needed.
+    on_failure = 'stop'
 
     _params_ = dict(
         cmd=Parameter(

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -144,6 +144,21 @@ def test_basics(path, nodspath):
             ds.run()
             assert_in("No command given", cml.out)
 
+    with chpwd(path):
+        # make sure that an invalid input declaration prevents command
+        # execution by default
+        assert_raises(
+            IncompleteResultsError,
+            ds.run, 'cd .> dummy0', inputs=['not-here'])
+        ok_(not (ds.pathobj / 'dummy0').exists())
+        # but the default behavior can be changed
+        assert_raises(
+            IncompleteResultsError,
+            ds.run, 'cd .> dummy0', inputs=['not-here'],
+            on_failure='continue')
+        # it has stilled failed, but the command got executed nevertheless
+        ok_((ds.pathobj / 'dummy0').exists())
+
 
 @known_failure_windows
 # ^ For an unknown reason, appveyor started failing after we removed


### PR DESCRIPTION
### Changelog
#### 💫 Enhancements and new features
- Individual command implementations can now declare a specific "on-failure" behavior by defining `Interface.on_failure` to be one of the supported modes (stop, continue, ignore). Previously, such a modification was only possible on a per-call basis. Fixes #6426
- The `run` command changed its default "on-failure" behavior from `continue` to `stop`. This change prevents the execution of a command in case a declared input can not be obtained. Previously, only an error result was yielded (and `run` eventually yielded a non-zero exit code or an `IncompleteResultsException`), but the execution proceeded and potentially saved a dataset modification despite incomplete inputs, in case the command succeeded. This previous default behavior can still be achieved by calling `run` with the equivalent of `--on-failure continue`. Fixes #6427
