### PR TITLE
MNT: Silence result rendering of copy-file's internal save() call

### DIFF
--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -318,6 +318,8 @@ class CopyFile(Interface):
             # we provide an explicit file list
             recursive=False,
             message=message,
+            return_type='generator',
+            result_renderer='disabled'
         )
 
 


### PR DESCRIPTION
Following #6461, this takes the output of copyfile from
```
❱ datalad copy-file input/dataset_description.json -d .
[INFO   ] Copying non-annexed file or copy into non-annex dataset: /tmp/abcd/input/dataset_description.json -> AnnexRepo(/tmp/abcd)
copy_file(ok): /tmp/abcd/input/dataset_description.json
add(ok): dataset_description.json (file)
save(ok): . (dataset)
action summary:
  add (ok: 1)
  save (ok: 1)
add(ok): dataset_description.json (file)
save(ok): . (dataset)
action summary:
  add (ok: 1)
  copy_file (ok: 1)
  save (ok: 1)
```
to
```
datalad copy-file input/participants.json -d .
[INFO   ] Copying non-annexed file or copy into non-annex dataset: /tmp/abcd/input/participants.json -> AnnexRepo(/tmp/abcd)
copy_file(ok): /tmp/abcd/input/participants.json
add(ok): participants.json (file)
save(ok): . (dataset)
action summary:
  add (ok: 1)
  copy_file (ok: 1)
  save (ok: 1)
```
no changelog necessary