### PR TITLE
require_dataset() uniformly raises NoDatasetFound

### DIFF
--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -562,7 +562,12 @@ def require_dataset(dataset, check_installed=True, purpose=None):
     Returns
     -------
     Dataset
-      Or raises an exception (InsufficientArgumentsError).
+      If a dataset could be determined.
+
+    Raises
+    ------
+    NoDatasetFound
+      If not dataset could be determined.
     """
     if dataset is not None and not isinstance(dataset, Dataset):
         dataset = Dataset(dataset)
@@ -587,8 +592,8 @@ def require_dataset(dataset, check_installed=True, purpose=None):
               dataset.path)
 
     if check_installed and not dataset.is_installed():
-        raise ValueError(u"No installed dataset found at "
-                         u"{0}.".format(dataset.path))
+        raise NoDatasetFound(
+            f"No installed dataset found at {dataset.path}")
 
     return dataset
 

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -271,7 +271,7 @@ def check_require_dataset(ds_path, topdir):
     os.mkdir(path)
     with chpwd(path):
         assert_raises(
-            InsufficientArgumentsError,
+            NoDatasetFound,
             require_dataset,
             None)
         create('.')
@@ -284,7 +284,7 @@ def check_require_dataset(ds_path, topdir):
             require_dataset('some', check_installed=False).path,
             abspath('some'))
         assert_raises(
-            ValueError,
+            NoDatasetFound,
             require_dataset,
             'some',
             check_installed=True)

--- a/datalad/local/configuration.py
+++ b/datalad/local/configuration.py
@@ -139,8 +139,9 @@ class Configuration(Interface):
             configuration sources (including overrides via environment
             variables) are considered according to the normal
             rules of precedence. For action 'get' only 'branch' and 'local'
-            (with include 'global' here) are supported. For action 'dump',
-            a scope selection is ignored and all scopes are considered.""",
+            (which include 'global' here) are supported. For action 'dump',
+            a scope selection is ignored and all available scopes are
+            considered.""",
             constraints=EnsureChoice('global', 'local', 'branch', None)),
         spec=Parameter(
             args=("spec",),
@@ -200,7 +201,7 @@ class Configuration(Interface):
                 ds = require_dataset(
                     dataset,
                     check_installed=True,
-                    purpose='configuration')
+                    purpose='configure')
             except NoDatasetFound:
                 if action != 'dump' or dataset:
                     raise


### PR DESCRIPTION
Before it claimed to raise InsufficientArgumentsError uniformly,
but actually raised NoDatasetFound or ValueError, depending
on the exact error condition.

This change consolidates and documents raising NoDatasetFound,
which seems to make most sense.

### Changelog
#### 🐛 Bug Fixes
- `require_dataset()` now uniformly raises `NoDatasetFound` when no dataset was found. Implementations that catch the previously documented `InsufficientArgumentsError` or the actually raised `ValueError` will continue to work, because `NoDatasetFound` is derived from both types. Fixes #6503
