### PR TITLE
Refuse to configure common data source if annex-uuid is missing

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -590,20 +590,23 @@ def _configure_remote(
                         message='cannot configure as a common data source, '
                                 'URL protocol is not http or https',
                         **result_props)
-                elif f'remote.{name}.annex-uuid' not in repo.config:
-                    yield dict(
-                        status='impossible',
-                        message='cannot configure as a common data source; '
-                                'the remote has no annex UUID, which may '
-                                'indicate absence of remote git-annex branch; '
-                                'consider running push first',
-                        **result_props)
                 else:
                     # XXX what if there is already a special remote
                     # of this name? Above check for remotes ignores special
                     # remotes. we need to `git annex dead REMOTE` on reconfigure
                     # before we can init a new one
                     # XXX except it is not enough
+
+                    # Warn if configuring something that has no annex UUID
+                    # which will produce a weird entry in git-annex:remote.log
+                    if f'remote.{name}.annex-uuid' not in repo.config:
+                        lgr.warning(
+                            f'Configuring the remote {name} as a common data'
+                            f'source {as_common_datasrc}, but the resulting '
+                            f'special remote configuration may be incomplete. '
+                            f'The {name} remote has no annex UUID, which may '
+                            f'indicate absence of git-annex branch on the '
+                            f'remote end; consider pushing / updating first.')
 
                     # make special remote of type=git (see #335)
                     repo.call_annex([


### PR DESCRIPTION
This WIP PR introduces an additional check / warning for `datalad siblings [add|configure] (...) --as-common-datasrc` to prevent unusable configuration. The update focuses on GIN use case, but I think it should be at least neutral, if not positive, for others.

### Overview

- For example, prior to this PR, trying to configure a sibling pointing to an empty GIN repo as a common data source produces an invalid `git-annex` configuration and may or may not produce an error: #6199 
- Adding / configuring a sibling involves a series of steps which add or change configuration entries as a result. Those related to the common data source are done last.
- The best indicator for validity of a sibling seems to be the presence of `remote.{name}.annex-uuid` in `.git/config`
  - Note: `create_sibling_gin` yields a configuration with `annex.ignore` unset, so `annex.ignore` alone cannot be checked
  - Note: adding a non-empty repo with `siblings add` will produce the `annex.uuid` entry before the proposed checks

### Proposed solution

- I propose to refuse configuring the sibling as a common data source if `annex.uuid` is missing, and to raise some kind of a warning rather then an error, because:
  - configuration steps prior to the common data source part may still be successful / meaningful
  - hard to determine in advance if the configuration will succeed (see note on adding a non-empty repo above)

### Introduced behaviour (example)

Compared to what happened previously, an attempt to configure an empty GIN repo additionally yields (impossible) result with an explanation. Behind the scenes, no entry is made in `git-annex:remote.log`.

```
datalad siblings add --url https://gin.g-node.org/msz/empty --pushurl git@gin.g-node.org:/msz/empty.git --name gin --as-common-datasrc gin-src
[INFO   ] Could not enable annex remote gin. This is expected if gin is a pure Git remote, or happens if it is not accessible. 
add-sibling(impossible): . (sibling) [cannot configure as a common data source; the remote has no annex UUID, which may indicate absence of remote git-annex branch; consider running push first]
[WARNING] Could not detect whether gin carries an annex. If gin is a pure Git remote, this is expected. Remote was marked by annex as annex-ignore. Edit .git/config to reset if you think that was done by mistake due to absent connection etc 
.: gin(-) [https://gin.g-node.org/msz/empty (git)]
```

### Open questions (feedback welcome!)

- What's the best way to communicate refusal to configure to users? I used `yield dict(status='impossible', message=...)` but maybe something else would be preferred?
- Are there other cases for which checking `remote.{name}.annex-uuid` wouldn't be the thing to do?
- What should a test for the behaviour look like?

### TODO
- [ ] Add a separate check for `annex.ignore=True`
- [ ] Add a test, if possible
- [ ] Write a changelog entry
- ...

### Changelog
#### 🐛 Bug Fixes
- Description... Fixes #issue
#### 💫 Enhancements and new features
-
#### 🪓 Deprecations and removals
-
#### 📝 Documentation
-
#### 🏠 Internal
-
#### 🛡 Tests
-
