### PR TITLE
Simplify pattern 'EnsureChoice(..) | EnsureNone'

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -222,8 +222,7 @@ class CreateSiblingRia(Interface):
             installation is required on the target host."""),
         existing=Parameter(
             args=("--existing",),
-            constraints=EnsureChoice(
-                'skip', 'error', 'reconfigure') | EnsureNone(),
+            constraints=EnsureChoice('skip', 'error', 'reconfigure', None),
             metavar='MODE',
             doc="""Action to perform, if a (storage) sibling is already
             configured under the given name and/or a target already exists.
@@ -242,8 +241,7 @@ class CreateSiblingRia(Interface):
         trust_level=Parameter(
             args=("--trust-level",),
             metavar="TRUST-LEVEL",
-            constraints=EnsureChoice(
-                'trust', 'semitrust', 'untrust') | EnsureNone(),
+            constraints=EnsureChoice('trust', 'semitrust', 'untrust', None),
             doc="""specify a trust level for the storage sibling. If not
             specified, the default git-annex trust level is used. 'trust'
             should be used with care (see the git-annex-trust man page).""",),

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -356,7 +356,7 @@ class WTF(Interface):
             action='append',
             dest='sections',
             metavar="SECTION",
-            constraints=EnsureChoice(*sorted(SECTION_CALLABLES) + ['*']) | EnsureNone(),
+            constraints=EnsureChoice(None, *sorted(SECTION_CALLABLES) + ['*']),
             doc="""section to include.  If not set - depends on flavor.
             '*' could be used to force all sections.
             [CMD: This option can be given multiple times. CMD]"""),
@@ -368,7 +368,7 @@ class WTF(Interface):
             Use [CMD: --section CMD][PY: `section` PY] to list other sections"""),
         decor=Parameter(
             args=("-D", "--decor"),
-            constraints=EnsureChoice('html_details') | EnsureNone(),
+            constraints=EnsureChoice('html_details', None),
             doc="""decoration around the rendering to facilitate embedding into
             issues etc, e.g. use 'html_details' for posting collapsible entry
             to GitHub issues."""),


### PR DESCRIPTION
By including None in the choice list. This makes for a better
documentation and enables auto-completion, provided by #6415

This accompanies https://github.com/datalad/datalad/pull/6415#issuecomment-1032559152 but it independent of it.


### Changelog
This does not need to show up in the changelog.