### PR TITLE
Unify keyword arguments in search in spirit of issue #6461

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -301,7 +301,9 @@ def _search_from_virgin_install(dataset, query):
             "Performing search using DataLad superdataset %r",
             default_ds.path
         )
-        for res in default_ds.search(query):
+        for res in default_ds.search(query,
+                                     return_type="generator",
+                                     result_renderer="disabled"):
             yield res
         return
     else:
@@ -466,13 +468,7 @@ class _WhooshSearch(_Search):
         if not exists(index_dir):
             os.makedirs(index_dir)
 
-        # this is a pretty cheap call that just pull this info from a file
-        dsinfo = self.ds.metadata(
-            get_aggregates=True,
-            return_type='list',
-            result_renderer='disabled')
-
-        self._mk_schema(dsinfo)
+        self._mk_schema()
 
         idx_obj = widx.create_in(index_dir, self.schema)
         idx = idx_obj.writer(
@@ -495,7 +491,6 @@ class _WhooshSearch(_Search):
             lgr.info,
             'autofieldidxbuild',
             'Start building search index',
-            total=len(dsinfo),
             label='Building search index',
             unit=' Datasets',
         )
@@ -654,7 +649,7 @@ class _BlobSearch(_WhooshSearch):
                 val2str=True,
                 schema=None).items()))
 
-    def _mk_schema(self, dsinfo):
+    def _mk_schema(self):
         from whoosh import fields as wf
         from whoosh.analysis import StandardAnalyzer
 
@@ -691,7 +686,7 @@ class _AutofieldSearch(_WhooshSearch):
     def _meta2doc(self, meta):
         return _meta2autofield_dict(meta, val2str=True, schema=self.schema)
 
-    def _mk_schema(self, dsinfo):
+    def _mk_schema(self):
         from whoosh import fields as wf
         from whoosh.analysis import SimpleAnalyzer
 
@@ -718,7 +713,6 @@ class _AutofieldSearch(_WhooshSearch):
             lgr.info,
             'idxschemabuild',
             'Start building search schema',
-            total=len(dsinfo),
             label='Building search schema',
             unit=' Datasets',
         )

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -301,10 +301,10 @@ def _search_from_virgin_install(dataset, query):
             "Performing search using DataLad superdataset %r",
             default_ds.path
         )
-        for res in default_ds.search(query,
-                                     return_type="generator",
-                                     result_renderer="disabled"):
-            yield res
+        yield from default_ds.search(
+            query,
+            return_type="generator",
+            result_renderer="disabled")
         return
     else:
         raise  # this function is called within exception handling block

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -288,18 +288,15 @@ def _search_from_virgin_install(dataset, query):
             from datalad.api import install
             from datalad.utils import DatasetFilteringIterator
 
-            dataset_or_iterable = install(
+            iterable = install(
                 DEFAULT_DATASET_PATH,
                 source='///',
                 result_renderer='disabled',
                 return_type='generator')
-            if isinstance(dataset_or_iterable, Dataset):
-                default_ds = dataset_or_iterable
-            else:
-                default_ds = yield from DatasetFilteringIterator(
-                    iterable=dataset_or_iterable,
-                    at_most_one=True,
-                    success_only=False)
+            default_ds = yield from DatasetFilteringIterator(
+                iterable=iterable,
+                at_most_one=True,
+                success_only=False)
             ui.message(
                 "From now on you can refer to this dataset using the "
                 "label '///'"

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -286,10 +286,20 @@ def _search_from_virgin_install(dataset, query):
                      "superdataset at %r?"
                      % DEFAULT_DATASET_PATH):
             from datalad.api import install
-            default_ds = install(
+            from datalad.utils import DatasetFilteringIterator
+
+            dataset_or_iterable = install(
                 DEFAULT_DATASET_PATH,
                 source='///',
-                result_renderer='disabled')
+                result_renderer='disabled',
+                return_type='generator')
+            if isinstance(dataset_or_iterable, Dataset):
+                default_ds = dataset_or_iterable
+            else:
+                default_ds = yield from DatasetFilteringIterator(
+                    iterable=dataset_or_iterable,
+                    at_most_one=True,
+                    success_only=False)
             ui.message(
                 "From now on you can refer to this dataset using the "
                 "label '///'"

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -148,8 +148,13 @@ def _check_mocked_install(default_dspath, mock_install):
     # we no longer do any custom path tune up from the one returned by search
     # so should match what search returns
     assert_equal(
-        list(gen), [report
-                    for report in _mocked_search_results])
+        list(gen),
+        [
+            report
+            for report
+            in _mocked_search_results
+        ])
+
     mock_install.assert_called_once_with(
         default_dspath,
         source='///',

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -94,6 +94,8 @@ def test_search_outside1_install_default_ds(tdir, default_dspath):
                   return_value=Dataset(default_dspath)) as mock_install, \
             patch('datalad.distribution.dataset.Dataset.search',
                   new_callable=_mock_search):
+
+            mock_install.return_value = iter([{"type": "dataset", "status": "ok", "path": "/tmp/t0"}])
             _check_mocked_install(default_dspath, mock_install)
 
             # now on subsequent run, we want to mock as if dataset already exists
@@ -101,6 +103,7 @@ def test_search_outside1_install_default_ds(tdir, default_dspath):
             from datalad.ui import ui
             ui.add_responses('yes')
             mock_install.reset_mock()
+            mock_install.return_value = iter([{"type": "dataset", "status": "ok", "path": "/tmp/t0"}])
             with patch(
                     'datalad.distribution.dataset.Dataset.is_installed',
                     True):
@@ -109,6 +112,7 @@ def test_search_outside1_install_default_ds(tdir, default_dspath):
             # and what if we say "no" to install?
             ui.add_responses('no')
             mock_install.reset_mock()
+            mock_install.return_value = iter([{"type": "dataset", "status": "ok", "path": "/tmp/t0"}])
             with assert_raises(NoDatasetFound):
                 list(search("."))
 
@@ -116,6 +120,7 @@ def test_search_outside1_install_default_ds(tdir, default_dspath):
             Dataset(default_dspath).create()
             ui.add_responses('no')
             mock_install.reset_mock()
+            mock_install.return_value = iter([{"type": "dataset", "status": "ok", "path": "/tmp/t0"}])
             with assert_raises(NoDatasetFound):
                 list(search("."))
 
@@ -158,7 +163,8 @@ def _check_mocked_install(default_dspath, mock_install):
     mock_install.assert_called_once_with(
         default_dspath,
         source='///',
-        result_renderer='disabled')
+        result_renderer='disabled',
+        return_type='generator')
 
 
 @with_tempfile

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2730,16 +2730,17 @@ class FilteringIterator:
 
     def __iter__(self):
         for element in self.iterable:
-            if isinstance(element, dict):
-                for pattern in self.patterns:
-                    if pattern.items() <= element.items():
-                        self.filtered.append(element)
-                        break
-                else:
-                    yield element
+            if isinstance(element, dict) and self._matches_patterns(element):
+                self.filtered.append(element)
             else:
                 yield element
         return self.filtered
+
+    def _matches_patterns(self, element: dict) -> bool:
+        for pattern in self.patterns:
+            if pattern.items() <= element.items():
+                return True
+        return False
 
 
 class DatasetFilteringIterator(FilteringIterator):

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2705,11 +2705,11 @@ class FilteringIterator:
     stored in the "filtered"-attribute, as well as returned as result of the
     iterator.
 
-    So the FilteIterator can be used like:
+    So the FilteringIterator can be used like this::
 
         filtered_dicts = yield from FilteringIterator(...)
 
-    or like
+    or like this::
 
         filtering_iterator = FilteringIterator(...)
         for e in filtering_iterator:


### PR DESCRIPTION
Disable result renderer in internal datalad API calls in search-code.

### Changelog
#### 🏠 Internal
- silence output from internal calls in `datalad search`
