### PR TITLE
Handle partially delivered encoded data

### DIFF
--- a/datalad/runner/exception.py
+++ b/datalad/runner/exception.py
@@ -38,7 +38,7 @@ class CommandError(RuntimeError):
         self.kwargs = kwargs
 
     def to_str(self, include_output=True):
-        from .utils import (
+        from datalad.utils import (
             ensure_unicode,
             join_cmdline,
         )

--- a/datalad/runner/gitrunner.py
+++ b/datalad/runner/gitrunner.py
@@ -13,14 +13,14 @@ import logging
 import os
 import os.path as op
 
+from datalad.dochelpers import borrowdoc
+from datalad.utils import generate_file_chunks
+
 from .runner import (
     GeneratorMixIn,
     WitlessRunner,
 )
-from .utils import (
-    borrowdoc,
-    generate_file_chunks,
-)
+
 
 lgr = logging.getLogger('datalad.runner.gitrunner')
 

--- a/datalad/runner/protocol.py
+++ b/datalad/runner/protocol.py
@@ -16,8 +16,9 @@ from collections import deque
 from locale import getpreferredencoding
 from typing import Optional
 
+from datalad.utils import ensure_unicode
+
 from .exception import CommandError
-from .utils import ensure_unicode
 
 lgr = logging.getLogger('datalad.runner.protocol')
 

--- a/datalad/runner/tests/test_utils.py
+++ b/datalad/runner/tests/test_utils.py
@@ -178,19 +178,6 @@ def test_assembling_decoder_mix_in_multiple_fail():
     assert_equal(decoded_strings, ["A: ", "B: ", "C: "])
 
 
-@patch("datalad.runner.utils.logger")
-def xtest_assembling_decoder_mix_in_warning(logger_mock):
-    encoding = "utf-8"
-    data_bytes = "🐷🐶.".encode(encoding)
-
-    adm = AssemblingDecoderMixIn()
-    result = adm.decode(1, data_bytes[0:1], encoding)
-    assert_equal(result, '')
-    del adm
-
-    assert_equal(logger_mock.call_count, 1)
-
-
 def test_assembling_decoder_mix_in_warning():
     encoding = "utf-8"
     data_bytes = "🐷🐶.".encode(encoding)

--- a/datalad/runner/tests/test_utils.py
+++ b/datalad/runner/tests/test_utils.py
@@ -204,3 +204,8 @@ def test_assembling_decoder_mix_in_warning():
         assert_in(
             call.warning("unprocessed data in AssemblingDecoderMixIn"),
             logger_mock.mock_calls)
+        assert_in(
+            call.debug(
+                "unprocessed data in AssemblingDecoderMixIn:\n"
+                "fd: 1, data: b'\\xf0'\n"),
+            logger_mock.mock_calls)

--- a/datalad/runner/tests/test_utils.py
+++ b/datalad/runner/tests/test_utils.py
@@ -1,9 +1,22 @@
+from typing import (
+    List,
+    Optional,
+)
+from unittest.mock import (
+    call,
+    patch,
+)
+
 from datalad.tests.utils import (
     assert_equal,
+    assert_in,
     assert_is_none,
 )
 
-from ..utils import LineSplitter
+from ..utils import (
+    AssemblingDecoderMixIn,
+    LineSplitter,
+)
 
 
 def test_line_splitter_basic():
@@ -94,3 +107,100 @@ def test_line_splitter_corner_cases():
     line_splitter = LineSplitter()
     lines = line_splitter.process("  a   \f \r\n")
     assert_equal(lines, ["  a   ", " "])
+
+
+def test_assembling_decoder_mix_in_basic():
+
+    encoding = "utf-8"
+    unicode_str = "These are not ASCII: ä, ö, ü. These can be ASCII: a, o, u."
+    data_bytes = unicode_str.encode(encoding)
+
+    adm = AssemblingDecoderMixIn()
+
+    single_result = "".join([
+        adm.decode(1, bytes([data_byte]), encoding)
+        for data_byte in data_bytes
+    ])
+    assert_equal(single_result, unicode_str)
+
+
+def _decode_multiple(adm: AssemblingDecoderMixIn,
+                     encoded_strings: List[bytes],
+                     encoding: str,
+                     fixed_index: Optional[int] = None) -> List[str]:
+
+    # Interleave decoding of multiple strings
+    decoded_chars = [list() for _ in range(len(encoded_strings))]
+    for data_index in range(max([len(es) for es in encoded_strings])):
+        for string_index in range(len(encoded_strings)):
+            if data_index < len(encoded_strings[string_index]):
+                decoded_char = adm.decode(
+                    string_index if fixed_index is None else fixed_index,
+                    bytes([encoded_strings[string_index][data_index]]),
+                    encoding)
+                decoded_chars[string_index].append(decoded_char)
+    return ["".join(decoded_list) for decoded_list in decoded_chars]
+
+
+def test_assembling_decoder_mix_in_multiple():
+    encoding = "utf-8"
+    unicode_strings = [
+        "These are not ASCII: ä, ö, ü. These can be ASCII: a, o, u.",
+        "Some other weird stuff: öäöß.",
+        "Even weirder: 🐷🐶.",
+    ]
+    encoded_strings = [
+        unicode_string.encode(encoding)
+        for unicode_string in unicode_strings
+    ]
+
+    adm = AssemblingDecoderMixIn()
+    decoded_strings = _decode_multiple(adm, encoded_strings, encoding)
+    assert_equal(unicode_strings, decoded_strings)
+
+
+def test_assembling_decoder_mix_in_multiple_fail():
+    encoding = "utf-8"
+    unicode_strings = [
+        "A: ä, ö, ü.",
+        "B: öäöß.",
+        "C: 🐷🐶.",
+    ]
+    encoded_strings = [
+        unicode_string.encode(encoding)
+        for unicode_string in unicode_strings
+    ]
+
+    adm = AssemblingDecoderMixIn()
+    decoded_strings = _decode_multiple(adm, encoded_strings, encoding, 0)
+    # Because the strings are not separated, we do not expect any proper
+    # output after single-byte encoded chars.
+    assert_equal(decoded_strings, ["A: ", "B: ", "C: "])
+
+
+@patch("datalad.runner.utils.logger")
+def xtest_assembling_decoder_mix_in_warning(logger_mock):
+    encoding = "utf-8"
+    data_bytes = "🐷🐶.".encode(encoding)
+
+    adm = AssemblingDecoderMixIn()
+    result = adm.decode(1, data_bytes[0:1], encoding)
+    assert_equal(result, '')
+    del adm
+
+    assert_equal(logger_mock.call_count, 1)
+
+
+def test_assembling_decoder_mix_in_warning():
+    encoding = "utf-8"
+    data_bytes = "🐷🐶.".encode(encoding)
+
+    adm = AssemblingDecoderMixIn()
+
+    with patch("datalad.runner.utils.logger") as logger_mock:
+        result = adm.decode(1, data_bytes[0:1], encoding)
+        assert_equal(result, '')
+        del adm
+        assert_in(
+            call.warning("unprocessed data in AssemblingDecoderMixIn"),
+            logger_mock.mock_calls)

--- a/datalad/runner/utils.py
+++ b/datalad/runner/utils.py
@@ -11,11 +11,15 @@
 All runner-related code imports from here, so this is a comprehensive declaration
 of utility dependencies.
 """
+import logging
 from collections import defaultdict
 from typing import (
     List,
     Optional,
 )
+
+
+logger = logging.getLogger("datalad.runner.utils")
 
 
 class LineSplitter:
@@ -111,3 +115,7 @@ class AssemblingDecoderMixIn:
             unicode_str = assembled_data[:e.start].decode(encoding)
             self.remaining_data[fd] = assembled_data[e.start:]
         return unicode_str
+
+    def __del__(self):
+        if any(self.remaining_data.values()):
+            logger.warning("unprocessed data in AssemblingDecoderMixIn")

--- a/datalad/runner/utils.py
+++ b/datalad/runner/utils.py
@@ -94,7 +94,7 @@ class LineSplitter:
 
 
 class AssemblingDecoderMixIn:
-    """ Mix in to safely decode data the is delivered in parts
+    """ Mix in to safely decode data that is delivered in parts
 
     This class can be used to decode data that is partially delivered.
     It detects partial encodings and stores the non-decoded data to

--- a/datalad/runner/utils.py
+++ b/datalad/runner/utils.py
@@ -118,4 +118,10 @@ class AssemblingDecoderMixIn:
 
     def __del__(self):
         if any(self.remaining_data.values()):
+            logger.debug(
+                "unprocessed data in AssemblingDecoderMixIn:\n"
+                +"\n".join(
+                    f"fd: {key}, data: {value}"
+                    for key, value in self.remaining_data.items())
+                + "\n")
             logger.warning("unprocessed data in AssemblingDecoderMixIn")

--- a/datalad/runner/utils.py
+++ b/datalad/runner/utils.py
@@ -17,16 +17,6 @@ from typing import (
     Optional,
 )
 
-from datalad.dochelpers import borrowdoc
-from datalad.utils import (
-    auto_repr,
-    ensure_unicode,
-    generate_file_chunks,
-    join_cmdline,
-    try_multiple,
-    unlink,
-)
-
 
 class LineSplitter:
     """


### PR DESCRIPTION
This PR adds code to correctly handle the situation where encoded data is delivered in parts to `SubprocessProtocol.pipe_data_received()`, and where a part ends in the middle of an encoded Unicode character. The PR introduces a mix-in class that is usually used in subclasses of `WitlessProtocol`.

This fixes issue #6526 and other parts of the code that could have potentially suffered from the same problem. 

TODO:

- [x] Tests
### Changelog
#### 🐛 Bug Fixes
- Fix an issue where partially delivered data lead to decoding errors ... Fixes #6526
