### PR TITLE
ENH: run: Provide result record for command execution

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -847,7 +847,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         status=status,
         message="Executed command",
         run_info=run_info,
-        exitcode=cmd_exitcode,
+        # use the same key that `get_status_dict()` would/will use
+        # to record the exit code in case of an exception
+        exit_code=cmd_exitcode,
         exception=exc,
         # Provide msg_path and explicit outputs so that, under
         # on_failure='stop', callers can react to a failure and then call

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -318,6 +318,23 @@ class Run(Interface):
             else:
                 raise ValueError(f"Unknown dry-run mode: {dry_run!r}")
         else:
+            if kwargs.get("on_failure") == "stop" and \
+               res.get("action") == "run" and res.get("status") == "error":
+                msg_path = res.get("msg_path")
+                if msg_path:
+                    if datalad.get_apimode() == 'python':
+                        ds_path = res["path"]
+                        help = f"\"Dataset('{ds_path}').save(path='.', " \
+                               "recursive=True, message_file='%s')\""
+                    else:
+                        help = "'datalad save -d . -r -F %s'"
+                    lgr.info(
+                        "The command had a non-zero exit code. "
+                        "If this is expected, you can save the changes with "
+                        f"{help}",
+                        # shorten to the relative path for a more concise
+                        # message
+                        msg_path.relative_to(ds.pathobj))
             generic_result_renderer(res)
 
 
@@ -580,7 +597,7 @@ def format_command(dset, command, **kwds):
     return sfmt.format(command, **kwds)
 
 
-def _execute_command(command, pwd, expected_exit=None):
+def _execute_command(command, pwd):
     from datalad.cmd import WitlessRunner
 
     exc = None
@@ -595,16 +612,6 @@ def _execute_command(command, pwd, expected_exit=None):
     except CommandError as e:
         exc = e
         cmd_exitcode = e.code
-
-        if expected_exit is not None and expected_exit != cmd_exitcode:
-            # we failed in a different way during a rerun.  This can easily
-            # happen if we try to alter a locked file
-            #
-            # TODO add the ability to `git reset --hard` the dataset tree on failure
-            # we know that we started clean, so we could easily go back, needs gh-1424
-            # to be able to do it recursively
-            raise exc
-
     lgr.info("== Command exit (modification check follows) =====")
     return cmd_exitcode or 0, exc
 
@@ -774,9 +781,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         return
 
     if not inject:
-        cmd_exitcode, exc = _execute_command(
-            cmd_expanded, pwd,
-            expected_exit=rerun_info.get("exit", 0) if rerun_info else None)
+        cmd_exitcode, exc = _execute_command(cmd_expanded, pwd)
         run_info['exit'] = cmd_exitcode
 
     # Re-glob to capture any new outputs.
@@ -823,30 +828,34 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     if outputs_to_save is not None and use_sidecar:
         outputs_to_save.append(record_path)
     do_save = outputs_to_save is None or outputs_to_save
+    msg_path = None
     if not rerun_info and cmd_exitcode:
         if do_save:
             repo = ds.repo
-            msg_path = repo.dot_git / "COMMIT_EDITMSG"
-            msg_path.write_text(msg)
-            if datalad.get_apimode() == 'python':
-                help = f"\"Dataset('{ds.path}').save(path='.', " \
-                       "recursive=True, message_file='%s')\""
-            else:
-                help = "'datalad save -d . -r -F %s'"
-            lgr.info("The command had a non-zero exit code. "
-                     "If this is expected, you can save the changes with "
-                     f"{help}",
-                     # shorten to the relative path for a more concise message
-                     msg_path.relative_to(ds.pathobj))
-            if repo.dirty and not explicit:
-                # Give clean-up hints if a formerly clean repo is left dirty
-                lgr.info(
-                    "The commands 'git clean -di' and/or 'git reset' "
-                    "could be used to get to a clean dataset state again. "
-                    "Consult their man pages for more information."
-                )
-        raise exc
-    elif do_save:
+            msg_path = relpath(opj(str(repo.dot_git), "COMMIT_EDITMSG"))
+            with open(msg_path, "wb") as ofh:
+                ofh.write(ensure_bytes(msg))
+
+    expected_exit = rerun_info.get("exit", 0) if rerun_info else None
+    if cmd_exitcode and expected_exit != cmd_exitcode:
+        status = "error"
+    else:
+        status = "ok"
+
+    yield get_status_dict(
+        "run", ds=ds,
+        status=status,
+        message="Executed command",
+        run_info=run_info,
+        exitcode=cmd_exitcode,
+        exception=exc,
+        # Provide msg_path and explicit outputs so that, under
+        # on_failure='stop', callers can react to a failure and then call
+        # save().
+        msg_path=msg_path,
+        explicit_outputs=outputs_to_save)
+
+    if do_save:
         with chpwd(pwd):
             for r in Save.__call__(
                     dataset=ds_path,

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -802,7 +802,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     else:
         use_sidecar = sidecar
 
-
+    record_id = None
     if use_sidecar:
         # record ID is hash of record itself
         from hashlib import md5
@@ -859,7 +859,9 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         # on_failure='stop', callers can react to a failure and then call
         # save().
         msg_path=str(msg_path) if msg_path else None,
-        explicit_outputs=outputs_to_save)
+        explicit_outputs=outputs_to_save,
+        record_id=record_id,
+    )
 
     if do_save:
         with chpwd(pwd):

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -146,6 +146,18 @@ def test_basics(path, nodspath):
             ds.run()
             assert_in("No command given", cml.out)
 
+    # running without a command is a noop
+    with chpwd(path):
+        with swallow_logs(new_level=logging.INFO) as cml:
+            assert_raises(
+                IncompleteResultsError,
+                ds.run,
+                '7i3amhmuch9invalid',
+                # this is on_failure=stop by default
+            )
+            # must give recovery hint in Python notation
+            assert_in("can save the changes with \"Dataset(", cml.out)
+
     with chpwd(path):
         # make sure that an invalid input declaration prevents command
         # execution by default
@@ -659,6 +671,9 @@ def test_dry_run(path):
         assert_not_in("blah", cmo.out)
 
     ds.save()
+
+    # unknown dry-run mode
+    assert_raises(ValueError, ds.run, 'blah', dry_run='absurd')
 
     with swallow_outputs() as cmo:
         ds.run("blah ", dry_run="basic")

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -101,15 +101,17 @@ def test_basics(path, nodspath):
     with chpwd(path), \
             swallow_outputs():
         # provoke command failure
-        with assert_raises(CommandError) as cme:
-            ds.run('7i3amhmuch9invalid')
+        res = ds.run('7i3amhmuch9invalid', on_failure="ignore",
+                     result_renderer=None)
+        assert_result_count(res, 1, action="run", status="error")
+        run_res = [r for r in res if r["action"] == "run"][0]
         # let's not speculate that the exit code is always 127
-        ok_(cme.exception.code > 0)
+        ok_(run_res["run_info"]["exit"] > 0)
         eq_(last_state, ds.repo.get_hexsha())
         # now one that must work
         res = ds.run('cd .> empty', message='TEST')
         assert_repo_status(ds.path)
-        assert_result_count(res, 2)
+        assert_result_count(res, 3)
         # TODO 'state' is still untracked!!!
         assert_result_count(res, 1, action='add',
                             path=op.join(ds.path, 'empty'), type='file')
@@ -192,8 +194,9 @@ def test_py2_unicode_command(path):
         assert_repo_status(ds.path)
         ok_exists(op.join(path, u" β1 "))
 
-    with assert_raises(CommandError), swallow_outputs():
-        ds.run(u"bβ2.dat")
+    assert_in_results(
+        ds.run(u"bβ2.dat", result_renderer=None, on_failure="ignore"),
+        status="error", action="run")
 
 
 @with_tempfile(mkdir=True)
@@ -312,8 +315,10 @@ def test_run_assume_ready(path):
     ds.drop("f1", check=False)
     if not adjusted:
         # If the input is not actually ready, the command will fail.
-        with assert_raises(CommandError):
-            ds.run(cat_cmd("f1"), inputs=["f1"], assume_ready="inputs")
+        assert_in_results(
+            ds.run(cat_cmd("f1"), inputs=["f1"], assume_ready="inputs",
+                   on_failure="ignore", result_renderer=None),
+            action="run", status="error")
 
     # --assume-ready=outputs
 
@@ -482,7 +487,7 @@ def test_run_cmdline_disambiguation(path):
                 main(["datalad", "run", "--", "--message"])
             exec_cmd.assert_called_once_with(
                 '"--message"' if on_windows else "--message",
-                path, expected_exit=None)
+                path)
 
         # Our parser used to mishandle --version (gh-3067),
         # treating 'datalad run CMD --version' as 'datalad --version'.
@@ -494,7 +499,7 @@ def test_run_cmdline_disambiguation(path):
                     main(["datalad", "run"] + sep + ["echo", "--version"])
                 exec_cmd.assert_called_once_with(
                     '"echo" "--version"' if on_windows else "echo --version",
-                    path, expected_exit=None)
+                    path)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/local/tests/test_rerun.py
+++ b/datalad/local/tests/test_rerun.py
@@ -301,15 +301,16 @@ def test_run_failure(path):
 
     hexsha_initial = ds.repo.get_hexsha()
 
-    with assert_raises(CommandError):
-        with swallow_outputs():
-            if on_windows:
-                # this does not do exactly the same as the cmd on other systems
-                # but is close enough to make running the test worthwhile
-                ds.run("echo x>{} & false".format(op.join("sub", "grows")))
-            else:
-                ds.run("echo x$({0} {1}) > {1} && false"
-                       .format(cat_command, op.join("sub", "grows")))
+    if on_windows:
+        # this does not do exactly the same as the cmd on other systems
+        # but is close enough to make running the test worthwhile
+        cmd_failing = "echo x>{} & false".format(op.join("sub", "grows"))
+    else:
+        cmd_failing = ("echo x$(cat {0}) > {0} && false"
+                       .format(op.join("sub", "grows")))
+
+    with assert_raises(IncompleteResultsError):
+        ds.run(cmd_failing, result_renderer=None)
     eq_(hexsha_initial, ds.repo.get_hexsha())
     ok_(ds.repo.dirty)
 
@@ -336,13 +337,13 @@ def test_run_failure(path):
     # error that doesn't match.
     ds.run("[ ! -e bar ] && echo c >bar")
     assert_repo_status(ds.path)
-    with assert_raises(CommandError):
-        ds.rerun()
+    assert_in_results(ds.rerun(result_renderer=None, on_failure="ignore"),
+                      action="run", status="error")
 
     # We don't show instructions if the caller specified us not to save.
     remove(msgfile)
-    with assert_raises(CommandError):
-        ds.run("false", explicit=True, outputs=None)
+    with assert_raises(IncompleteResultsError):
+        ds.run("false", explicit=True, outputs=None, on_failure="stop")
     assert_false(op.exists(msgfile))
 
 
@@ -454,8 +455,10 @@ def test_rerun_outofdate_tree(path):
     # Change tree so that it is no longer compatible.
     ds.remove("foo")
     # Now rerunning should fail because foo no longer exists.
-    with swallow_outputs():
-        assert_raises(CommandError, ds.rerun, revision=DEFAULT_BRANCH + "~")
+    assert_in_results(
+        ds.rerun(revision=DEFAULT_BRANCH + "~",
+                 result_renderer=None, on_failure="ignore"),
+        status="error", action="run")
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/local/tests/test_run_procedure.py
+++ b/datalad/local/tests/test_run_procedure.py
@@ -67,7 +67,10 @@ def test_invalid_call(path):
 def test_dirty(path):
     ds = Dataset(path).create(force=True)
     # must fail, because README.md is to be modified, but already dirty
-    assert_raises(CommandError, ds.run_procedure, 'cfg_yoda')
+    assert_in_results(
+        ds.run_procedure('cfg_yoda',
+                         on_failure="ignore", result_renderer=None),
+        action="run", status="error")
     # make sure that was the issue
     # save to git explicitly to keep the test simple and avoid unlocking...
     ds.save('README.md', to_git=True)
@@ -327,8 +330,10 @@ def test_quoting(path):
                   scope='branch')
     with swallow_outputs():
         ds.run_procedure(spec=["just2args", "with ' sing", 'with " doub'])
-        with assert_raises(CommandError):
-            ds.run_procedure(spec=["just2args", "still-one arg"])
+        assert_in_results(
+            ds.run_procedure(spec=["just2args", "still-one arg"],
+                             on_failure="ignore", result_renderer=None),
+            action="run", status="error")
 
         runner = WitlessRunner(cwd=ds.path)
         runner.run(


### PR DESCRIPTION
Note that this contains a breaking change:

  * it changes a CommandError to a result record with status="error"

As pointed out in https://github.com/datalad/datalad/issues/3071#issuecomment-1034648920 we could continue to raise a CommandError for Python-API users. But @mih is not convinced that this is worth it.

This is the last piece from the closed https://github.com/datalad/datalad/pull/5695

Demo:

```
% datalad -f json_pp run "echo 12"
[INFO   ] == Command start (output follows) ===== 
12
[INFO   ] == Command exit (modification check follows) ===== 
{
  "action": "run",
  "exitcode": 0,
  "explicit_outputs": null,
  "message": "Executed command",
  "msg_path": null,
  "path": "/tmp/runny",
  "record_id": "49f818a6e4ab1d9c70610db52da25daf",
  "run_info": {
    "chain": [],
    "cmd": "echo 12",
    "dsid": "2f0b7d17-f5d2-4659-8da8-8bd9dd781e14",
    "exit": 0,
    "extra_inputs": [],
    "inputs": [],
    "outputs": [],
    "pwd": "."
  },
  "status": "ok",
  "type": "dataset"
}
{                                                                                                                           
  "action": "save",
  ...
```

TODO:

- [x] Add sidecar info to result record
- [x] Avoid duplicate exit_code record in the error case (use `exit_code`)

### Changelog
#### 💫 Enhancements and new features
- `run` now yields a result record immediately after executing a command.  This allows callers to use the standard `--on-failure
ignore` switch to control whether dataset modifications will be saved for a command that exited with an error. Fixes #3071 (edited postfact by @yarikoptic to fix HI slop)
#### 🪓 Deprecations and removals
- `run` no longer raises a `CommandError` exception for failed commands, but yields an `error` result that includes a superset of the information provided by the exception. This change impacts command line usage insofar as the exit code of the underlying command is no longer relayed as the exit code of the `run` command call -- although `run` continues to exit with a non-zero exit code in case of an error. For Python API users, the nature of the raised exception changes from `CommandError` to `IncompleteResultsError`, and the exception handling is now configurable using the standard `on_failure` command argument. The original `CommandError` exception remains available via the `exception` property of the newly introduced result record for the command execution, and this result record is available via `IncompleteResultsError.failed`, if such an exception is raised.
