### PR TITLE
MNT: use generator return_type in internal save call in clone

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -396,7 +396,8 @@ class Clone(Interface):
                 )
                 yield from ds.save('.gitmodules',
                                    amend=True, to_git=True,
-                                   result_renderer='disabled')
+                                   result_renderer='disabled',
+                                   return_type='generator')
             else:
                 # We didn't really commit. Just call `subdatasets`
                 # in that case to have the modification included in the


### PR DESCRIPTION
Update after #6446, which did not set the return type explicitly as outlined in #6461.
This change specifies the return type of a save call to save .gitmodules to be a generator.

no changelog needed