### PR TITLE
UX: Better message when ORA does not find store via HTTP

### DIFF
--- a/datalad/customremotes/__init__.py
+++ b/datalad/customremotes/__init__.py
@@ -34,7 +34,7 @@ class RemoteError(_RemoteError):
             exc_cause = format_exception_with_cause(exc_cause)
         if exc_str and exc_cause:
             # with have the full picture
-            msg = f'{exc_str} caused by {exc_cause}'
+            msg = f'{exc_str} -caused by- {exc_cause}'
         elif exc_str and not exc_cause:
             # only a custom message
             msg = exc_str

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -645,7 +645,12 @@ class SSHRemoteIO(IOBase):
         try:
             out = self._run(cmd, no_output=False, check=True)
         except RemoteCommandFailedError as e:
-            raise RIARemoteError(f"Could not read {file_path}") from e
+            # Currently we don't read stderr. All we know is, we couldn't read.
+            # Try narrowing it down by calling a subsequent exists()
+            if not self.exists(file_path):
+                raise FileNotFoundError(f"{str(file_path)} not found.") from e
+            else:
+                raise RuntimeError(f"Could not read {file_path}") from e
 
         return out
 
@@ -745,18 +750,38 @@ class HTTPRemoteIO(object):
         url = self.store_url + file_path.as_posix()
         try:
             content = download_url(url)
-        except DownloadError as e:
+
+            # NOTE re Exception handling:
+            # We reraise here to:
+            #   1. Unify exceptions across IO classes
+            #   2. Get cleaner user messages. ATM what we get from the
+            #   Downloaders are exceptions, that have their cause-chain baked
+            #   into their string rather than being e proper exception chain.
+            #   Hence, we can't generically extract the ultimate cause.
+            #   RemoteError will eventually pass the entire chain string to
+            #   annex. If we add our own exception here on top, this is what is
+            #   displayed first to the user, rather than being buried deep into
+            #   a hard to parse message.
+        except AccessDeniedError as exc:
+            raise PermissionError(f"Permission denied: '{url}'") from exc
+
+        except DownloadError as exc:
             # Note: This comes from the downloader. `check_response_status`
             # in downloaders/http.py does not currently use
             # `raise_from_status`, hence we don't get a proper HTTPError to
             # check for a 404 and thereby distinguish from connection issues.
             # When this is addressed in the downloader code, we need to
             # adjust here.
-            if "not found" in str(e):
+            if "not found" in str(exc):
                 # Raise uniform exception across IO classes:
-                raise FileNotFoundError(f"{url} not found.") from e
+                raise FileNotFoundError(f"{url} not found.") from exc
             else:
-                raise
+                # Note: There's AccessFailedError(DownloadError) as well.
+                # However, we can't really tell them meaningfully apart,
+                # since possible underlying HTTPErrors, etc. are baked into
+                # their strings. Hence, "Failed to access" is what we can
+                # tell here in either case.
+                raise RuntimeError(f"Failed to access {url}") from exc
         return content
 
 
@@ -897,73 +922,13 @@ class RIARemote(SpecialRemote):
         try:
             self.remote_dataset_tree_version = \
                 self._get_version_config(dataset_tree_version_file)
-            if self.remote_dataset_tree_version not in self.known_versions_dst:
-                # Note: In later versions, condition might change in order to
-                # deal with older versions.
-                raise UnknownLayoutVersion(
-                    "RIA store layout version unknown: %s" %
-                    self.remote_dataset_tree_version)
-
-        except (RemoteError, FileNotFoundError):
-            # Exception class depends on whether self.io is local or SSH.
-            # assume file doesn't exist
-            # TODO: Is there a possibility RemoteError has a different reason
-            #       and should be handled differently?
-            #       Don't think so ATM. -> Reconsider with new execution layer.
-
-            # Note: Error message needs entire URL not just the missing
-            #       path, since it could be due to invalid URL. Path isn't
-            #       telling if it's not clear what system we are looking at.
-            # Note: Case switch due to still supported configs as an
-            #       alternative to ria+ URLs. To be deprecated.
-            if self.ria_store_url:
-                target = self.ria_store_url
-            elif self.storage_host:
-                target = "ria+ssh://{}{}".format(
-                    self.storage_host,
-                    dataset_tree_version_file.parent)
-            else:
-                target = "ria+" + dataset_tree_version_file.parent.as_uri()
-
-            if not self.io.exists(dataset_tree_version_file.parent):
-                # unify exception to FileNotFoundError
-
-                raise FileNotFoundError(
-                    "Configured RIA store not found at %s " % target
-                )
-            else:
-                # Directory is there, but no version file. We don't know what
-                # that is. Treat the same way as if there was an unknown version
-                # on record.
-                raise NoLayoutVersion(
-                    "Configured RIA store lacks a 'ria-layout-version' file at"
-                    " %s" % target
-                )
-
-        except AccessFailedError as exc:
-            # Downloader failed to access the store. Note, that the case of a
-            # 404 on the config file's URL is already handled as a
-            # FileNotFoundError (as raised by HTTPRemoteIO.read_file). Hence,
-            # if we get here there's a broader issue connecting to that
-            # store and it probably doesn't make sense to keep sending
-            # requests by treating it as a read-only store.
-
-            # RemoteError currently has `__cause__` put into its __str__
-            # unconditionally and this is what `annexremote` will put into a
-            # message to annex. Hence, cut off the ties here rather than
-            # raising "from exc" and provide a message that can be parsed by
-            # a regular user.
-            # TODO: How to deal with that needs to be reconsidered with now
-            # supported logging from within special remotes.
-            url = self.ria_store_url[4:] + dataset_tree_version_file.as_posix()
-            raise RIARemoteError(f"RIA store unavailable: Failed to access "
-                                 f"{url}")
-        except AccessDeniedError as exc:
-            # As with AccessFailedError above, reword error since message
-            # will be user-facing:
-            url = self.ria_store_url[4:] + dataset_tree_version_file.as_posix()
-            raise RIARemoteError(f"RIA store unavailable: Access denied to"
-                                 f" {url}")
+        except Exception as exc:
+            raise RIARemoteError("RIA store unavailable.") from exc
+        if self.remote_dataset_tree_version not in self.known_versions_dst:
+            # Note: In later versions, condition might change in order to
+            # deal with older versions.
+            raise UnknownLayoutVersion(f"RIA store layout version unknown: "
+                                       f"{self.remote_dataset_tree_version}")
 
     def verify_ds_in_store(self):
         """Check whether the dataset exists in store and reports a layout
@@ -981,45 +946,11 @@ class RIARemote(SpecialRemote):
         try:
             self.remote_object_tree_version =\
                 self._get_version_config(object_tree_version_file)
-            if self.remote_object_tree_version not in self.known_versions_objt:
-                raise UnknownLayoutVersion
-        except (RemoteError, FileNotFoundError) as e:
-            # Exception class depends on whether self.io is local or SSH.
-            # assume file doesn't exist
-            # TODO: Is there a possibility RemoteError has a different reason
-            #       and should be handled differently?
-            #       Don't think so ATM. -> Reconsider with new execution layer.
-            if not self.io.exists(object_tree_version_file.parent):
-                # unify exception
-                raise e
-            else:
-                raise NoLayoutVersion from e
-
-        except AccessFailedError as exc:
-            # Downloader failed to access the store. Note, that the case of a
-            # 404 on the config file's URL is already handled as a
-            # FileNotFoundError (as raised by HTTPRemoteIO.read_file). Hence,
-            # if we get here there's a broader issue connecting to that
-            # store and it probably doesn't make sense to keep sending
-            # requests by treating it as a read-only store.
-
-            # RemoteError currently has `__cause__` put into its __str__
-            # unconditionally and this is what `annexremote` will put into a
-            # message to annex. Hence, cut off the ties here rather than
-            # raising "from exc" and provide a message that can be parsed by
-            # a regular user.
-            # TODO: How to deal with that needs to be reconsidered with now
-            # supported logging from within special remotes.
-
-            url = self.ria_store_url[4:] + object_tree_version_file.as_posix()
-            raise RIARemoteError(f"Dataset unavailable from RIA store: "
-                                 f"Failed to access {url}.")
-        except AccessDeniedError as exc:
-            # As with AccessFailedError above, reword error since message
-            # will be user-facing:
-            url = self.ria_store_url[4:] + object_tree_version_file.as_posix()
-            raise RIARemoteError(f"Dataset unavailable from RIA store: "
-                                 f" Access denied to {url}.")
+        except Exception as e:
+            raise RIARemoteError("Dataset unavailable from RIA store.")
+        if self.remote_object_tree_version not in self.known_versions_objt:
+            raise UnknownLayoutVersion(f"RIA dataset layout version unknown: "
+                                       f"{self.remote_object_tree_version}")
 
     def _load_cfg(self, gitdir, name):
         # Whether or not to force writing to the remote. Currently used to
@@ -1125,7 +1056,27 @@ class RIARemote(SpecialRemote):
         """ Get version and config flags from remote file
         """
 
-        file_content = self.io.read_file(path).strip().split('|')
+        if self.ria_store_url:
+            target_ri = self.ria_store_url[4:] + path.as_posix()
+        elif self.storage_host:
+            target_ri = "ssh://{}{}".format(self.storage_host, path.as_posix())
+        else:
+            target_ri = path.as_uri()
+
+        try:
+            file_content = self.io.read_file(path).strip().split('|')
+
+        # Note, that we enhance the reporting here, as the IO classes don't
+        # uniformly operate on that kind of RI (which is more informative
+        # as it includes the store base address including the access
+        # method).
+        except FileNotFoundError as exc:
+            raise NoLayoutVersion(f"{target_ri} not found.") from exc
+        except PermissionError as exc:
+            raise PermissionError(f"Permission denied: {target_ri}") from exc
+        except Exception as exc:
+            raise RuntimeError(f"Failed to access {target_ri}") from exc
+
         if not (1 <= len(file_content) <= 2):
             self.message("invalid version file {}".format(path),
                          type='info')


### PR DESCRIPTION
@mih reported on the following current behavior:

> This is what it was -- not pretty, but this is 0.15
> ```
> % datalad clone https://github.com/psychoinformatics-de/studyforrest-data-phase2.git httpclone0.15
> [INFO   ] scanning for annexed files (this may take some time)                                                                                                                             
> [INFO   ] Remote origin not usable by git-annex; setting annex-ignore                                                                                                                      
> [INFO   ] https://github.com/psychoinformatics-de/studyforrest-data-phase2.git/config download failed: Not Found 
> [INFO   ] [INFO] Fetching 'http://studyforrest.ds.inm7.de/ria-layout-version' 
> [INFO   ] Failed to establish a new session 1 times. 
> install(ok): /tmp/httpclone0.15 (dataset)
> ```

> and now it is even more verbose, failing to download, failing to establish a session, but then being OK nevertheless
> ```
> % datalad clone https://github.com/psychoinformatics-de/studyforrest-data-phase2.git httpclone
> [INFO   ] scanning for annexed files (this may take some time)                                                                                                                             
> [INFO   ] Remote origin not usable by git-annex; setting annex-ignore                                                                                                                      
> [INFO   ] https://github.com/psychoinformatics-de/studyforrest-data-phase2.git/config download failed: Not Found 
> [INFO   ] [INFO] Fetching 'http://studyforrest.ds.inm7.de/ria-layout-version' 
> [INFO   ] Failed to establish a new session 1 times.  -caused by- HTTPConnectionPool(host='studyforrest.ds.inm7.de', port=80): Max retries exceeded with url: /ria-layout-version (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7efc22bb5880>: Failed to establish a new connection: [Errno -2] Name or service not known')) 
> install(ok): /tmp/httpclone (dataset)
> ```


This let's ORA account for HTTP failures during initremote/enableremote and report an invalid store (and its URL).
With support for `annexremote`'s logging framework we'll have other means for detailed messaging soon.

Please note, that the fact we get an `ok` result is not ORA's fault. It's `git annex init` that actually succeeds (zero-exit), while ORA now correctly reports `INITREMOTE-FAILURE Invalid store at ria+http://studyforrest.ds.inm7.de`:

<details>
  <summary> `git clone` + `git annex --debug init`</summary>

```
❱ git clone https://github.com/psychoinformatics-de/studyforrest-data-phase2.git httpclone0.162
Cloning into 'httpclone0.162'...
remote: Enumerating objects: 54786, done.
remote: Counting objects: 100% (7945/7945), done.
remote: Compressing objects: 100% (6769/6769), done.
remote: Total 54786 (delta 191), reused 7600 (delta 177), pack-reused 46841
Receiving objects: 100% (54786/54786), 5.00 MiB | 2.05 MiB/s, done.
Resolving deltas: 100% (4313/4313), done.
(datalad-core-dev) ben@tree in /tmp
❱ cd httpclone0.162
(datalad-core-dev) ben@tree in /tmp/httpclone0.162 on git:master
❱ git annex --debug init
init  [2022-03-10 17:29:00.489432914] (Utility.Process) process [37799] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","--hash","refs/heads/git-annex"]
[2022-03-10 17:29:00.493406347] (Utility.Process) process [37799] done ExitFailure 1
[2022-03-10 17:29:00.494390089] (Utility.Process) process [37800] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","--verify","-q","refs/remotes/origin/git-annex"]
[2022-03-10 17:29:00.498298774] (Utility.Process) process [37800] done ExitSuccess
[2022-03-10 17:29:00.499345349] (Utility.Process) process [37801] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","branch","--no-track","git-annex","refs/remotes/origin/git-annex"]
[2022-03-10 17:29:00.504030974] (Utility.Process) process [37801] done ExitSuccess
[2022-03-10 17:29:00.505082636] (Utility.Process) process [37802] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","--hash","refs/heads/git-annex"]
[2022-03-10 17:29:00.509112137] (Utility.Process) process [37802] done ExitSuccess
[2022-03-10 17:29:00.511281667] (Utility.Process) process [37803] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","config","annex.uuid","9d6288da-33a0-405c-b753-23b352c6b070"]
[2022-03-10 17:29:00.515971936] (Utility.Process) process [37803] done ExitSuccess
[2022-03-10 17:29:00.517537884] (Utility.Process) process [37804] read: git ["config","--null","--list"]
[2022-03-10 17:29:00.521343702] (Utility.Process) process [37804] done ExitSuccess
[2022-03-10 17:29:00.526302903] (Utility.Process) process [37805] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","git-annex"]
[2022-03-10 17:29:00.531911791] (Utility.Process) process [37805] done ExitSuccess
[2022-03-10 17:29:00.532977264] (Utility.Process) process [37806] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","--hash","refs/heads/git-annex"]
[2022-03-10 17:29:00.535839026] (Utility.Process) process [37806] done ExitSuccess
[2022-03-10 17:29:00.536672047] (Utility.Process) process [37807] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","log","refs/heads/git-annex..7ff5eafaad121f0abb0e1d12bee999f40be6da8e","--pretty=%H","-n1"]
[2022-03-10 17:29:00.539457162] (Utility.Process) process [37807] done ExitSuccess
[2022-03-10 17:29:00.549149919] (Utility.Process) process [37808] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","--hash","refs/heads/git-annex"]
[2022-03-10 17:29:00.550645726] (Utility.Process) process [37808] done ExitSuccess
[2022-03-10 17:29:00.551187404] (Utility.Process) process [37809] feed: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","update-index","-z","--index-info"]
[2022-03-10 17:29:00.551590321] (Utility.Process) process [37810] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","ls-tree","-z","-r","--full-tree","refs/heads/git-annex"]
[2022-03-10 17:29:00.566835977] (Utility.Process) process [37810] done ExitSuccess
[2022-03-10 17:29:00.570494737] (Utility.Process) process [37809] done ExitSuccess
[2022-03-10 17:29:00.57109641] (Utility.Process) process [37811] chat: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","cat-file","--batch"]
[2022-03-10 17:29:00.573069818] (Utility.Process) process [37812] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","config","annex.version","8"]
[2022-03-10 17:29:00.574504495] (Utility.Process) process [37812] done ExitSuccess
[2022-03-10 17:29:00.574963083] (Utility.Process) process [37813] read: git ["config","--null","--list"]
[2022-03-10 17:29:00.576102547] (Utility.Process) process [37813] done ExitSuccess
[2022-03-10 17:29:00.576491401] (Utility.Process) process [37814] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","status","--porcelain"]
[2022-03-10 17:29:00.603273269] (Utility.Process) process [37814] done ExitSuccess
[2022-03-10 17:29:00.603610109] (Utility.Process) process [37819] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","config","filter.annex.smudge","git-annex smudge -- %f"]
[2022-03-10 17:29:00.604544673] (Utility.Process) process [37819] done ExitSuccess
[2022-03-10 17:29:00.604855256] (Utility.Process) process [37820] read: git ["config","--null","--list"]
[2022-03-10 17:29:00.605643935] (Utility.Process) process [37820] done ExitSuccess
[2022-03-10 17:29:00.605921902] (Utility.Process) process [37821] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","config","filter.annex.clean","git-annex smudge --clean -- %f"]
[2022-03-10 17:29:00.606821445] (Utility.Process) process [37821] done ExitSuccess
[2022-03-10 17:29:00.606969428] (Utility.Process) process [37822] read: git ["config","--null","--list"]
[2022-03-10 17:29:00.607748951] (Utility.Process) process [37822] done ExitSuccess
[2022-03-10 17:29:00.615478554] (Utility.Process) process [37824] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","-c","filter.annex.smudge=","-c","filter.annex.clean=","-c","filter.annex.process=","write-tree"]
[2022-03-10 17:29:00.617062774] (Utility.Process) process [37824] done ExitSuccess
[2022-03-10 17:29:00.617374827] (Utility.Process) process [37825] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","--hash","refs/annex/last-index"]
[2022-03-10 17:29:00.618255919] (Utility.Process) process [37825] done ExitFailure 1
[2022-03-10 17:29:00.618293711] (Database.Keys) reconcileStaged start
[2022-03-10 17:29:00.618616354] (Utility.Process) process [37826] chat: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","cat-file","--batch-check=%(objectname) %(objecttype) %(objectsize)","--buffer"]
[2022-03-10 17:29:00.618841825] (Utility.Process) process [37827] chat: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","cat-file","--batch=%(objectname) %(objecttype) %(objectsize)","--buffer"]
[2022-03-10 17:29:00.619057717] (Utility.Process) process [37828] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","-c","filter.annex.smudge=","-c","filter.annex.clean=","-c","filter.annex.process=","-c","diff.external=","diff","4b825dc642cb6eb9a060e54bf8d69288fbee4904","3d0f4b475f3a0369f2a7cf0cf05c3d371da7c907","--raw","-z","--no-abbrev","-G/annex/objects/","--no-renames","--ignore-submodules=all","--no-ext-diff"]
[2022-03-10 17:29:00.647158018] (Utility.Process) process [37828] done ExitSuccess
(scanning for annexed files...)
[2022-03-10 17:29:00.848507909] (Utility.Process) process [37827] done ExitSuccess
[2022-03-10 17:29:00.848607397] (Utility.Process) process [37826] done ExitSuccess
[2022-03-10 17:29:00.849096028] (Utility.Process) process [37829] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","update-ref","refs/annex/last-index","3d0f4b475f3a0369f2a7cf0cf05c3d371da7c907"]
[2022-03-10 17:29:00.850252806] (Utility.Process) process [37829] done ExitSuccess
[2022-03-10 17:29:00.850288442] (Database.Keys) reconcileStaged end
[2022-03-10 17:29:00.850680954] (Utility.Process) process [37830] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","symbolic-ref","-q","HEAD"]
[2022-03-10 17:29:00.851465456] (Utility.Process) process [37830] done ExitSuccess
[2022-03-10 17:29:00.851821325] (Utility.Process) process [37831] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","refs/heads/master"]
[2022-03-10 17:29:00.852756416] (Utility.Process) process [37831] done ExitSuccess
[2022-03-10 17:29:00.85300547] (Utility.Process) process [37832] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","symbolic-ref","-q","HEAD"]
[2022-03-10 17:29:00.853874262] (Utility.Process) process [37832] done ExitSuccess
[2022-03-10 17:29:00.854192045] (Utility.Process) process [37833] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","--hash","refs/heads/master"]
[2022-03-10 17:29:00.855108305] (Utility.Process) process [37833] done ExitSuccess
[2022-03-10 17:29:00.856565785] (Utility.Process) process [37834] read: uname ["-n"]
[2022-03-10 17:29:00.856890913] (Utility.Process) process [37834] done ExitSuccess
[2022-03-10 17:29:00.857024361] (Annex.Branch) read uuid.log
[2022-03-10 17:29:00.857846891] (Annex.Branch) set uuid.log
[2022-03-10 17:29:00.857899122] (Annex.Branch) read remote.log
[2022-03-10 17:29:00.866725528] (Utility.Url) Request {
  host                 = "github.com"
  port                 = 443
  secure               = True
  requestHeaders       = [("Accept-Encoding","identity"),("User-Agent","git-annex/8.20211123")]
  path                 = "/psychoinformatics-de/studyforrest-data-phase2.git/config"
  queryString          = ""
  method               = "GET"
  proxy                = Nothing
  rawBody              = False
  redirectCount        = 10
  responseTimeout      = ResponseTimeoutDefault
  requestVersion       = HTTP/1.1
}


  Remote origin not usable by git-annex; setting annex-ignore
[2022-03-10 17:29:01.216567177] (Utility.Process) process [37835] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","config","remote.origin.annex-ignore","true"]
[2022-03-10 17:29:01.220896165] (Utility.Process) process [37835] done ExitSuccess
[2022-03-10 17:29:01.221789229] (Utility.Process) process [37836] read: git ["config","--null","--list"]
[2022-03-10 17:29:01.224924817] (Utility.Process) process [37836] done ExitSuccess

  https://github.com/psychoinformatics-de/studyforrest-data-phase2.git/config download failed: Not Found
[2022-03-10 17:29:01.225717781] (Annex.Branch) read trust.log
(Auto enabling special remote inm7-storage...)
[2022-03-10 17:29:01.230686423] (Utility.Process) process [37837] chat: /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora []
[2022-03-10 17:29:01.423465672] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> VERSION 1
[2022-03-10 17:29:01.423558387] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- EXTENSIONS INFO GETGITREMOTENAME ASYNC
[2022-03-10 17:29:01.423716679] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> EXTENSIONS
[2022-03-10 17:29:01.423748627] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- EXPORTSUPPORTED
[2022-03-10 17:29:01.423878052] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> EXPORTSUPPORTED-FAILURE
[2022-03-10 17:29:01.424240744] (Utility.Process) process [37856] chat: /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora []
[2022-03-10 17:29:01.591349978] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> VERSION 1
[2022-03-10 17:29:01.591449988] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- EXTENSIONS INFO GETGITREMOTENAME ASYNC
[2022-03-10 17:29:01.59159535] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> EXTENSIONS
[2022-03-10 17:29:01.591638169] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- LISTCONFIGS
[2022-03-10 17:29:01.591866055] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> CONFIG archive-id Dataset ID. Should be set automatically by datalad
[2022-03-10 17:29:01.591925873] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> CONFIG push-url URL for pushing to the RIA store. Optional.
[2022-03-10 17:29:01.592063811] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> CONFIG url RIA store to use
[2022-03-10 17:29:01.59211857] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> CONFIGEND
[2022-03-10 17:29:01.592194611] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- INITREMOTE
[2022-03-10 17:29:01.592341586] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> GETGITDIR
[2022-03-10 17:29:01.592400791] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- VALUE .git
[2022-03-10 17:29:01.620611209] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> GETCONFIG name
[2022-03-10 17:29:01.620739544] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- VALUE inm7-storage
[2022-03-10 17:29:01.620884218] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> GETCONFIG url
[2022-03-10 17:29:01.620951318] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- VALUE ria+http://studyforrest.ds.inm7.de
[2022-03-10 17:29:01.621118888] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> GETCONFIG push-url
[2022-03-10 17:29:01.621182383] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- VALUE ria+ssh://bulk1.htc.inm7.de/ds/studyforrest/srv
[2022-03-10 17:29:01.621695002] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> GETCONFIG archive-id
[2022-03-10 17:29:01.621754888] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- VALUE 5eaff716-54eb-11e8-803d-a0369f7c647e
[2022-03-10 17:29:01.621855758] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> GETCONFIG force-write
[2022-03-10 17:29:01.621912012] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] <-- VALUE 
[INFO] Fetching 'http://studyforrest.ds.inm7.de/ria-layout-version' 
[2022-03-10 17:29:01.678509094] (Annex.ExternalAddonProcess) /home/ben/venvs/datalad-core-dev/bin/git-annex-remote-ora[1] --> INITREMOTE-FAILURE Invalid store at ria+http://studyforrest.ds.inm7.de

  Invalid store at ria+http://studyforrest.ds.inm7.de
(Auto enabling special remote mddatasrc...)
[2022-03-10 17:29:01.683094365] (Utility.Process) process [37898] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","remote","add","mddatasrc","http://psydata.ovgu.de/studyforrest/phase2/.git"]
[2022-03-10 17:29:01.693890189] (Utility.Process) process [37898] done ExitSuccess
ok
[2022-03-10 17:29:01.694650893] (Utility.Process) process [37899] chat: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","hash-object","-w","--stdin-paths","--no-filters"]
[2022-03-10 17:29:01.695079283] (Utility.Process) process [37900] feed: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","update-index","-z","--index-info"]
[2022-03-10 17:29:01.699625725] (Utility.Process) process [37900] done ExitSuccess
[2022-03-10 17:29:01.699977964] (Utility.Process) process [37901] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","show-ref","--hash","refs/heads/git-annex"]
[2022-03-10 17:29:01.701146888] (Utility.Process) process [37901] done ExitSuccess
(recording state in git...)
[2022-03-10 17:29:01.701545396] (Utility.Process) process [37902] read: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","write-tree"]
[2022-03-10 17:29:01.727341916] (Utility.Process) process [37902] done ExitSuccess
[2022-03-10 17:29:01.727890169] (Utility.Process) process [37903] chat: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","commit-tree","65ca5c50dabe1c3780324db639fb2faa9a4e6571","--no-gpg-sign","-p","refs/heads/git-annex"]
[2022-03-10 17:29:01.72929311] (Utility.Process) process [37903] done ExitSuccess
[2022-03-10 17:29:01.729748125] (Utility.Process) process [37904] call: git ["--git-dir=.git","--work-tree=.","--literal-pathspecs","-c","annex.debug=true","update-ref","refs/heads/git-annex","b6416923520ae31f5bebf640baa981c47e16f62f"]
[2022-03-10 17:29:01.730915073] (Utility.Process) process [37904] done ExitSuccess
[2022-03-10 17:29:01.731647167] (Utility.Process) process [37811] done ExitSuccess
[2022-03-10 17:29:01.731941703] (Utility.Process) process [37899] done ExitSuccess
```
</details>

Overall the above call would now look like this:

```
❱ datalad clone https://github.com/psychoinformatics-de/studyforrest-data-phase2.git httpclone0.16
[INFO   ] scanning for annexed files (this may take some time)                                                                                                                                                                                                                  
[INFO   ] Remote origin not usable by git-annex; setting annex-ignore                                                                                                                                                                                                           
[INFO   ] https://github.com/psychoinformatics-de/studyforrest-data-phase2.git/config download failed: Not Found 
[INFO   ] [INFO] Fetching 'http://studyforrest.ds.inm7.de/ria-layout-version' 
[INFO   ] Invalid store at ria+http://studyforrest.ds.inm7.de 
install(ok): /tmp/httpclone0.16 (dataset)
```




### Changelog
#### 🐛 Bug Fixes
- Fix ORA special remote not properly reporting on HTTP failures.
