### PR TITLE
Support next generation metadata in search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
     env:
     - PYTEST_SELECTION_OP=not
     - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20210310 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=10.20220525 -m conda"
   - python: 3.7
     env:
     - PYTEST_SELECTION_OP=""

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1045,10 +1045,10 @@ class Metadata(Interface):
 
 
 def gen4_query_aggregated_metadata(reporton: str,
-                                 ds: Dataset,
-                                 aps: List[Dict],
-                                 recursive: bool = False,
-                                 **kwargs):
+                                   ds: Dataset,
+                                   aps: List[Dict],
+                                   recursive: bool = False,
+                                   **kwargs):
     """Query metadata in a metadata store
 
     Query paths (`aps["path"]`) have to be contained in the poth of the ds.

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1140,7 +1140,7 @@ def query_aggregated_metadata(reporton: str,
                               ds: Dataset,
                               aps: List[Dict],
                               recursive: bool = False,
-                              use_metadata: Optional[str] = None,
+                              metadata_source: Optional[str] = None,
                               **kwargs):
     """Query legacy and NG-metadata stored in a dataset or its metadata store
 
@@ -1156,11 +1156,11 @@ def query_aggregated_metadata(reporton: str,
     recursive : bool
       Whether or not to report metadata underneath all query paths
       recursively.
-    use_metadata : Optional[str]
-      Metadata generation that should be used. If set to "legacy", only
-      prior metalad version 0.3.0 metadata will be queried, if set to "gen4",
-      only metalad version 0.3.0 and beyond metadata will be queried, if set
-      to 'None', both will be queried.
+    metadata_source : Optional[str]
+      Metadata source that should be used. If set to "legacy", only metadata
+      prior metalad version 0.3.0 will be queried, if set to "gen4", only
+      metadata of metalad version 0.3.0 and beyond will be queried, if set
+      to 'None', all known metadata will be queried.
     **kwargs
       Any other argument will be passed on to the query result dictionary.
 
@@ -1170,7 +1170,7 @@ def query_aggregated_metadata(reporton: str,
       Of result dictionaries.
     """
 
-    if use_metadata in (None, "legacy"):
+    if metadata_source in (None, "legacy"):
         yield from legacy_query_aggregated_metadata(
             reporton=reporton,
             ds=ds,
@@ -1179,7 +1179,7 @@ def query_aggregated_metadata(reporton: str,
             **kwargs
         )
 
-    if use_metadata in (None, "gen4") and next_generation_metadata_available:
+    if metadata_source in (None, "gen4") and next_generation_metadata_available:
         yield from gen4_query_aggregated_metadata(
             reporton=reporton,
             ds=ds,

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import (
     Dict,
     List,
+    Optional,
 )
 
 from datalad import cfg
@@ -1120,6 +1121,7 @@ def query_aggregated_metadata(reporton: str,
                               ds: Dataset,
                               aps: List[Dict],
                               recursive: bool = False,
+                              use_metadata: Optional[str] = None,
                               **kwargs):
     """Query legacy and NG-metadata stored in a dataset or its metadata store
 
@@ -1144,15 +1146,16 @@ def query_aggregated_metadata(reporton: str,
       Of result dictionaries.
     """
 
-    yield from legacy_query_aggregated_metadata(
-        reporton=reporton,
-        ds=ds,
-        aps=aps,
-        recursive=recursive,
-        **kwargs
-    )
+    if use_metadata in (None, "old"):
+        yield from legacy_query_aggregated_metadata(
+            reporton=reporton,
+            ds=ds,
+            aps=aps,
+            recursive=recursive,
+            **kwargs
+        )
 
-    if next_generation_metadata_available:
+    if use_metadata in (None, "new") and next_generation_metadata_available:
         yield from ng_query_aggregated_metadata(
             reporton=reporton,
             ds=ds,

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1108,6 +1108,7 @@ def gen4_query_aggregated_metadata(reporton: str,
                 continue
 
             yield {
+                **kwargs,
                 "status": "ok",
                 "type": metadata["type"],
                 "path": str(dump_result["path"]),

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1146,7 +1146,7 @@ def query_aggregated_metadata(reporton: str,
       Of result dictionaries.
     """
 
-    if use_metadata in (None, "old"):
+    if use_metadata in (None, "legacy"):
         yield from legacy_query_aggregated_metadata(
             reporton=reporton,
             ds=ds,
@@ -1155,8 +1155,8 @@ def query_aggregated_metadata(reporton: str,
             **kwargs
         )
 
-    if use_metadata in (None, "new") and next_generation_metadata_available:
-        yield from ng_query_aggregated_metadata(
+    if use_metadata in (None, "gen4") and next_generation_metadata_available:
+        yield from gen4_query_aggregated_metadata(
             reporton=reporton,
             ds=ds,
             aps=aps,

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1041,7 +1041,7 @@ class Metadata(Interface):
                  ','.join(ensure_list(meta['tag'])))))
 
 
-def ng_query_aggregated_metadata(reporton: str,
+def gen4_query_aggregated_metadata(reporton: str,
                                  ds: Dataset,
                                  aps: List[Dict],
                                  recursive: bool = False,

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -313,9 +313,9 @@ def _search_from_virgin_install(dataset, query):
 
 
 class _Search(object):
-    def __init__(self, ds, use_metadata=None, **kwargs):
+    def __init__(self, ds, metadata_source=None, **kwargs):
         self.ds = ds
-        self.use_metadata = use_metadata
+        self.metadata_source = metadata_source
         self.documenttype = self.ds.config.obtain(
             'datalad.search.index-{}-documenttype'.format(self._mode_label),
             default=self._default_documenttype)
@@ -350,8 +350,8 @@ class _Search(object):
 
 
 class _WhooshSearch(_Search):
-    def __init__(self, ds, use_metadata=None, force_reindex=False, **kwargs):
-        super(_WhooshSearch, self).__init__(ds, use_metadata, **kwargs)
+    def __init__(self, ds, metadata_source=None, force_reindex=False, **kwargs):
+        super(_WhooshSearch, self).__init__(ds, metadata_source, **kwargs)
 
         self.idx_obj = None
         # where does the bunny have the eggs?
@@ -511,7 +511,7 @@ class _WhooshSearch(_Search):
                 # MIH: I cannot see a case when we would not want recursion (within
                 # the metadata)
                 recursive=True,
-                use_metadata=self.use_metadata):
+                metadata_source=self.metadata_source):
             # this assumes that files are reported after each dataset report,
             # and after a subsequent dataset report no files for the previous
             # dataset will be reported again
@@ -631,7 +631,7 @@ class _WhooshSearch(_Search):
                         aps=annotated_hits,
                         # never recursive, we have direct hits already
                         recursive=False,
-                        use_metadata=self.use_metadata):
+                        metadata_source=self.metadata_source):
                     res.update(
                         refds=self.ds.path,
                         action='search',
@@ -736,7 +736,7 @@ class _AutofieldSearch(_WhooshSearch):
                 ds=self.ds,
                 aps=[dict(path=self.ds.path, type='dataset')],
                 recursive=True,
-                use_metadata=self.use_metadata):
+                metadata_source=self.metadata_source):
             meta = res.get('metadata', {})
             # no stringification of values for speed, we do not need/use the
             # actual values at this point, only the keys
@@ -773,8 +773,8 @@ class _EGrepCSSearch(_Search):
     _mode_label = 'egrepcs'
     _default_documenttype = 'datasets'
 
-    def __init__(self, ds, use_metadata=None, **kwargs):
-        super(_EGrepCSSearch, self).__init__(ds, use_metadata, **kwargs)
+    def __init__(self, ds, metadata_source=None, **kwargs):
+        super(_EGrepCSSearch, self).__init__(ds, metadata_source, **kwargs)
         self._queried_keys = None  # to be memoized by get_query
 
     # If there were custom "per-search engine" options, we could expose
@@ -794,7 +794,7 @@ class _EGrepCSSearch(_Search):
                 # MIH: I cannot see a case when we would not want recursion (within
                 # the metadata)
                 recursive=True,
-                use_metadata=self.use_metadata):
+                metadata_source=self.metadata_source):
             # this assumes that files are reported after each dataset report,
             # and after a subsequent dataset report no files for the previous
             # dataset will be reported again
@@ -923,7 +923,7 @@ class _EGrepCSSearch(_Search):
                 ds=self.ds,
                 aps=[dict(path=self.ds.path, type='dataset')],
                 recursive=True,
-                use_metadata=self.use_metadata):
+                metadata_source=self.metadata_source):
             meta = res.get('metadata', {})
             # inject a few basic properties into the dict
             # analog to what the other modes do in their index
@@ -1369,7 +1369,7 @@ class Search(Interface):
                 'unknown search mode "{}"'.format(mode))
 
         searcher = searcher(
-            ds, use_metadata=metadata_source, force_reindex=force_reindex)
+            ds, metadata_source=metadata_source, force_reindex=force_reindex)
 
         if show_keys:
             searcher.show_keys(show_keys, regexes=query)

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -1314,14 +1314,16 @@ class Search(Interface):
             doc="""if given, the formal query that was generated from the given
             query string is shown, but not actually executed. This is mostly useful
             for debugging purposes."""),
-        use_metadata=Parameter(
-            args=('--use-metadata',),
+        metadata_source=Parameter(
+            args=('--metadata-source',),
             choices=('legacy', 'gen4'),
             default=None,
-            doc="""if given, defines which metadata should be used to search.
-            'legacy' will limit search to metadata in the old format, i.e.
-            stored in '$DATASET/.datalad/metadata'. 'gen4' will limit search to
-            metadata stored by the git-backend of 'datalad-metadata-model'.""")
+            doc="""if given, defines which metadata source will be used to
+            search. 'legacy' will limit search to metadata in the old format,
+            i.e. stored in '$DATASET/.datalad/metadata'. 'gen4' will limit
+            search to metadata stored by the git-backend of 
+            'datalad-metadata-model'. If not given, metadata from all supported
+            sources will be included in search.""")
     )
 
     @staticmethod
@@ -1336,7 +1338,7 @@ class Search(Interface):
                  full_record=False,
                  show_keys=None,
                  show_query=False,
-                 use_metadata=None):
+                 metadata_source=None):
         try:
             ds = require_dataset(dataset, check_installed=True, purpose='dataset search')
             if ds.id is None:
@@ -1367,7 +1369,7 @@ class Search(Interface):
                 'unknown search mode "{}"'.format(mode))
 
         searcher = searcher(
-            ds, use_metadata=use_metadata, force_reindex=force_reindex)
+            ds, use_metadata=metadata_source, force_reindex=force_reindex)
 
         if show_keys:
             searcher.show_keys(show_keys, regexes=query)

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -1316,12 +1316,12 @@ class Search(Interface):
             for debugging purposes."""),
         use_metadata=Parameter(
             args=('--use-metadata',),
-            choices=('old', 'new'),
+            choices=('legacy', 'gen4'),
             default=None,
             doc="""if given, defines which metadata should be used to search.
-            'old' will limit search to metadata in the old format, i.e. stored
-            in '$DATASET/.datalad/metadata'. 'new' will limit search to metadata
-            stored by the git-backend of 'datalad-metadata-model'.""")
+            'legacy' will limit search to metadata in the old format, i.e.
+            stored in '$DATASET/.datalad/metadata'. 'gen4' will limit search to
+            metadata stored by the git-backend of 'datalad-metadata-model'.""")
     )
 
     @staticmethod

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -11,7 +11,6 @@
 
 __docformat__ = 'restructuredtext'
 
-import collections
 import logging
 from datalad.log import log_progress
 lgr = logging.getLogger('datalad.metadata.search')
@@ -26,18 +25,29 @@ import sys
 from time import time
 
 from datalad import cfg
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
-from datalad.interface.utils import eval_results
-from datalad.distribution.dataset import Dataset
-from datalad.distribution.dataset import datasetmethod, EnsureDataset, \
-    require_dataset
-from datalad.support.gitrepo import GitRepo
-from datalad.support.param import Parameter
-from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureInt
-
 from datalad.consts import SEARCH_INDEX_DOTGITDIR
+from datalad.distribution.dataset import Dataset
+from datalad.distribution.dataset import (
+    datasetmethod,
+    EnsureDataset,
+    require_dataset,
+)
+from datalad.dochelpers import single_or_plural
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.utils import eval_results
+from datalad.support.constraints import (
+    EnsureInt,
+    EnsureNone,
+)
+from datalad.support.exceptions import (
+    CapturedException,
+    NoDatasetFound,
+)
+from datalad.support.param import Parameter
+from datalad.ui import ui
 from datalad.utils import (
     as_unicode,
     ensure_list,
@@ -46,12 +56,6 @@ from datalad.utils import (
     shortened_repr,
     unicode_srctypes,
 )
-from datalad.support.exceptions import (
-    CapturedException,
-    NoDatasetFound,
-)
-from datalad.ui import ui
-from datalad.dochelpers import single_or_plural
 from datalad.metadata.metadata import query_aggregated_metadata
 
 # TODO: consider using plain as_unicode, without restricting

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -493,13 +493,6 @@ def test_multiple_entry_points():
 
 
 def test_gen4_query_aggregated_metadata():
-
-    #try:
-    #    from datalad_metalad.dump import Dump
-    #    from datalad_metalad.exceptions import NoMetadataStoreFound
-    #except ImportError:
-    #    raise SkipTest("datalad-metalad gen4 seemingly not installed")
-
     class DatasetMock:
         def __init__(self, path: str):
             self.path = path

--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -490,6 +490,12 @@ def test_multiple_entry_points():
 
 def test_gen4_query_aggregated_metadata():
 
+    try:
+        from datalad_metalad.dump import Dump
+        from datalad_metalad.exceptions import NoMetadataStoreFound
+    except ImportError:
+        raise SkipTest("datalad-metalad gen4 seemingly not installed")
+
     class DatasetMock:
         def __init__(self, path: str):
             self.pathobj = Path(path)
@@ -498,20 +504,47 @@ def test_gen4_query_aggregated_metadata():
     extracted_metadata = {'info': 'this is mocked metadata'}
 
     def mocked_dump(**kwargs):
-        print(kwargs)
-        yield {
-            'action': 'dump',
-            'status': 'ok',
-            'path': '/ds1',
-            'metadata': {
-                'type': 'file',
-                'dataset_id': str(UUID(int=1234)),
-                'dataset_version': '0000001111111',
-                'extractor_name': extractor_name,
-                'path': kwargs['path'],
-                'extracted_metadata': extracted_metadata
+        yield from [
+            {
+                'action': 'dump',
+                'status': 'ok',
+                'path': '/ds1',
+                'metadata': {
+                    'type': 'file',
+                    'dataset_id': str(UUID(int=1234)),
+                    'dataset_version': '0000001111111',
+                    'extractor_name': extractor_name,
+                    'path': kwargs['path'],
+                    'extracted_metadata': extracted_metadata
+                }
+            },
+            {
+                'action': 'dump',
+                'status': 'error',
+                'path': '/ds1',
+                'metadata': {
+                    'type': 'file',
+                    'dataset_id': str(UUID(int=12345)),
+                    'dataset_version': '0000002222222',
+                    'extractor_name': extractor_name,
+                    'path': kwargs['path'],
+                    'extracted_metadata': extracted_metadata
+                }
+            },
+            {
+                'action': 'dump',
+                'status': 'ok',
+                'path': '/ds1',
+                'metadata': {
+                    'type': 'something',
+                    'dataset_id': str(UUID(int=123456)),
+                    'dataset_version': '0000003333333',
+                    'extractor_name': extractor_name,
+                    'path': kwargs['path'],
+                    'extracted_metadata': extracted_metadata
+                }
             }
-        }
+        ]
 
     mocked_annotated_paths = [
         {

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from _datalad_build_support.setup import (
 requires = {
     'core': [
         'platformdirs',
-        'chardet>=3.0.4',      # rarely used but small/omnipresent
+        'chardet>=3.0.4, <5.0.0',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
         'importlib-metadata >=3.6; python_version < "3.10"',


### PR DESCRIPTION
This PR extends search to use next generation metadata, if a next generation metalad extension is found.

This PR is marked as work in progress and exists to support experiments with the new metadata system. One shortcoming of this patch is that legacy and NG-metadata results are both used and not de-duplicated. Also, the mapping of NG-metadata on the expected result structure, i.e. the legacy metadata-results, is probably sub-optimal.

- [x] possibly add a flag to `search` that allows the selection of the metadata that should be searched.
- [x] add test

### Changelog
#### 💫 Enhancements and new features
- use next generation metadata code in search, if it is availble
