### PR TITLE
DOC: Add remark to old credential env vars

### DIFF
--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -67,6 +67,10 @@ class Keyring(object):
     # proxy few methods of interest explicitly, to be rebound to the module's
     def get(self, name, field):
         # consult environment, might be provided there and should take precedence
+        # NOTE: This env var specification is outdated and not advertised
+        # anymmore, but needs to be supported. For example, it is used with and
+        # was advertised for
+        # https://github.com/datalad-datasets/human-connectome-project-openaccess
         env_var = ('DATALAD_%s_%s' % (name, field)).replace('-', '_')
         lgr.log(5, 'Credentials lookup attempt via env var %s', env_var)
         if env_var in os.environ:


### PR DESCRIPTION
This outdated way of specifying credentials needs to be kept while at
the same time it is not documented (only indirectly in context of HCP OA
for example). Hence, the added note is important to stumble upon on
refactoring.

Just an internal comment - no changelog here.