### PR TITLE
Replace custom entrypoint with standard for special remotes

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -14,6 +14,7 @@ from datalad.customremotes import (
     RemoteError,
     SpecialRemote,
 )
+from datalad.customremotes.main import main as super_main
 from datalad.support.annexrepo import AnnexRepo
 from datalad.customremotes.ria_utils import (
     get_layout_locations,
@@ -1427,10 +1428,9 @@ def _sanitize_key(key):
 
 def main():
     """cmdline entry point"""
-    from annexremote import Master
-    from datalad.ui import ui
-    master = Master()
-    remote = RIARemote(master)
-    ui.set_backend('annex')  # interactive, stdin/stdout will be used for interactions with annex
-    master.LinkRemote(remote)
-    master.Listen()
+    super_main(
+        cls=RIARemote,
+        remote_name='ora',
+        description=\
+        "transport file content to and from datasets hosted in RIA stores",
+    )


### PR DESCRIPTION
New pattern introduced with ecd4577753d9e82cdb097d35368eadcf79e24e21

### Changelog
#### 💫 Enhancements and new features
- `git-annex-remote-ora` now provides the same standardized CLI interface as other special remotes and the core package with support for help and version reporting.
