### PR TITLE
BF/RF: Silence save result rendering in clone and download url

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -367,6 +367,7 @@ class Clone(Interface):
                     return_type='generator',
                     result_filter=None,
                     result_xfm=None,
+                    result_renderer='disabled',
                     on_failure='ignore'):
                 actually_saved_subds = actually_saved_subds or (
                         r['action'] == 'save' and
@@ -394,7 +395,8 @@ class Clone(Interface):
                      source]
                 )
                 yield from ds.save('.gitmodules',
-                                   amend=True, to_git=True)
+                                   amend=True, to_git=True,
+                                   result_renderer='disabled')
             else:
                 # We didn't really commit. Just call `subdatasets`
                 # in that case to have the modification included in the

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -279,6 +279,7 @@ class Install(Interface):
                         on_failure='ignore',
                         return_type='generator',
                         result_xfm=None,
+                        result_renderer='disabled',
                         result_filter=None,
                         **common_kwargs):
                     # no post-processing of get'ed content on disk should be

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -301,6 +301,16 @@ def eval_results(wrapped):
             # use verbatim, if not a known label
             common_params['result_xfm'])
         result_renderer = common_params['result_renderer']
+
+        if result_renderer == 'tailored' and not hasattr(wrapped_class,
+                                                         'custom_result_renderer'):
+            # a tailored result renderer is requested, but the class
+            # does not provide any, fall back to the generic one
+            result_renderer = 'generic'
+        if result_renderer == 'default':
+            # standardize on the new name 'generic' to avoid more complex
+            # checking below
+            result_renderer = 'generic'
         # look for potential override of logging behavior
         result_log_level = dlcfg.get('datalad.log.result-level', 'debug')
 
@@ -530,16 +540,6 @@ def _process_results(
             if sys.stdout.isatty() \
                and dlcfg.obtain('datalad.ui.suppress-similar-results') \
             else float("inf")
-
-    if result_renderer == 'tailored' and not hasattr(cmd_class,
-                                                     'custom_result_renderer'):
-        # a tailored result renderer is requested, but the class
-        # does not provide any, fall back to the generic one
-        result_renderer = 'generic'
-    if result_renderer == 'default':
-        # standardize on the new name 'generic' to avoid more complex
-        # checking below
-        result_renderer = 'generic'
 
     for res in results:
         if not res or 'action' not in res:

--- a/datalad/local/download_url.py
+++ b/datalad/local/download_url.py
@@ -234,6 +234,7 @@ URLs:
                             # preserve relative path handling semantics.
                             dataset=dataset,
                             return_type="generator",
+                            result_renderer='disabled',
                             result_xfm=None,
                             result_filter=None,
                             on_failure="ignore"):


### PR DESCRIPTION

A recent change has introduced double reporting for a number of commands (#6445). I haven't figured out why this change has suddenly happened, but this PR silences (``result_renderer='disabled'``) internal calls to ``save`` and ``get`` that should be silenced anyway.

In addition, it contains a small RF that centralizes general result renderer switches outside of a loop. Coincidentally, this RF reinstates action summaries for a few commands that had lost it (#6258)


### Changelog
#### 🐛 Bug Fixes
- A number of commands stopped to double-report results (by @adswa)

