### PR TITLE
MNT: Silence internal command calls' result rendering in add-readme

### DIFF
--- a/datalad/local/add_readme.py
+++ b/datalad/local/add_readme.py
@@ -98,15 +98,20 @@ class AddReadme(Interface):
                 # configure the README to go into Git
                 dataset.repo.set_gitattributes(
                     [(filename, {'annex.largefiles': 'nothing'})])
-                dataset.save(
+                yield from dataset.save(
                     path='.gitattributes',
                     message="[DATALAD] Configure README to be in Git",
-                    to_git=True
+                    to_git=True,
+                    return_type='generator',
+                    result_renderer='disabled'
                 )
 
         # get any metadata on the dataset itself
         dsinfo = dataset.metadata(
-            '.', reporton='datasets', return_type='item-or-list',
+            '.',
+            reporton='datasets',
+            return_type='item-or-list',
+            result_renderer='disabled',
             on_failure='ignore')
         meta = {}
         if not isinstance(dsinfo, dict) or dsinfo.get('status', None) != 'ok':
@@ -232,9 +237,11 @@ files by whom, and when.
                 type='file',
                 action='add_readme')
 
-        for r in dataset.save(
+        yield from dataset.save(
                 fpath,
                 message='[DATALAD] added README',
                 result_filter=None,
-                result_xfm=None):
-            yield r
+                result_xfm=None,
+                return_type='generator',
+                result_renderer='disabled'
+        )

--- a/datalad/local/add_readme.py
+++ b/datalad/local/add_readme.py
@@ -88,7 +88,11 @@ class AddReadme(Interface):
 
         # unlock, file could be annexed
         if lexists(fpath):
-            dataset.unlock(fpath)
+            yield from dataset.unlock(
+                fpath,
+                return_type='generator',
+                result_renderer='disabled'
+            )
         if not lexists(fpath):
             # if we have an annex repo, shall the README go to Git or annex?
 


### PR DESCRIPTION
This updates `add-readme`  according to #6461. Previously, 'datalad add-readme' resulted in double reporting that looked
like this:
```
datalad add-readme
[WARNING] Found no aggregated metadata info file /tmp/abcd/more/.datalad/metadata/aggregate_v1.json. You will likely need to either update the dataset from its original location or reaggregate metadata locally.
metadata(impossible): . (dataset) [Dataset at . contains no aggregated metadata on this path]
[WARNING] Could not obtain dataset metadata, proceeding without
add_readme(ok): /tmp/abcd/more/README.md (file)
add(ok): README.md (file)
save(ok): . (dataset)
action summary:
  add (ok: 1)
  save (ok: 1)
add(ok): README.md (file)
save(ok): . (dataset)
action summary:
  add (ok: 1)
  add_readme (ok: 1)
  save (ok: 1)
```
With this change applied, it looks like this:
```
datalad add-readme
[WARNING] Found no aggregated metadata info file /tmp/abcd/more/more/more/.datalad/metadata/aggregate_v1.json. You will likely need to either update the dataset from its original location or reaggregate metadata locally.
[WARNING] Could not obtain dataset metadata, proceeding without
add_readme(ok): /tmp/abcd/more/more/more/README.md (file)
add(ok): README.md (file)
save(ok): . (dataset)
action summary:
  add (ok: 1)
  add_readme (ok: 1)
  save (ok: 1)
```