### PR TITLE
Stop including annex-bundle info in SSH connection socket name

### DIFF
--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1192,9 +1192,9 @@ def test_annex_ssh(topdir):
     from datalad import ssh_manager
 
     # check whether we are the first to use these sockets:
-    hash_1 = get_connection_hash('datalad-test', bundled=True)
+    hash_1 = get_connection_hash('datalad-test')
     socket_1 = opj(str(ssh_manager.socket_dir), hash_1)
-    hash_2 = get_connection_hash('datalad-test2', bundled=True)
+    hash_2 = get_connection_hash('datalad-test2')
     socket_2 = opj(str(ssh_manager.socket_dir), hash_2)
     datalad_test_was_open = exists(socket_1)
     datalad_test2_was_open = exists(socket_2)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -582,7 +582,7 @@ def test_GitRepo_ssh_fetch(remote_path, repo_path):
 
     url = _path2localsshurl(remote_path)
     socket_path = op.join(str(ssh_manager.socket_dir),
-                          get_connection_hash('datalad-test', bundled=True))
+                          get_connection_hash('datalad-test'))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 
@@ -613,7 +613,7 @@ def test_GitRepo_ssh_push(repo_path, remote_path):
     remote_repo = GitRepo(remote_path, create=True)
     url = _path2localsshurl(remote_path)
     socket_path = op.join(str(ssh_manager.socket_dir),
-                          get_connection_hash('datalad-test', bundled=True))
+                          get_connection_hash('datalad-test'))
     repo = GitRepo(repo_path, create=True)
     repo.add_remote("ssh-remote", url)
 

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -104,7 +104,7 @@ def test_ssh_open_close(tmp_path, tfile1):
     socket_path = None
     if _ssh_manager_is_multiplex:
         socket_path = opj(str(manager.socket_dir),
-                   get_connection_hash('datalad-test', bundled=True))
+                   get_connection_hash('datalad-test'))
         # TODO: facilitate the test when it didn't exist
         existed_before = exists(socket_path)
 
@@ -162,9 +162,9 @@ def test_ssh_manager_close():
         manager.get_connection('ssh://datalad-test').open()
 
     ok_(exists(opj(str(manager.socket_dir),
-                   get_connection_hash('datalad-test', bundled=True))))
+                   get_connection_hash('datalad-test'))))
     ok_(exists(opj(str(manager.socket_dir),
-                   get_connection_hash('datalad-test2', bundled=True))))
+                   get_connection_hash('datalad-test2'))))
 
     manager.close()
 
@@ -266,27 +266,6 @@ def test_ssh_compound_cmds():
 
 
 @skip_if_on_windows
-@skip_nomultiplex_ssh
-def test_ssh_close_target():
-    manager = SSHManager()
-    path0 = manager.socket_dir / get_connection_hash(
-        'datalad-test', bundled=True)
-    path1 = manager.socket_dir / get_connection_hash(
-        'datalad-test', bundled=False)
-    existed0 = path0.exists()
-    existed1 = path1.exists()
-    manager.get_connection('ssh://datalad-test').open()
-    manager.get_connection('ssh://datalad-test',
-                           use_remote_annex_bundle=False).open()
-    manager.close(ctrl_path=[str(path0)])
-    # The requested path is closed.
-    eq_(existed0, path0.exists())
-    ok_(path1.exists())
-    if not existed1:
-        path1.unlink()
-
-
-@skip_if_on_windows
 @skip_ssh
 def test_ssh_custom_identity_file():
     ifile = "/tmp/dl-test-ssh-id"  # Travis
@@ -302,8 +281,7 @@ def test_ssh_custom_identity_file():
             if _ssh_manager_is_multiplex:
                 expected_socket = op.join(
                     str(manager.socket_dir),
-                    get_connection_hash("datalad-test", identity_file=ifile,
-                                        bundled=True))
+                    get_connection_hash("datalad-test", identity_file=ifile))
                 ok_(exists(expected_socket))
             manager.close()
             assert_in("-i", cml.out)


### PR DESCRIPTION
As far as I can see it, the socket provides an authenticated connection,
but no persistent shell. Any command adjustments for use of a bundled
Git are per-call, and do not anyhow impact the SSH control master
process.

The `bundled` parameter of `get_connection_hash()` is ignored from now,
but kept to not break user code. Deprecation messages have been added.

### Changelog
#### 🪓 Deprecations and removals
- The `bundled` parameter of `get_connection_hash()` is now ignored and will be removed with a future release. Fixes #6531.
