### PR TITLE
BF: do not use BaseDownloader instance wide InterProcessLock - resolves stalling or errors during parallel installs

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -114,10 +114,6 @@ class BaseDownloader(object, metaclass=ABCMeta):
         self.credential = credential
         self.authenticator = authenticator
         self._cache = None  # for fetches, not downloads
-        self._lock = InterProcessLock(
-            op.join(cfg.obtain('datalad.locations.locks'),
-                    'downloader-auth.lck')
-        )
 
     def access(self, method, url, allow_old_session=True, **kwargs):
         """Generic decorator to manage access to the URL via some method
@@ -155,10 +151,18 @@ class BaseDownloader(object, metaclass=ABCMeta):
             msg_types = ''
             supported_auth_types = []
             used_old_session = False
+            # Lock must be instantiated here, within each thread to avoid problems
+            # when used in our parallel.ProducerConsumer
+            # see https://github.com/datalad/datalad/issues/6483
+            interp_lock = InterProcessLock(
+                op.join(cfg.obtain('datalad.locations.locks'),
+                        'downloader-auth.lck')
+            )
+
             try:
                 # Try to lock since it might desire to ask for credentials, but still allow to time out at 5 minutes
                 # while providing informative message on what other process might be holding it.
-                with try_lock_informatively(self._lock, purpose="establish download session", proceed_unlocked=False):
+                with try_lock_informatively(interp_lock, purpose="establish download session", proceed_unlocked=False):
                     used_old_session = self._establish_session(url, allow_old=allow_old_session)
                 if not allow_old_session:
                     assert(not used_old_session)
@@ -193,7 +197,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
                 # in case of parallel downloaders, one would succeed to get the
                 # lock, ask user if necessary and other processes would just wait
                 # got it to return back
-                with try_lock(self._lock) as got_lock:
+                with try_lock(interp_lock) as got_lock:
                     if got_lock:
                         if isinstance(e, AccessPermissionExpiredError) \
                                 and not credential_was_refreshed \


### PR DESCRIPTION
apparently that does not play nice with multi-threading parallelization,
where (I guess) we instantiate and reuse the same Downloader across multiple
threads, and thus reusing the lock.

Bu instantiating the lock right before using it, albeit may be adding even more runtime
overhead, we are avoiding the problems with InterProcessLock.

Closes #6483 and also see https://github.com/harlowja/fasteners/issues/91 for more
information.  Filed also https://github.com/datalad/datalad/issues/6506 which observed while troubleshooting.

~~I am yet to try it on actual original HCP use case, but~~ with this script
http://www.onerussian.com/tmp/ts-parallel-download.py
and this list of urls for our store http://www.onerussian.com/tmp/store-configs.txt
`/bin/rm -f /tmp/out/*; head -n 1000 /tmp/store-configs.txt | python ts-parallel-download.py` now works ok

edit: HCP timing on smaug:

```
action summary:
  install (ok: 4547)
                 datalad get -n -r HCP1200 --jobs 32  11158.83s user 7123.09s system 176% cpu 2:52:38.36 total
```