### PR TITLE
BF(TST): Skip 3 tests if root --  PermissionError not raised

### DIFF
--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -47,6 +47,7 @@ from datalad.tests.utils import (
     serve_path_via_http,
     skip_if_adjusted_branch,
     skip_if_no_network,
+    skip_if_root,
     skip_ssh,
     skip_wo_symlink_capability,
     slow,
@@ -788,4 +789,4 @@ def _test_permission(host, storepath, dspath):
 
 def test_obtain_permission():
     yield skip_ssh(_test_permission), 'datalad-test'
-    yield _test_permission, None
+    yield skip_if_root(_test_permission), None

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -118,6 +118,7 @@ from .utils import (
     skip_if,
     skip_if_no_module,
     skip_if_on_windows,
+    skip_if_root,
     skip_known_failure,
     SkipTest,
     skip_wo_symlink_capability,
@@ -1348,6 +1349,7 @@ def test_splitjoin_cmdline():
         eq_(join_cmdline(['abc', 'def']), 'abc def')
 
 
+@skip_if_root
 @with_tempfile
 def test_obtain_write_permission(path):
     path = Path(path)
@@ -1369,6 +1371,7 @@ def test_obtain_write_permission(path):
     path.write_text("yet another thing")
 
 
+@skip_if_root
 @with_tempfile(mkdir=True)
 def test_ensure_write_permission(path):
 


### PR DESCRIPTION
failures were observed in the sudo run on cron on travis,
https://app.travis-ci.com/github/datalad/datalad/jobs/563044936

	======================================================================
	FAIL: datalad.distributed.tests.test_ria_basics.test_obtain_permission(None,)
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/nose/case.py", line 198, in runTest
		self.test(*self.arg)
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/datalad/tests/utils.py", line 2016, in _wrap_skip_if_adjusted_branch
		return func(*args, **kwargs)
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/datalad/tests/utils.py", line 874, in _wrap_with_tempfile
		return t(*(arg + (filename,)), **kw)
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/datalad/tests/utils.py", line 874, in _wrap_with_tempfile
		return t(*(arg + (filename,)), **kw)
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/datalad/distributed/tests/test_ria_basics.py", line 779, in _test_permission
		assert_raises(PermissionError, file_key_in_store.unlink)
	AssertionError: PermissionError not raised by unlink
	======================================================================
	FAIL: datalad.tests.test_utils.test_ensure_write_permission
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/nose/case.py", line 198, in runTest
		self.test(*self.arg)
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/datalad/tests/utils.py", line 874, in _wrap_with_tempfile
		return t(*(arg + (filename,)), **kw)
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/datalad/tests/test_utils.py", line 1388, in test_ensure_write_permission
		assert_raises(PermissionError, file_.unlink)
	AssertionError: PermissionError not raised by unlink
	======================================================================
	FAIL: datalad.tests.test_utils.test_obtain_write_permission
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/nose/case.py", line 198, in runTest
		self.test(*self.arg)
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/datalad/tests/utils.py", line 874, in _wrap_with_tempfile
		return t(*(arg + (filename,)), **kw)
	  File "/tmp/dl-miniconda-yilg0v_t/lib/python3.9/site-packages/datalad/tests/test_utils.py", line 1361, in test_obtain_write_permission
		assert_raises(PermissionError, path.write_text, "different thing")
	AssertionError: PermissionError not raised by write_text
### Changelog


not needed I believe since for changes in master