### PR TITLE
BF: define git config and GIT_ASKPASS in the setup_package instead of each CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,9 +53,6 @@ shallow_clone: false
 
 environment:
   DATALAD_TESTS_SSH: 1
-  # Prevent interactive credential entry (note "true" is the command to run)
-  # See also the core.askPass setting below
-  GIT_ASKPASS: true
 
   # Do not use `image` as a matrix dimension, to have fine-grained control over
   # what tests run on which platform
@@ -215,8 +212,6 @@ init:
   # Identity setup
   - git config --global user.email "test@appveyor.land"
   - git config --global user.name "Appveyor Almighty"
-  # Companion to the GIT_ASKPASS environment setting above
-  - git config --global core.askPass ""
   # globally setting filter.annex.process (needs git-annex 8.20211117) to reduce git-add runtime
   # https://git-annex.branchable.com/bugs/Windows__58___substantial_per-file_cost_for___96__add__96__/
   - cmd: git config --system filter.annex.process "git-annex filter-process"

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -26,9 +26,6 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-        # Prevent interactive credential entry
-        # See also the GIT_ASKPASS env var below
-        git config --global core.askPass ""
 
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -47,9 +44,6 @@ jobs:
       env:
         # forces all test repos/paths into the VFAT FS
         TMPDIR: /crippledfs
-        # Prevent interactive credential entry
-        # (note "true" is the command to run)
-        GIT_ASKPASS: true
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -29,9 +29,6 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-        # Prevent interactive credential entry
-        # See also the GIT_ASKPASS env var below
-        git config --global core.askPass ""
 
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -61,10 +58,6 @@ jobs:
       run: |
         datalad wtf
     - name: ${{ matrix.extension }} tests
-      env:
-        # Prevent interactive credential entry
-        # (note "true" is the command to run)
-        GIT_ASKPASS: true
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -19,9 +19,6 @@ jobs:
         brew install exempi
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-        # Prevent interactive credential entry
-        # See also the GIT_ASKPASS env var below
-        git config --global core.askPass ""
 
 
     - uses: actions/checkout@v1
@@ -49,10 +46,6 @@ jobs:
         datalad wtf
 
     - name: Run tests
-      env:
-        # Prevent interactive credential entry
-        # (note "true" is the command to run)
-        GIT_ASKPASS: true
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_win2019_disabled
+++ b/.github/workflows/test_win2019_disabled
@@ -28,9 +28,6 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-        # Prevent interactive credential entry
-        # See also the GIT_ASKPASS env var below
-        git config --global core.askPass ""
 
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -56,10 +53,6 @@ jobs:
         datalad wtf
         dir
     - name: ${{ matrix.module }} tests
-      env:
-        # Prevent interactive credential entry
-        # (note "true" is the command to run)
-        GIT_ASKPASS: true
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ env:
     # How/which git-annex we install.  conda's build would be the fastest, but it must not
     # get ahead in PATH to not shadow travis' python
     - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20201007 -m conda"
-    # Prevent interactive credential entry (note "true" is the command to run)
-    # See also the core.askPass setting below
-    - GIT_ASKPASS=true
 
 matrix:
   include:
@@ -226,13 +223,6 @@ before_install:
 install:
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
-  # Don't let git ask for credentials in CI runs. Note, that this variable
-  # technically is not a flag, but an executable (which is why name and value
-  # are a bit confusing here - we just want a no-op basically). The environment
-  # variable GIT_ASKPASS overwrites this, but neither env var nor this config
-  # are supported by git-credential on all systems and git versions (most recent
-  # ones should work either way, though). Hence use both across CI builds.
-  - git config --global core.askPass ""
   - cd ..; pip install -q codecov; cd -
   - pip install -r requirements-devel.txt
   # So we could test under sudo -E with PATH pointing to installed location

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -218,10 +218,19 @@ def setup_package():
                .format(DEFAULT_BRANCH, DEFAULT_REMOTE))
 
     def prep_tmphome():
+        # re core.askPass:
+        # Don't let git ask for credentials in CI runs. Note, that this variable
+        # technically is not a flag, but an executable (which is why name and value
+        # are a bit confusing here - we just want a no-op basically). The environment
+        # variable GIT_ASKPASS overwrites this, but neither env var nor this config
+        # are supported by git-credential on all systems and git versions (most recent
+        # ones should work either way, though). Hence use both across CI builds.
         gitconfig = """\
 [user]
 	name = DataLad Tester
 	email = test@example.com
+[core]
+	askPass =
 [datalad "log"]
 	exc = 1
 """
@@ -286,6 +295,10 @@ def setup_package():
     else:
         # We are not overriding them, since explicitly were asked to have some log level
         _test_states['loglevel'] = None
+
+    # Prevent interactive credential entry (note "true" is the command to run)
+    # See also the core.askPass setting above
+    set_envvar('GIT_ASKPASS', 'true')
 
     # Set to non-interactive UI
     _test_states['ui_backend'] = ui.backend


### PR DESCRIPTION
We should strive to avoid needing to adjust CI and packaging (which runs tests)
to introduce some new testing aspect.  All setup should be carried out in
fixtures and our fake test HOME whenever necessary.

Otherwise, I cannot even run tests locally ATM without setting up some
variables etc, or discovering what login it actually wants from me:

	$> python -m nose -s -v datalad/local/tests/test_gitcredential.py
	datalad.local.tests.test_gitcredential.test_credential_cycle ... create(ok): . (dataset)
	add(ok): .datalad/providers/test_cycle.cfg (file)
	save(ok): . (dataset)
	Username for 'https://some.data.exampe.com':

### Changelog

no need since feature fixed here was introduced after release

Closes  #6442 (hopefully)

Replaces https://github.com/datalad/git-annex/pull/101