### PR TITLE
Unify keyword in the spirit of issue #6461

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -612,7 +612,8 @@ def _install_targetpath(
                 path=target_path,
                 recursive=recursive,
                 recursion_limit=recursion_limit,
-                return_type='generator'):
+                return_type='generator',
+                result_renderer='disabled'):
             res.update(
                 contains=[Path(res['path'])],
                 action='get',


### PR DESCRIPTION
Add a missing result_renderer-spec in call to subdatasets

### Changelog
#### 🏠 Internal
- disable result renderer in internal call  to subdataset in get