### PR TITLE
OPT+RF: create-sibling --since=^ -- diff to HEAD, use "^" instead of ""

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -673,7 +673,7 @@ class CreateSibling(Interface):
                 for r in diff_dataset(
                     ds,
                     fr=since,
-                    to=None,
+                    to='HEAD',
                     # make explicit, but doesn't matter, no recursion in diff()
                     constant_refs=True,
                     # contrain to the paths of all locally existing subdatasets

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -551,7 +551,9 @@ class CreateSibling(Interface):
             constraints=EnsureStr() | EnsureNone(),
             doc="""limit processing to subdatasets that have been changed since
             a given state (by tag, branch, commit, etc). This can be used to
-            create siblings for recently added subdatasets."""),
+            create siblings for recently added subdatasets.
+            If '^' is given, the last state of the current branch at the sibling
+            is taken as a starting point."""),
     )
 
     @staticmethod
@@ -591,6 +593,17 @@ class CreateSibling(Interface):
                     "package. Please install the Python package "
                     "`datalad_deprecated` to be able to deploy it."
                 )
+
+        # push uses '^' to annotate the previous pushed committish, and None for default
+        # behavior. '' was/is (to be deprecated) used in `publish` and 'create-sibling'.
+        # Alert user about the mistake
+        if since == '':
+            # deprecation was added prior 0.16.0
+            import warnings
+            warnings.warn("'since' should point to commitish or use '^'.",
+                          DeprecationWarning)
+            since = '^'
+
         #
         # nothing without a base dataset
         #
@@ -655,7 +668,7 @@ class CreateSibling(Interface):
                 "No sibling name given. Using %s'%s' as sibling name",
                 "URL hostname " if ssh_sibling else "",
                 name)
-        if since == '':
+        if since == '^':
             # consider creating siblings only since the point of
             # the last update
             # XXX here we assume one to one mapping of names from local branches

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -406,7 +406,22 @@ def check_target_ssh_recursive(use_ssh, origin, src_path, target_path):
             # hence we must not publish the base dataset on its own without recursion,
             # if we want to have this mechanism do its job
             #push(to=remote_name)  # no recursion
-            assert_create_sshwebserver(
+            out1 = assert_create_sshwebserver(
+                name=remote_name,
+                sshurl=sshurl,
+                target_dir=target_dir_tpl,
+                recursive=True,
+                existing='skip',
+                ui=have_webui(),
+                since='^'
+            )
+            assert_postupdate_hooks(target_path_, installed=have_webui(), flat=flat)
+            assert_result_count(out1, 1, status='ok', sibling_name=remote_name)
+
+            # ensure that nothing is created since since is used.
+            # Also cover deprecation for since='' support.  Takes just 60ms or so.
+            # TODO: change or remove when removing since='' deprecation support
+            out2 = assert_create_sshwebserver(
                 name=remote_name,
                 sshurl=sshurl,
                 target_dir=target_dir_tpl,
@@ -415,7 +430,8 @@ def check_target_ssh_recursive(use_ssh, origin, src_path, target_path):
                 ui=have_webui(),
                 since=''
             )
-            assert_postupdate_hooks(target_path_, installed=have_webui(), flat=flat)
+            assert_result_count(out2, 1, status='notneeded', sibling_name=remote_name)
+
         # so it was created on remote correctly and wasn't just skipped
         assert(Dataset(_path_(target_path_, ('prefix-' if flat else '') + sub3_name)).is_installed())
         push(dataset=source, to=remote_name, recursive=True, since='^') # just a smoke test


### PR DESCRIPTION
Two commits:

    OPT: create_sibling - diff to HEAD not None (tree)
    
    Primary motivation is very slow --since= mode of operation of create-sibling
    on a heavy superdataset (see #6399).  Although it could be argued that there might be
    a benefit from create-sibling to be able to create siblings for not yet committed
    submodules, I think such use cases are sparse if any and thus diff"ing to the committed
    state (HEAD) is actually the desired effect.
    
    Fixes #6399 (although I did not check explicitly)

-----

    RF: create-sibling --since to take "^" instead of ""
    
    to be consistent with "push" and thus reduce cognitive load.  Old value of an
    empty string will remain supported.  While at it, added a tiny bit of testing
    to ensure that --since actually works out the way we expect and only deals with
    that subdataset (or notneeded)

Moreover, apparently `--since=` was not even documented before, this fixes it.

First commit I would not even mind to destine against `maint` but decided not to bother since 0.16.0 is imminent, right?

### Changelog
#### 💫 Enhancements and new features
- `create-sibling --since=^` mode will now be as fast as `push --since=^` to figure out for which subdatasets to create siblings.
#### 🪓 Deprecations and removals
- `create-sibling` will require now "^" instead of an empty string for `since` option. 
#### 📝 Documentation
- `--since=^` mode of operation of `create-sibling` is documented now
