### PR TITLE
Disable internal save-result rendering in update()

### DIFF
--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -419,26 +419,33 @@ class Update(Interface):
         # we need to save updated states only if merge was requested -- otherwise
         # it was a pure fetch
         if how_curr and recursive:
-            if path and not saw_subds:
-                lgr.warning(
-                    'path constraints did not match an installed subdataset: %s',
-                    path)
-            if refds in update_failures:
-                lgr.warning("Not saving because top-level dataset %s "
-                            "had an update failure in subdataset",
-                            refds.path)
-            else:
-                save_paths = [p for p in save_paths if p != refds.path]
-                if not save_paths:
-                    return
-                lgr.debug(
-                    'Subdatasets where updated state may need to be '
-                    'saved in the parent dataset: %s', save_paths)
-                for r in refds.save(
-                        path=save_paths,
-                        recursive=False,
-                        message='[DATALAD] Save updated subdatasets'):
-                    yield r
+            yield from _save_after_update(
+                refds, save_paths, update_failures, path, saw_subds)
+
+
+def _save_after_update(refds, tosave, update_failures, path_arg, saw_subds):
+    if path_arg and not saw_subds:
+        lgr.warning(
+            'path constraints did not match an installed subdataset: %s',
+            path_arg)
+    if refds in update_failures:
+        lgr.warning("Not saving because top-level dataset %s "
+                    "had an update failure in subdataset",
+                    refds.path)
+    else:
+        save_paths = [p for p in tosave if p != refds.path]
+        if not save_paths:
+            return
+        lgr.debug(
+            'Subdatasets where updated state may need to be '
+            'saved in the parent dataset: %s', save_paths)
+        for r in refds.save(
+                path=save_paths,
+                recursive=False,
+                message='[DATALAD] Save updated subdatasets',
+                return_type='generator',
+                result_renderer='disabled'):
+            yield r
 
 
 def _choose_update_target(repo, branch, remote, cfg_remote):


### PR DESCRIPTION
Move `save()` call into a dedicated helper to reduce the cognitive
complexity of the monster Update.__call__() method.

In the spirit of datalad/datalad#6461

No changelog needed.