### PR TITLE
UX: Make export-to-figshare yield an impossible result instead of a RunTimeError in dirty ds

### DIFF
--- a/datalad/distributed/export_to_figshare.py
+++ b/datalad/distributed/export_to_figshare.py
@@ -13,6 +13,7 @@ __docformat__ = 'restructuredtext'
 from datalad.utils import unlink
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
 
 import logging
 lgr = logging.getLogger('datalad.distributed.export_to_figshare')
@@ -274,9 +275,14 @@ class ExportToFigshare(Interface):
             )
 
         if dataset.repo.dirty:
-            raise RuntimeError(
-                "Paranoid authors of DataLad refuse to proceed in a dirty repository"
-            )
+            yield get_status_dict(
+                'export_to_figshare',
+                ds=dataset,
+                status='impossible',
+                message=(
+                    'clean dataset required to export; '
+                    'use `datalad status` to inspect unsaved changes'))
+            return
         if filename is None:
             filename = dataset.path
         lgr.info(


### PR DESCRIPTION
This aims at standardizing result reporting/behavior over operations that
refuse to operate in dirty datasets. export-to-figshare does it similarly
to run now, and yields an impossible result. Fixes #6474.

Before:
```
datalad export-to-figshare
[ERROR  ] RuntimeError(Paranoid authors of DataLad refuse to proceed in a dirty repository) (RuntimeError)
```
Now:
```
datalad export-to-figshare
export_to_figshare(impossible): /tmp/super (dataset) [clean dataset required to export; use `datalad status` to inspect unsaved changes]
```


### Changelog
#### 💫 Enhancements and new features
- When operating in a dirty dataset, `export-to-figshare` now yields and impossible result instead of raising a RunTimeError
