### PR TITLE
Remove invalid `AnnexCustomRemote.whereis()` implementation

### DIFF
--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -89,11 +89,6 @@ class AnnexCustomRemote(SpecialRemote):
     def remove(self, key):
         raise RemoteError("Removal of content from urls is not possible")
 
-    def whereis(self, key):
-        # All that information is stored in annex itself,
-        # we can't complement anything
-        raise RemoteError()
-
     def getcost(self):
         return self.COST
 

--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -61,6 +61,13 @@ def check_basic_scenario(url, d):
     whereis2 = annex.whereis(filename, output='full')
     eq_(len(whereis2), 1)  # datalad
 
+    # make sure that there are no "hidden" error messages, despite the
+    # whereis command succeeding
+    # https://github.com/datalad/datalad/issues/6453#issuecomment-1047533276
+    from datalad.runner import StdOutErrCapture
+    out = annex._call_annex(['whereis'], protocol=StdOutErrCapture)
+    eq_(out['stderr'].strip(), '')
+
     # if we provide some bogus address which we can't access, we shouldn't pollute output
     with assert_raises(CommandError) as cme:
         annex.add_urls([url + '_bogus'])


### PR DESCRIPTION
This was a leftover from before this class inherited from
`AnnexRemote.SpecialRemote`. In order to communicate that
a whereis isn't supported/meaningful, one would need to raise
`UnsupportedRequest()` instead -- which happens to be the default
implementation in the base class.

Therefore removal is the best and a sufficient fix.

This change does not include a proper test. Despite the protocol
violation, a `git-annex whereis` (the relevant call to test here) would
succeed. Consequently, the added test only verified that no
error messages pops up anymore.

Fixes datalad/datalad#6453

### Changelog
No needed, no change in behavior from a previous release.