### PR TITLE
Salvage parts of #5695

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -593,8 +593,6 @@ def _execute_command(command, pwd, expected_exit=None):
             command
         )
     except CommandError as e:
-        # strip our own info from the exception. The original command output
-        # went to stdout/err -- we just have to exitcode in the same way
         exc = e
         cmd_exitcode = e.code
 

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -515,6 +515,30 @@ def test_incorrect_msg_interpolation():
     TestUtils2().__call__("%eatthis")
 
 
+class CustomResultRenderer(Interface):
+    result_renderer = "tailored"
+    _params_ = dict(x=Parameter(args=("x",)))
+
+    @staticmethod
+    @eval_results
+    def __call__(x):
+        yield get_status_dict(action="foo", status="ok", message="message",
+                              x=x, logger=lgr)
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        # This custom result renderer gets the command's keyword arguments and
+        # all of the common ones too, even those not explicitly specified.
+        assert_in("x", kwargs)
+        assert_in("on_failure", kwargs)
+        assert_in("result_filter", kwargs)
+        assert_in("result_renderer", kwargs)
+
+
+def test_custom_result_renderer():
+    list(CustomResultRenderer().__call__("arg"))
+
+
 class CustomSummary(Interface):
     result_renderer = "tailored"
     _params_ = dict(x=Parameter(args=("x",)))

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -271,11 +271,6 @@ def eval_results(wrapped):
     @wraps(wrapped)
     def eval_func(*args, **kwargs):
         lgr.log(2, "Entered eval_func for %s", wrapped)
-        # for result filters
-        # we need to produce a dict with argname/argvalue pairs for all args
-        # incl. defaults and args given as positionals
-        allkwargs = get_allargs_as_kwargs(wrapped, args, kwargs)
-
         # determine the command class associated with `wrapped`
         wrapped_class = get_wrapped_class(wrapped)
 
@@ -290,6 +285,12 @@ def eval_results(wrapped):
                 # default set in that class
                 getattr(wrapped_class, p_name))
             for p_name in eval_params}
+
+        # for result filters
+        # we need to produce a dict with argname/argvalue pairs for all args
+        # incl. defaults and args given as positionals
+        allkwargs = get_allargs_as_kwargs(wrapped, args,
+                                          {**kwargs, **common_params})
 
         # short cuts and configured setup for common options
         return_type = common_params['return_type']


### PR DESCRIPTION
This PR salvages all commits from https://github.com/datalad/datalad/pull/5695 that are still relevant, except for https://github.com/datalad/datalad/pull/5695/commits/a5d554b70d56587eb5e0a9652ae1dbac036dac1b which is presently being debated in https://github.com/datalad/datalad/issues/6438 (as one of two options).

### Changelog
#### 🏠 Internal
- Common command arguments are now uniformly and exhaustively passed to result renderers and filters for decision making. Previously, the presence of a particular argument depended on the respective API and circumstances of a command call.
