### PR TITLE
OPT: create-sibling do not try to OPT by limiting paths to installed submodules

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -689,23 +689,14 @@ class CreateSibling(Interface):
                     to='HEAD',
                     # make explicit, but doesn't matter, no recursion in diff()
                     constant_refs=True,
-                    # contrain to the paths of all locally existing subdatasets
-                    path=[
-                        sds['path']
-                        for sds in ds.subdatasets(
-                            recursive=recursive,
-                            recursion_limit=recursion_limit,
-                            state='present',
-                            result_renderer='disabled')
-                    ],
                     # save cycles, we are only looking for datasets
                     annex=None,
                     untracked='no',
-                    # recursion was done faster by subdatasets()
-                    recursive=False,
+                    recursive=True,
                     # save cycles, we are only looking for datasets
                     eval_file_type=False,
                 )
+                # not installed subdatasets would be 'clean' so we would skip them
                 if r.get('type') == 'dataset' and r.get('state', None) != 'clean'
             ]
             if not since:


### PR DESCRIPTION
Prior approach did not  work well together well with --since specification, where
subdatasets recursively would traverse entire tree for no need. And it was added in
8c673a4d75f8d073a00dabfd00033f1744349ebe RFing as an OPT to avoid expensive traversal
of subdatasets which are not installed.  But for those there should be no extra cost
since we cannot descend into not installed subdatasets.  But may be there is cost since
we will be analyzing entire trees (I guess) and not just subdatasets, which is
what matters for create-sibling -- so there could be more OPT I think

### PR checklist

- [ ] Provide an overview of the changes you're making and explain why you're proposing them, ideally in the form of a changelog (template below)
- [ ] Include `Fixes #NNN` somewhere in the description if this PR addresses an existing issue.
- [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
  Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
- [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
- [ ] **Delete these instructions**. :-)

Thanks for contributing!

### Changelog
#### 🐛 Bug Fixes
- Description... Fixes #issue
#### 💫 Enhancements and new features
-
#### 🪓 Deprecations and removals
-
#### 📝 Documentation
-
#### 🏠 Internal
-
#### 🛡 Tests
-
