### PR TITLE
Guard RI-type determination

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -1447,7 +1447,8 @@ def decode_source_spec(spec, cfg=None):
     # scheme.
     spec = cfg.rewrite_url(spec)
     # common starting point is a RI instance, support for accepting an RI
-    # instance is kept for backward-compatibility reasons
+    # instance is kept for backward-compatibility reasons.
+    # this conversion will raise ValueError for any unrecognized RI
     source_ri = RI(spec) if not isinstance(spec, RI) else spec
 
     # scenario switch, each case must set 'giturl' at the very minimum

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -403,14 +403,25 @@ class RI(object):
            uninitialized RI object of appropriate class with _str
            set to string representation if was provided
 
+        Raises
+        ------
+        ValueError
+          Whenever the RI type cannot be determined.
         """
         if cls is RI and ri is not None:
             # RI class was used as a factory
-            cls = _guess_ri_cls(ri)
+            try:
+                cls = _guess_ri_cls(ri)
+            except Exception as e:
+                # when anything goes wrong here, ensure a homogeneous
+                # exception with a regular error
+                raise ValueError(
+                    f"Could not determine resource identifier type for {ri!r}"
+                ) from e
 
         if cls is RI:
-            # should we fail or just pretend we are nothing??? ;-) XXX
-            raise ValueError("Could not deduce RI type for %r" % (ri,))
+            raise ValueError(
+                f"Could not determine resource identifier type for {ri!r}")
 
         ri_obj = super(RI, cls).__new__(cls)
         # Store internally original str


### PR DESCRIPTION
Instead of randomly crashing, raise a uniform ValueError whenever
anything goes wrong. Include any original exception as a cause.

Re datalad/datalad#6494 this changes:

```
[ERROR  ] ValueError(invalid literal for int() with base 10: 'datalad-datasets') (ValueError)
```

to

```
[ERROR  ] ValueError(Could not determine resource identifier type for 'https://github.com:datalad-datasets/human-connectome-project-openaccess.git') (ValueError)
```

### Changelog
#### 🐛 Bug Fixes
- Improve error message when an invalid URL is given to `clone`. Fixes #6494
