### PR TITLE
Set a minimum dependency on keyrings version 20.0 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requires = {
     ],
     'downloaders': [
         'boto',
-        'keyring>=8.0', 'keyrings.alt',
+        'keyring>=20.0', 'keyrings.alt',
         'msgpack',
         'requests>=1.2',
     ],


### PR DESCRIPTION
https://github.com/datalad/datalad-osf/issues/123 reported a failure for
token-based authentication when elderly versions of SecretStorage were used
that could not handle empty passwords (as is the case with token-based auth).
This PR updates the minimum dependency of the ``keyring`` package to fix
this issue. ``keyring`` versions ``20.0`` or higher have dependencies to sufficiently
recent versions of SecretStorage that contain a fix for the original issue.
This dependency has not be set for quite a while because recent enough
versions of ``keyring`` were not uniformly available (see https://github.com/datalad/datalad-osf/pull/130),
but now that recent versions of the package are widely available, we can 
incorporate this fix into datalad core.

fixes #6498 and https://github.com/datalad/datalad-osf/issues/123


### Changelog
#### 🐛 Bug Fixes
- DataLad declares a minimum version dependency to ``keyring >= 20.0`` to ensure that token-based authentication can be used.
