### PR TITLE
Silence result rendering in run's use of drop()

### DIFF
--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -519,8 +519,11 @@ def _unlock_or_remove(dset_path, paths):
         # Note: If Unlock() is given a directory (including a subdataset) as a
         # path, files without content present won't be reported, so those cases
         # aren't being covered by the "remove if not present" logic below.
-        for res in Unlock()(dataset=dset_path, path=existing,
-                            on_failure="ignore"):
+        for res in Unlock()(dataset=dset_path,
+                            path=existing,
+                            on_failure="ignore",
+                            result_renderer='disabled',
+                            return_type='generator'):
             if res["status"] == "impossible" and res["type"] == "file" \
                and "cannot unlock" in res["message"]:
                 notpresent_results.append(res)


### PR DESCRIPTION
This prevents double reporting of unlock.
Prior to this change, a run that unlocks a file looks like this:
```
datalad run --input api.py --output some 'cat api.py >> some'
[INFO   ] Making sure inputs are available (this may take some time)
unlock(ok): some (file)
unlock(ok): some (file)
[INFO   ] == Command start (output follows) =====
[INFO   ] == Command exit (modification check follows) =====
run(ok): /tmp/mamam (dataset) [Executed command]
add(ok): some (file)
save(ok): . (dataset)
```
With this change:
```
 datalad run --input api.py --output some 'cat api.py >> some'
[INFO   ] Making sure inputs are available (this may take some time)
unlock(ok): some (file)
[INFO   ] == Command start (output follows) =====
[INFO   ] == Command exit (modification check follows) =====
run(ok): /tmp/mamam (dataset) [Executed command]
add(ok): some (file)
save(ok): . (dataset)
```

I also set the return_type of ``drop()`` to ``generator`` because I think it makes sense there - let me know if that's wrong.

The changes should not conflict with #6424

### Changelog
not needed