### PR TITLE
Replace left-over (unused) mode label in CLI parser

### DIFF
--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -124,7 +124,7 @@ def setup_parser(
 
     command_provider = 'core'
 
-    if status == 'full' and not help_ignore_extensions:
+    if status == 'allparsers' and not help_ignore_extensions:
         from .helpers import add_entrypoints_to_interface_groups
         add_entrypoints_to_interface_groups(interface_groups)
 


### PR DESCRIPTION
This is used to support the weird parser construction mode that is
only used to construct parsers for manpage generation during extension
package documentation builds. Eventually this must all be factored
out into dedicated helpers that do this, and only only this -- instead
of being shoehorned into code that must run a quick as possible.

That being said, this fix removes this 0.16 release blocker, and makes
the broken extension package doc build work again.

Fixes datalad/datalad#6490

### Changelog
No entry needed, only broken in unreleased code.