### PR TITLE
Make SSH remote annex bundle sensing configurable and off by default

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -337,6 +337,24 @@ definitions = {
         'default': not on_windows,
         'type': EnsureBool(),
     },
+    'datalad.ssh.try-use-annex-bundled-git': {
+        'ui': ('question', {
+               'title': "Whether to attempt adjusting the PATH in a remote "
+                        "shell to include Git binaries located in a detected "
+                        "git-annex bundle",
+               'text': "If enabled, this will be a 'best-effort' attempt that "
+                       "only supports remote hosts with a Bourne shell and "
+                       "the `which` command available. The remote PATH must "
+                       "already contain a git-annex installation. "
+                       "If git-annex is not found, or the detected git-annex "
+                       "does not have a bundled Git installation, detection "
+                       "failure will not result in an error, but only slow "
+                       "remote execution by one-time sensing overhead per "
+                       "each opened connection."}),
+        'destination': 'global',
+        'default': False,
+        'type': EnsureBool(),
+    },
     'datalad.annex.retry': {
         'ui': ('question',
                {'title': 'Value for annex.retry to use for git-annex calls',


### PR DESCRIPTION
Previously, this feature was enabled unconditionally for any use of
`datalad sshrun`. We use this command as `GIT_SSH_COMMAND` and also
configure it to be used by git-annex. Consequently, it is used for
pretty much any SSH-related functionality.

This change introduces a new config switch to enable/disable this
feature, and the defaults of the underlying methods have been adjusted
to honor this switch.

As can be seen below, this has the potential to increase remote
execution performance substantially (here 500ms or 20+% for a call to
`uname`. The observed cost is per each call to `sshrun`.

```
===> multitime results
1: datalad -c datalad.ssh.try-use-annex-bundled-git=true sshrun judac.fz-juelich.de uname
            Mean        Std.Dev.    Min         Median      Max
real        2.530       0.126       2.367       2.526       2.703
user        0.266       0.015       0.253       0.263       0.294
sys         0.081       0.008       0.071       0.081       0.094

===> multitime results
1: datalad -c datalad.ssh.try-use-annex-bundled-git=false sshrun judac.fz-juelich.de uname
            Mean        Std.Dev.    Min         Median      Max
real        1.899       0.024       1.869       1.905       1.932
user        0.271       0.013       0.249       0.274       0.288
sys         0.064       0.018       0.041       0.064       0.093
```

The default of this config switch is OFF (in contrast to the previous
default behavior). Rational: In general it is nohow guaranteed that

- there will be a git-annex installation on the remote end there
- a potentially existing bundled Git is "better" (could be missing
  system-provided security fixes)

Another reason is that in the case of non-multiplexed connections, even the auth-step is duplicated for sensing. See https://github.com/datalad/datalad/issues/6524#issuecomment-1064425024

### Changelog
#### 💫 Enhancements and new features
- A new configuration setting `datalad.ssh.try-use-annex-bundled-git=yes|no` can be used to influence the default remote git-annex bundle sensing for SSH connections. This was previously done unconditionally for any call to `datalad sshrun` (which is also used for any SSH-related Git or git-annex functionality triggered by DataLad-internal processing) and could incur a substantial per-call runtime cost. The new default is to not perform this sensing, because for, e.g., use as GIT_SSH_COMMAND there is no expectation to have a remote git-annex installation, and even with an existing git-annex/Git bundle on the remote, it is not certain that the bundled Git version is to be preferred over any other Git installation in a user's PATH. Fixes #6530
