### PR TITLE
Enable coverage for subprocesses

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -343,10 +343,11 @@ test_script:
   - cd __testhome__
     # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
   - cmd: python -W error::DeprecationWarning:^datalad -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad %DTS%
-  - sh:  python -W error::DeprecationWarning:^datalad -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad ${DTS}
+  - sh: PATH=$PWD/../tools/coverage-bin:$PATH python -W error::DeprecationWarning:^datalad -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad ${DTS}
 
 
 after_test:
+  - sh: python -m coverage combine -a /tmp/.coverage-entrypoints-*;
   - python -m coverage xml
   - cmd: curl -fsSL -o codecov.exe "https://uploader.codecov.io/latest/windows/codecov.exe"
   - cmd: .\codecov.exe -f "coverage.xml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -233,8 +233,8 @@ install:
 script:
   # Now it should be safe to point TMPDIR to a "tricky" setup just for the purpose of testing
   - if [ -n "${_DL_TMPDIR:-}" ]; then export TMPDIR="${_DL_TMPDIR}"; fi
-  # Test installation system-wide
-  - sudo pip install .
+  # Test installation for user
+  - sudo pip install --user .
   # Report WTF information using system wide installed version
   - datalad wtf
   - mkdir -p __testhome__

--- a/tools/coverage-bin/datalad
+++ b/tools/coverage-bin/datalad
@@ -11,7 +11,8 @@ curdatalad=$(which datalad)
 curdir=$(dirname $curdatalad)
 
 COVERAGE_RUN="-m coverage run"
-
+export COVERAGE_PROCESS_START=$PWD/../.coveragerc
+export PYTHONPATH="$PWD/../tools/coverage-bin/"
 export PATH=${PATH//$curdir:/}
 newdatalad=$(which datalad)
 newbin=$(which $bin)

--- a/tools/coverage-bin/sitecustomize.py
+++ b/tools/coverage-bin/sitecustomize.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+import coverage
+coverage.process_startup()


### PR DESCRIPTION
The changes here enable subprocess coverage and fix #6367. They follow different docs:
- Following https://coverage.readthedocs.io/en/latest/subprocess.html, this change sets the ``COVERAGE_PROCESS_START`` environment variable, and lets it point to the ``.coveragerc`` file.
- Following the first approach described in https://coverage.readthedocs.io/en/latest/subprocess.html, this change creates a ``sitecustomize.py`` file. As this file needs to be in the Pythonpath, I'm following https://pymotw.com/2/site/#sitecustomize to modify the ``PYTHONPATH`` accordingly
- Finally, this change changes the installation of DataLad from a system-wide installation to a local (user) installation. This is a workaround, because with a system-wide installation coverage refused to collect any coverage for datalad or other packages in ``site-packages`` as it reported them to be "in the stdlib" (see details below). We should discuss if this is a problem - was there any reason that the installation is done system-wide? Is there any problem doing it only per user (``pip install . --user``)?

<details>

```
........S...................sys.path:
    /home/travis/build/datalad/datalad/__testhome__
    /home/travis/build/datalad/datalad/__testhome__/tools/coverage-bin/sitecustomize.py
    /tmp/dl-miniconda-lwdfcfx3/lib/python39.zip
    /tmp/dl-miniconda-lwdfcfx3/lib/python3.9
    /tmp/dl-miniconda-lwdfcfx3/lib/python3.9/lib-dynload
    /tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages
Python stdlib matching: <TreeMatcher pylib ['/tmp/dl-miniconda-lwdfcfx3/lib/python3.9']>
Coverage code matching: <TreeMatcher coverage ['/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/coverage']>
Third-party lib matching: <TreeMatcher third ['/home/travis/.local/bin', '/home/travis/.local/lib/python3.9/site-packages', '/tmp/dl-miniconda-lwdfcfx3/bin', '/tmp/dl-miniconda-lwdfcfx3/lib/python', '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages']>
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/threading.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/coverage/execfile.py': is part of coverage.py
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/genericpath.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/coverage/files.py': is part of coverage.py
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/posixpath.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/coverage/python.py': is part of coverage.py
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/coverage/phystokens.py': is part of coverage.py
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/tokenize.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/bin/datalad': is a third-party module
Not tracing '<frozen importlib._bootstrap>': not a real original file name
Not tracing '<frozen importlib._bootstrap_external>': not a real original file name
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/_collections_abc.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/os.py': is in the stdlib
Not tracing '<frozen zipimport>': not a real original file name
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/config.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/logging/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/string.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/re.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/enum.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/types.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/sre_compile.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/sre_parse.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/_weakrefset.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/weakref.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/fasteners/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/__future__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/fasteners/lock.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/fasteners/_utils.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/contextlib.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/functools.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/fasteners/process_lock.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/fasteners/version.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/pathlib.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/urllib/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/urllib/parse.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/collections/__init__.py': is in the stdlib
Not tracing '<string>': not a real original file name
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/abc.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/consts.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/runner/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/runner/coreprotocols.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/runner/protocol.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/base_events.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/concurrent/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/concurrent/futures/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/concurrent/futures/_base.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/ssl.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/constants.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/coroutines.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/base_futures.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/format_helpers.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/log.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/events.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/contextvars.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/exceptions.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/base_tasks.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/futures.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/protocols.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/sslproto.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/transports.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/staggered.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/locks.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/tasks.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/typing.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/trsock.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/runners.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/queues.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/streams.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/subprocess.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/threads.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/unix_events.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/base_subprocess.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/asyncio/selector_events.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/utils.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/tempfile.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/gzip.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/support/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/support/exceptions.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/runner/exception.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/platform.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/runner/gitrunner.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/dochelpers.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/runner/runner.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/runner/nonasyncrunner.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/queue.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/runner/runnerthreads.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/shutil.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/subprocess.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/warnings.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/log.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/logging/handlers.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/support/ansi_colors.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/ui/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/ui/dialog.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/getpass.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/ui/base.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/interface/__init__.py': is in the stdlib
Not tracing '/tmp/dl-miniconda-lwdfcfx3/lib/python3.9/site-packages/datalad/interface/common_cfg.py': is in the stdlib
[...]
```
</details>


I have tested whether this works and what an impact it would make by running only ``datalad.distributed`` tests, which include the ``ora_remote.py`` that was covered to only 33.9%:

![Pre-subprocess-coverage state](https://user-images.githubusercontent.com/29738718/158353569-cef9dcd6-1ee6-4b51-8d7e-dca9828d8ece.png)


With the changes in this PR, coverage of ``ora_remote.py`` seems to be bumped by +46% to 80% coverage:
![Screenshot from 2022-03-15 11-02-48](https://user-images.githubusercontent.com/29738718/158353944-9432e247-dbbd-4b3d-a264-bb7c05540c45.png)
