### PR TITLE
Restore the previous result rendering of ``create -c <proc>`` and ``run-procedure``

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -347,7 +347,9 @@ class Create(Interface):
         cfg_proc_specs = []
         if cfg_proc:
             discovered_procs = tbds.run_procedure(
-                discover=True, result_renderer='disabled')
+                discover=True,
+                result_renderer='disabled',
+            )
             for cfg_proc_ in cfg_proc:
                 for discovered_proc in discovered_procs:
                     if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
@@ -430,7 +432,9 @@ class Create(Interface):
         )
 
         for cfg_proc_spec in cfg_proc_specs:
-            for r in tbds.run_procedure(cfg_proc_spec):
+            for r in tbds.run_procedure(cfg_proc_spec,
+                                        result_renderer='disabled',
+                                        ):
                 yield r
 
         # the next only makes sense if we saved the created dataset,
@@ -441,6 +445,7 @@ class Create(Interface):
             # -> make submodule
             for r in refds.save(
                     path=tbds.path,
+                    result_renderer='disabled'
             ):
                 yield r
 

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -437,7 +437,9 @@ class Create(Interface):
                                         result_renderer='disabled',
                                         return_type='generator',
                                         ):
-                yield r
+                if r['status'] != 'ok':
+                    # only yield when there is an error
+                    yield r
 
         # the next only makes sense if we saved the created dataset,
         # otherwise we have no committed state to be registered

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -433,13 +433,11 @@ class Create(Interface):
         )
 
         for cfg_proc_spec in cfg_proc_specs:
-            for r in tbds.run_procedure(cfg_proc_spec,
-                                        result_renderer='disabled',
-                                        return_type='generator',
-                                        ):
-                if r['status'] != 'ok':
-                    # only yield when there is an error
-                    yield r
+            yield from tbds.run_procedure(
+                cfg_proc_spec,
+                result_renderer='disabled',
+                return_type='generator',
+            )
 
         # the next only makes sense if we saved the created dataset,
         # otherwise we have no committed state to be registered
@@ -447,12 +445,11 @@ class Create(Interface):
         if isinstance(refds, Dataset) and refds.path != tbds.path:
             # we created a dataset in another dataset
             # -> make submodule
-            for r in refds.save(
-                    path=tbds.path,
-                    return_type='generator',
-                    result_renderer='disabled'
-            ):
-                yield r
+            yield from refds.save(
+                path=tbds.path,
+                return_type='generator',
+                result_renderer='disabled',
+            )
 
         res.update({'status': 'ok'})
         yield res

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -349,6 +349,7 @@ class Create(Interface):
             discovered_procs = tbds.run_procedure(
                 discover=True,
                 result_renderer='disabled',
+                return_type='generator',
             )
             for cfg_proc_ in cfg_proc:
                 for discovered_proc in discovered_procs:
@@ -434,6 +435,7 @@ class Create(Interface):
         for cfg_proc_spec in cfg_proc_specs:
             for r in tbds.run_procedure(cfg_proc_spec,
                                         result_renderer='disabled',
+                                        return_type='generator',
                                         ):
                 yield r
 
@@ -445,6 +447,7 @@ class Create(Interface):
             # -> make submodule
             for r in refds.save(
                     path=tbds.path,
+                    return_type='generator',
                     result_renderer='disabled'
             ):
                 yield r

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -464,7 +464,8 @@ class RunProcedure(Interface):
                 outputs=None,
                 # pass through here
                 on_failure='ignore',
-                return_type='generator'
+                return_type='generator',
+                result_renderer='disabled'
         ):
             yield r
 

--- a/datalad/resources/procedures/cfg_metadatatypes.py
+++ b/datalad/resources/procedures/cfg_metadatatypes.py
@@ -34,4 +34,5 @@ for nt in sys.argv[2:]:
 ds.save(
     path=op.join(ds.path, DATASET_CONFIG_FILE),
     message="Configure metadata type(s)",
+    result_renderer='disabled'
 )

--- a/datalad/resources/procedures/cfg_noannex.py
+++ b/datalad/resources/procedures/cfg_noannex.py
@@ -34,7 +34,8 @@ def no_annex(ds):
         lgr.info("Creating and committing a .noannex file")
         noannex_file.touch()
         ds.save(noannex_file,
-                message="Added .noannex to prevent accidental initialization of git-annex")
+                message="Added .noannex to prevent accidental initialization of git-annex",
+                result_renderer='disabled')
 
 
 if __name__ == '__main__':

--- a/datalad/resources/procedures/cfg_text2git.py
+++ b/datalad/resources/procedures/cfg_text2git.py
@@ -22,4 +22,5 @@ git_attributes_file = op.join(ds.path, '.gitattributes')
 ds.save(
     git_attributes_file,
     message="Instruct annex to add text files to Git",
+    result_renderer='disabled'
 )

--- a/datalad/resources/procedures/cfg_yoda.py
+++ b/datalad/resources/procedures/cfg_yoda.py
@@ -88,4 +88,5 @@ ds.repo.set_gitattributes(
 ds.save(
     path=to_modify,
     message="Apply YODA dataset setup",
+    result_renderer='disabled'
 )


### PR DESCRIPTION
Judging from the handbook, a ``create -c text2git`` call produced the following output in the past:
```
$ datalad create -c text2git DataLad-101
[INFO] Creating a new annex repo at /home/me/dl-101/DataLad-101 
[INFO] scanning for unlocked files (this may take some time)
[INFO] Running procedure cfg_text2git 
[INFO] == Command start (output follows) ===== 
[INFO] == Command exit (modification check follows) ===== 
create(ok): /home/me/dl-101/DataLad-101 (dataset)
```

Currently, the output looks like this:
```
datalad create -c text2git dl-101
[INFO   ] Creating a new annex repo at /tmp/dl-101 
[INFO   ] Running procedure cfg_text2git 
[INFO   ] == Command start (output follows) ===== 
add(ok): .gitattributes (file)                                                                                    
save(ok): . (dataset)                                                                                             
action summary:                                                                                                   
  add (ok: 1)
  save (ok: 1)
[INFO   ] == Command exit (modification check follows) ===== 
run(ok): /tmp/dl-101 (dataset) [Executed command]
run(ok): /tmp/dl-101 (dataset) [Executed command]
run(ok): /tmp/dl-101 (dataset) [Executed command]
create(ok): /tmp/dl-101 (dataset)
action summary:
  create (ok: 1)
  run (ok: 1)
```

Likewise, a ``datalad run-procedure`` call currently looks like this:

```
 datalad run-procedure cfg_yoda
[INFO   ] Running procedure cfg_yoda 
[INFO   ] == Command start (output follows) ===== 
add(ok): CHANGELOG.md (file)                                                                                      
add(ok): README.md (file)                                                                                         
add(ok): code/.gitattributes (file)                                                                               
add(ok): code/README.md (file)                                                                                    
add(ok): .gitattributes (file)                                                                                    
save(ok): . (dataset)                                                                                             
action summary:                                                                                                   
  add (ok: 5)
  save (ok: 1)
[INFO   ] == Command exit (modification check follows) ===== 
run(ok): /tmp/dl-101 (dataset) [Executed command]
run(ok): /tmp/dl-101 (dataset) [Executed command]
```

The changes proposed in the first commit of this PR silence the result rendering of the internally used commands, including the final ``save()`` in the procedures themselves. 
With those, a ``create`` call's clutter is reduced to
```
datalad create -c text2git bi
[INFO   ] Creating a new annex repo at /tmp/bi
[INFO   ] Running procedure cfg_text2git
[INFO   ] == Command start (output follows) =====
[INFO   ] == Command exit (modification check follows) =====
run(ok): /tmp/bi (dataset) [Executed command]
create(ok): /tmp/bi (dataset)
action summary:
  create (ok: 1)
  run (ok: 1)
```

and a ``run-procedure`` calls looks like this:
```
datalad run-procedure cfg_text2git
[INFO   ] Running procedure cfg_text2git 
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) =====                                                      
run(ok): /tmp/dl-101/abcd (dataset) [Executed command]     
```

The third, potentially controversial commit in this PR, turns off rendering of successful ``run-procedure`` executions, and reestablishes the previous looks of the result record of ``create -c <proc>``:

```
datalad create -c text2git biet
[INFO   ] Creating a new annex repo at /tmp/biet
[INFO   ] Running procedure cfg_text2git
[INFO   ] == Command start (output follows) =====
[INFO   ] == Command exit (modification check follows) =====
create(ok): /tmp/biet (dataset)
```

The second commit sets the ``return_types`` of the internal command calls explicitly to ``generator``. 

### Changelog

no need to be mentioned in the changelog
