### PR TITLE
BF: No object tree in RIA w/o special remote

### DIFF
--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -181,7 +181,8 @@ def create_store(io, base_path, version):
     io.mkdir(error_logs)
 
 
-def create_ds_in_store(io, base_path, dsid, obj_version, store_version, alias=None):
+def create_ds_in_store(io, base_path, dsid, obj_version, store_version,
+                       alias=None, init_obj_tree=True):
     """Helper to create a dataset in a RIA store
 
     Note, that this is meant as an internal helper and part of intermediate
@@ -203,6 +204,9 @@ def create_ds_in_store(io, base_path, dsid, obj_version, store_version, alias=No
       layout version of the dataset itself (object tree)
     alias: str, optional
       alias for the dataset in the store
+    init_obj_tree: bool
+      whether or not to create the base directory for an annex objects tree (
+      'annex/objects')
     """
 
     # TODO: Note for RF'ing, that this is about setting up a valid target
@@ -225,7 +229,8 @@ def create_ds_in_store(io, base_path, dsid, obj_version, store_version, alias=No
     _ensure_version(io, dsgit_dir, obj_version)
 
     io.mkdir(archive_dir)
-    io.mkdir(dsobj_dir)
+    if init_obj_tree:
+        io.mkdir(dsobj_dir)
     if alias:
         alias_dir = base_path / "alias"
         io.mkdir(alias_dir)

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -597,7 +597,8 @@ def _create_sibling_ria(
             " and '{}'".format(storage_name) if storage_name else '',
         ))
     create_ds_in_store(SSHRemoteIO(ssh_host) if ssh_host else LocalIO(),
-                       base_path, ds.id, '2', '1', alias)
+                       base_path, ds.id, '2', '1', alias,
+                       init_obj_tree=storage_sibling is not False)
     if storage_sibling:
         # we are using the main `name`, if the only thing we are creating
         # is the storage sibling

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -18,6 +18,7 @@ from datalad.api import (
 )
 from datalad.tests.utils import (
     attr,
+    assert_false,
     assert_in,
     assert_raises,
     assert_repo_status,
@@ -356,6 +357,12 @@ def test_no_storage(store1, store2, ds_path):
     assert_result_count(res, 1, status='ok', action='create-sibling-ria')
     eq_({'datastore2', 'datastore1', 'here'},
         {s['name'] for s in ds.siblings(result_renderer='disabled')})
+
+    # no annex/object dir should be created when there is no special remote
+    # to use it.
+    for s in [store1, store2]:
+        p = Path(s) / ds.id[:3] / ds.id [3:] / 'annex' / 'objects'
+        assert_false(p.exists())
 
     # smoke test that we can push to it
     res = ds.push(to='datastore1')

--- a/datalad/distributed/tests/test_ria_git_remote.py
+++ b/datalad/distributed/tests/test_ria_git_remote.py
@@ -82,10 +82,7 @@ def _test_bare_git_version_1(host, dspath, store):
     create_store(io, store, '1')
     # set up the dataset location, too.
     # Note: Dataset layout version 1 (dirhash lower):
-    create_ds_in_store(io, store, ds.id, '1', '1')
-    # Avoid triggering a git-annex safety check. See gh-5253.
-    assert objdir.is_absolute()
-    io.remove_dir(objdir)
+    create_ds_in_store(io, store, ds.id, '1', '1', init_obj_tree=False)
 
     # Now, let's have the bare repo as a git remote and use it with annex
     git_url = "ssh://{host}{path}".format(host=host, path=bare_repo_path) \


### PR DESCRIPTION
`create-sibling-ria` and the underlying helper created a dataset's `annex/objects` directory unconditionally.
However, only having the git repositories in store with no special remote and no data whatsoever is valid and supported usecase. The existence of that (empty) directory increases the inode count per dataset, is superfluous and leads to failures of annex commands being executed directly in store. While the latter is something to generally be very careful about, there are valid usecases and with the previous behavior we'd cause annex to pointlessly fail on discovery of that dir, indicating to annex that the repo is not annex-init'ed but was apparently used with annex before.


### Changelog
#### 🐛 Bug Fixes
- `create-sibling-ria` no longer creates an `annex/objects` directory in-store, when called with `--no-storage-sibling`. [#6495](https://github.com/datalad/datalad/pull/6495) (by @bpoldrack )
