### PR TITLE
Issue #6461 work on `unlock()`

### DIFF
--- a/datalad/local/unlock.py
+++ b/datalad/local/unlock.py
@@ -137,7 +137,8 @@ class Unlock(Interface):
                 annex="availability",
                 recursive=recursive,
                 recursion_limit=recursion_limit,
-                result_renderer='disabled',
+                result_renderer="disabled",
+                return_type="generator",
                 on_failure="ignore"):
             if res["action"] != "status" or res["status"] != "ok":
                 yield res


### PR DESCRIPTION
Add missing keyword args to internal call of Status-interface

### Changelog
#### 🏠 Internal
- add `return_type` keyword arg to internal Status call in unlock 
