### PR TITLE
Stop forcefully disabling keyboard-interactive SSH auth

### DIFF
--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -347,27 +347,6 @@ class NoMultiplexSSHConnection(BaseSSHConnection):
     The connection is opened for execution of a single process, and closed
     as soon as the process end.
     """
-    def __init__(self, sshri, **kwargs):
-        """Create a connection handler
-
-        The actual opening of the connection is performed on-demand.
-
-        Parameters
-        ----------
-        sshri: SSHRI
-          SSH resource identifier (contains all connection-relevant info),
-          or another resource identifier that can be converted into an SSHRI.
-        **kwargs
-          Pass on to BaseSSHConnection
-        """
-        super().__init__(sshri, **kwargs)
-        self._ssh_open_args += [
-            # we presently do not support any interactive authentication
-            # at the time of process execution
-            '-o', 'PasswordAuthentication=no',
-            '-o', 'KbdInteractiveAuthentication=no',
-        ]
-
     def __call__(self, cmd, options=None, stdin=None, log_output=True):
         """Executes a command on the remote.
 


### PR DESCRIPTION
We did this initially for non-multiplex connections, assuming that it
would not work "by-design" when the SSH process is controlled by a
process that is not directly connected to a terminal on windows.

However, explorations documented in https://github.com/datalad/datalad/issues/5829
and https://github.com/datalad/datalad/issues/6524 revealed that this is
wrong, and the reason for it appearing to not work is in the protocol
handling within `Runner`.

This patch merely removed the forceful disabling, and thereby
immediately makes `sshrun` functional on windows.


### Changelog
#### 🐛 Bug Fixes
- Keyboard-interactive authentication is now possibly with non-multiplexed SSH connections (i.e., when no connection sharing is possible, due to lack of socket support, for example on Windows). Previously, it was disabled forcefully by DataLad for no valid reason.
