### PR TITLE
Demote BatchedCommand remaining content-warning to debug message

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -119,7 +119,7 @@ class BatchedCommandProtocol(GeneratorMixIn, StdOutErrCapture):
         if fd == STDOUT_FILENO:
             remaining_line = self.line_splitter.finish_processing()
             if remaining_line is not None:
-                lgr.warning(f"unterminated line: {remaining_line}")
+                lgr.debug(f"unterminated line: {remaining_line}")
                 self.send_result((fd, remaining_line))
 
     def timeout(self, fd: Optional[int]) -> bool:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -389,12 +389,12 @@ class BatchedCommand(SafeDelCloseMixin):
         Get a single stdout line from the generator.
 
         If timeout was specified, and exception_on_timeout is False,
-        and if a timeout occurs, return None. Otherwise return the
-        str that was read from the generator.
+        and if a timeout occurs, return None. Otherwise, return the
+        string that was read from the generator.
         """
 
         # Implementation remarks:
-        # 1. We known that BatchedCommandProtocol only returns complete lines on
+        # 1. We know that BatchedCommandProtocol only returns complete lines on
         #    stdout, that makes this code simple.
         # 2. stderr is handled transparently within this method,
         #    by adding all stderr-content to an internal buffer.
@@ -469,7 +469,7 @@ class BatchedCommand(SafeDelCloseMixin):
                 self.return_code = command_error.code
 
             if remaining:
-                lgr.warning(f"{self}: remaining content: {remaining}")
+                lgr.debug(f"{self}: remaining content: {remaining}")
 
             self.wait_timed_out = timeout is True
             if self.wait_timed_out:

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -961,13 +961,21 @@ class BatchedRegisterUrl(RegisterUrl):
         super().__init__(ds, repo)
         self._batch_commands = {}
 
-    def _batch(self, command, batch_input,
-               output_proc=None, json=False, batch_options=None):
+    def _batch(self,
+               command,
+               batch_input,
+               output_proc=None,
+               json=False,
+               batch_options=None):
+
         bcmd = self._batch_commands.get(command)
         if not bcmd:
             repo = self.repo
             bcmd = repo._batched.get(
-                command, path=repo.path, json=json, output_proc=output_proc,
+                codename=command,
+                path=repo.path,
+                json=json,
+                output_proc=output_proc,
                 annex_options=batch_options)
             self._batch_commands[command] = bcmd
         return bcmd(batch_input)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3768,6 +3768,32 @@ class AnnexInitOutput(WitlessProtocol):
             lgr.info(line.strip())
 
 
+@auto_repr
+class BatchedAnnex(BatchedCommand):
+    """Container for an annex process which would allow for persistent communication
+    """
+
+    def __init__(self, annex_cmd, git_options=None, annex_options=None, path=None,
+                 json=False, output_proc=None):
+        if not isinstance(annex_cmd, list):
+            annex_cmd = [annex_cmd]
+        cmd = \
+            ['git'] + \
+            (git_options if git_options else []) + \
+            ['annex'] + \
+            annex_cmd + \
+            (annex_options if annex_options else []) + \
+            (['--json', '--json-error-messages'] if json else []) + \
+            ['--batch'] + \
+            (['--debug'] if lgr.getEffectiveLevel() <= 8 else [])
+        output_proc = \
+            output_proc if output_proc else readline_json if json else None
+        super(BatchedAnnex, self).__init__(
+            cmd,
+            path=path,
+            output_proc=output_proc)
+
+
 # TODO: Why was this commented out?
 # @auto_repr
 class BatchedAnnexes(SafeDelCloseMixin, dict):
@@ -3779,7 +3805,7 @@ class BatchedAnnexes(SafeDelCloseMixin, dict):
         self.git_options = git_options or []
         super(BatchedAnnexes, self).__init__()
 
-    def get(self, codename, annex_cmd=None, **kwargs):
+    def get(self, codename, annex_cmd=None, **kwargs) -> BatchedAnnex:
         if annex_cmd is None:
             annex_cmd = codename
 
@@ -3842,29 +3868,3 @@ def readlines_until_ok_or_failed(stdout, maxlines=100):
 def readline_json(stdout):
     toload = stdout.readline().strip()
     return json_loads(toload) if toload else {}
-
-
-@auto_repr
-class BatchedAnnex(BatchedCommand):
-    """Container for an annex process which would allow for persistent communication
-    """
-
-    def __init__(self, annex_cmd, git_options=None, annex_options=None, path=None,
-                 json=False, output_proc=None):
-        if not isinstance(annex_cmd, list):
-            annex_cmd = [annex_cmd]
-        cmd = \
-            ['git'] + \
-            (git_options if git_options else []) + \
-            ['annex'] + \
-            annex_cmd + \
-            (annex_options if annex_options else []) + \
-            (['--json', '--json-error-messages'] if json else []) + \
-            ['--batch'] + \
-            (['--debug'] if lgr.getEffectiveLevel() <= 8 else [])
-        output_proc = \
-            output_proc if output_proc else readline_json if json else None
-        super(BatchedAnnex, self).__init__(
-            cmd,
-            path=path,
-            output_proc=output_proc)


### PR DESCRIPTION
This PR changes a warning message to a debug message. The message indicates that there is still unprocessed command-output in a BatchedCommand object, when the BatchedCommand object is closed.

This PR fixes #6431 


### Changelog
#### 🏠 Internal
- Remove a warning message that does not necessarily indicate an error, but might confuse users.