### PR TITLE
Split Ubuntu CI run to prevent timeouts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,9 +66,15 @@ environment:
     # is a need for debugging
 
     # Ubuntu core tests
-    - ID: Ubu20
-      # ~50min
-      DTS: datalad
+    - ID: Ubu20core
+      # ~30min
+      DTS: >
+          datalad.cli
+          datalad.core
+          datalad.customremotes
+          datalad.dataset
+          datalad.distributed
+          datalad.distribution
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
@@ -77,7 +83,7 @@ environment:
     # Windows core tests
     - ID: WinP39core
       # ~35 min
-      DTS: datalad.core datalad.runner
+      DTS: datalad.core datalad.dataset datalad.runner
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       # Python version specification is non-standard on windows
       PY: 39-x64
@@ -87,8 +93,8 @@ environment:
       # INSTALL_GITANNEX: git-annex -m datalad/packages
     # MacOS core tests
     - ID: MacP38core
-      # ~30min
-      DTS: datalad.core datalad.runner
+      # ~40min
+      DTS: datalad.core datalad.dataset datalad.runner datalad.support
       APPVEYOR_BUILD_WORKER_IMAGE: macOS
       PY: 3.8
       # does not give a functional installation
@@ -99,6 +105,22 @@ environment:
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
 
     # Additional test runs
+    - ID: Ubu20a1
+      # ~30min
+      DTS: >
+          datalad.downloaders
+          datalad.interface
+          datalad.local
+          datalad.metadata
+          datalad.runner
+          datalad.support
+          datalad.tests
+          datalad.ui
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      INSTALL_SYSPKGS: python3-virtualenv
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+      # system git-annex is way too old, use better one
+      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
     - ID: WinP39a1
       # ~40min
       DTS: >
@@ -114,7 +136,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       PY: 39-x64
     - ID: WinP39a2
-      # ~40min
+      # ~45min
       DTS: >
           datalad.local
           datalad.support
@@ -138,11 +160,10 @@ environment:
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
     - ID: MacP38a2
-      # ~50min
+      # ~40min
       DTS: >
           datalad.local
           datalad.distributed
-          datalad.support
       APPVEYOR_BUILD_WORKER_IMAGE: macOS
       PY: 3.8
       INSTALL_GITANNEX: git-annex
@@ -150,9 +171,33 @@ environment:
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
 
     # Test alternative Python versions
-    - ID: Ubu20P37
+    - ID: Ubu20P37a
+      # ~35min
       PY: 3.7
-      DTS: datalad
+      DTS: >
+          datalad.cli
+          datalad.core
+          datalad.customremotes
+          datalad.dataset
+          datalad.distributed
+          datalad.distribution
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      INSTALL_SYSPKGS: python3-virtualenv
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+      # system git-annex is way too old, use better one
+      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+    - ID: Ubu20P37b
+      # ~25min
+      PY: 3.7
+      DTS: >
+          datalad.downloaders
+          datalad.interface
+          datalad.local
+          datalad.metadata
+          datalad.runner
+          datalad.support
+          datalad.tests
+          datalad.ui
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov


### PR DESCRIPTION
Also test datalad.dataset on Mac and Win

No changelog item needed.

I canceled all other workflows.