### PR TITLE
Fixing test failures with recent annex

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -643,6 +643,8 @@ def test_partial_unlocked(path):
     ds.save()
     assert_repo_status(ds.path)
     # but now a change in the attributes
+    if '10.20220127' <= ds.repo.git_annex_version < '10.20220322':
+        raise SkipTest("annex bug https://git-annex.branchable.com/bugs/Change_to_annex.largefiles_leaves_repo_modified/")
     ds.unlock('culprit.txt')
     ds.repo.set_gitattributes([
         ('*', {'annex.largefiles': 'nothing'})])

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -302,13 +302,20 @@ def test_status_symlinked_dir_within_repo(path):
     if ds.repo.git_annex_version < "8.20200522" or on_windows:
         # TODO: on windows even with a recent annex -- no CommandError is raised, TODO
         assert_result_count(call(), 0)
-    else:
+
+    elif ds.repo.git_annex_version < '10.20220127' or (
+            ds.repo.git_annex_version > '10.20220322' and not ds.config.getbool(
+                    section="annex", option="skipunknown", default=False)):
         # As of 2a8fdfc7d (Display a warning message when asked to operate on a
         # file inside a symlinked directory, 2020-05-11), git-annex will error.
-        #
-        # TODO: Consider providing better error handling in this case.
+        # However, there's an annex bug for a brief period, where it exits
+        # zero. Later on, it depends on how the reporting by annex looks like
+        # whether or not we fail or ignore that error. This in turn depends
+        # on the config queried in the condition.
         with assert_raises(CommandError):
             call()
+    else:
+        assert_result_count(call(), 0)
 
 
 @with_tempfile

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -300,22 +300,27 @@ def test_status_symlinked_dir_within_repo(path):
                          on_failure="ignore", result_renderer='disabled')
 
     if ds.repo.git_annex_version < "8.20200522" or on_windows:
-        # TODO: on windows even with a recent annex -- no CommandError is raised, TODO
+        # TODO: on windows even with a recent annex -- no CommandError is
+        # raised, TODO
         assert_result_count(call(), 0)
-
-    elif ds.repo.git_annex_version < '10.20220127' or (
-            ds.repo.git_annex_version > '10.20220322' and not ds.config.getbool(
-                    section="annex", option="skipunknown", default=False)):
+    elif ds.repo.git_annex_version < '10.20220127':
         # As of 2a8fdfc7d (Display a warning message when asked to operate on a
         # file inside a symlinked directory, 2020-05-11), git-annex will error.
-        # However, there's an annex bug for a brief period, where it exits
-        # zero. Later on, it depends on how the reporting by annex looks like
-        # whether or not we fail or ignore that error. This in turn depends
-        # on the config queried in the condition.
         with assert_raises(CommandError):
             call()
-    else:
+    elif '10.20220127' <= ds.repo.git_annex_version < '10.20220322':
+        # No error on annex' side since 10.20220127;
+        # However, we'd now get something like this:
+        # > git annex find bar/f
+        # error: pathspec 'bar/f' did not match any file(s) known to git
+        # Did you forget to 'git add'?
+        #
+        # But exists zero until 10.20220322!
         assert_result_count(call(), 0)
+    else:
+        res = call()
+        assert_result_count(res, 1, status='error', state='unknown',
+                            path=str(bar_f))
 
 
 @with_tempfile

--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -793,7 +793,7 @@ def _postproc_annexdrop_result(res, respath_by_status, ds, **kwargs):
     respath_by_status[success] = \
         respath_by_status.get(success, []) + [res['path']]
     if res["status"] == "error" and res["action"] == "drop":
-        msg = res["message"]
+        msg = res.get("message", None)
         if isinstance(msg, str) and "Use --force to" in msg:
             # Avoid confusing datalad-drop callers with git-annex-drop's
             # suggestion to use --force.

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -77,7 +77,7 @@ def test_drop_file_content(path, outside_path):
             type='file',
             status='error',
             action='drop',
-            message='not found',
+            error_message='File unknown to git',
             path=str(ds.pathobj / rp),
             refds=ds.path,
         )

--- a/datalad/support/annex_utils.py
+++ b/datalad/support/annex_utils.py
@@ -1,0 +1,67 @@
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Internal helper functions for interfacing git-annex
+"""
+
+from datalad.utils import ensure_list
+
+
+def _fake_json_for_non_existing(paths, cmd):
+    """Create faked JSON records for nonexisting paths provided by `paths`
+    after running `cmd`.
+
+    Internal helper for `AnnexRepo._call_annex_records`.
+
+    Parameters:
+    -----------
+    paths: str or list of str
+        paths to create annex-like JSON records for, communicating that the
+        path is unknown.
+    cmd: str
+        annex cmd for which to fake this result
+    """
+
+    return [{"command": cmd,
+             "file": f,
+             "note": "not found",
+             "success": False,
+             "error-messages": ["File unknown to git"]  # Note,
+             # that git's and annex' reporting here differs by config and
+             # command on whether they say "does not exist" or "did not match
+             # any file known to git".
+             } for f in ensure_list(paths)]
+
+
+def _get_non_existing_from_annex_output(output):
+    """This parses annex' output for messages about non-existing paths
+    and returns a list of such paths (as strings).
+
+    Internal helper for `_call_annex_records`.
+    """
+
+    # This should cease to exist whenever annex provides an actual API
+    # for retrieving such information;
+    # see https://git-annex.brachable.com/todo/api_for_telling_when_nonexistant_or_non_git_files_passed/
+
+    # Output largely depends on annex config annex.skipunknown
+    # (see https://github.com/datalad/datalad/pull/6510#issuecomment-1054499339)
+    # and git-annex' default of annex.skipunknown changed as of 10.20220127.
+    # However, that appears to not be true for all commands. annex-add would
+    # still report in the "git-annex: ... not found" fashion rather than
+    # "error:  ... did not match any file(s) known to git". Depends on
+    # what annex is calling internally *and* on that config. Apparently git
+    # itself isn't consistent in that regard.
+    # Therefore, account for both ways of reporting unknown paths.
+
+    unknown_paths = []
+    for line in output.splitlines():
+        if 'did not match any file(s) known to git' in line:
+            unknown_paths.append(line[17:-40])
+        elif line.startswith('git-annex:') and line.endswith(' not found'):
+            unknown_paths.append(line[11:-10])
+
+    return unknown_paths

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -57,6 +57,10 @@ from datalad.runner.utils import (
 # must not be loads, because this one would log, and we need to log ourselves
 from datalad.support.json_py import json_loads
 from datalad.support.exceptions import CapturedException
+from datalad.support.annex_utils import (
+    _fake_json_for_non_existing,
+    _get_non_existing_from_annex_output,
+)
 from datalad.ui import ui
 import datalad.utils as ut
 from datalad.utils import (
@@ -1047,15 +1051,9 @@ class AnnexRepo(GitRepo, RepoInterface):
             )
         except CommandError as e:
             # Note: Workaround for not existing files as long as annex doesn't
-            # report it within JSON response:
+            # report it within JSON.
             # see http://git-annex.branchable.com/bugs/copy_does_not_reflect_some_failed_copies_in_--json_output/
-            not_existing = [
-                # cut the file path from the middle, no useful delimiter
-                # need to deal with spaces too!
-                line[11:-10] for line in e.stderr.splitlines()
-                if line.startswith('git-annex:') and
-                line.endswith(' not found')
-            ]
+            not_existing = _get_non_existing_from_annex_output(e.stderr)
             if not_existing:
                 if out is None:
                     # we create the error reporting herein. If all files were
@@ -1063,13 +1061,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                     # anything
                     out = {'stdout_json': []}
                 out['stdout_json'].extend(
-                    {
-                        "command": args[0],
-                        "file": f,
-                        "note": "not found",
-                        "success": False,
-                    }
-                    for f in not_existing
+                    _fake_json_for_non_existing(not_existing, args[0])
                 )
 
             # Note: insert additional code here to analyse failure and possibly
@@ -1100,6 +1092,23 @@ class AnnexRepo(GitRepo, RepoInterface):
             #        "Running %s resulted in stderr output: %s",
             #        args, shorten(e.stderr)
             #    )
+
+        # git-annex fails to non-zero exit when reporting an error on
+        # non-existing paths in some versions and/or commands.
+        # Hence, check for it on non-failure, too. This became apparent with
+        # annex 10.20220127, but was a somewhat "hidden" issue for longer.
+        #
+        # Note, that this may become unnecessary after annex'
+        # ce91f10132805d11448896304821b0aa9c6d9845 (Feb 28, 2022)
+        # "fix annex.skipunknown false error propagation"
+        if 'stderr' in out:
+            not_existing = _get_non_existing_from_annex_output(out['stderr'])
+            if not_existing:
+                if out is None:
+                    out = {'stdout_json': []}
+                out['stdout_json'].extend(
+                    _fake_json_for_non_existing(not_existing, args[0])
+                )
 
         json_objects = out.pop('stdout_json')
 
@@ -2353,12 +2362,17 @@ class AnnexRepo(GitRepo, RepoInterface):
             else:
                 json_objects = _call_cmd(cmd, files)
 
+        # json_objects can contain entries w/o a "whereis" field. Unknown to
+        # git paths in particular are returned in such records. Code below is
+        # only concerned with actual whereis results.
+        whereis_json_objects = [o for o in json_objects if "whereis" in
+                                o.keys()]
 
         if output in {'descriptions', 'uuids'}:
             return [
                 [remote.get(output[:-1]) for remote in j.get('whereis')]
                 if j.get('success') else []
-                for j in json_objects
+                for j in whereis_json_objects
             ]
         elif output == 'full':
             # TODO: we might want to optimize storage since many remotes entries will be the
@@ -2371,7 +2385,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                 else str(Path(PurePosixPath(j['file'])))
                 if on_windows else j['file']
                 : self._whereis_json_to_dict(j)
-                for j in json_objects
+                for j in whereis_json_objects
                 if not j.get('key', '').endswith('.this-is-a-test-key')
             }
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2165,6 +2165,7 @@ def test_error_reporting(path):
             # whole thing, despite space, properly quotes backslash
             'file': 'gl\\orious BS',
             'note': 'not found',
+            'error-messages': ['File unknown to git'],
             'success': False}]
     )
 

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1397,6 +1397,22 @@ def test_annex_copy_to(src, origin, clone):
             # That is not how annex behaves
             # http://git-annex.branchable.com/bugs/copy_does_not_reflect_some_failed_copies_in_--json_output/
             # for non-existing files output goes into stderr
+            #
+            # stderr output depends on config+version of annex, though:
+            if not dl_cfg.getbool(
+                    section="annex", option="skipunknown",
+                    # git-annex switched default for this config:
+                    default=bool(
+                        external_versions['cmd:annex'] < '10.20220127')):
+
+                stderr = "error: pathspec 'nonex1' did not match any file(s) " \
+                         "known to git\n" \
+                         "error: pathspec 'nonex2' did not match any file(s) " \
+                         "known to git\n"
+            else:
+                stderr = "git-annex: nonex1 not found\n" \
+                         "git-annex: nonex2 not found\n"
+
             raise CommandError(
                 "Failed to run ...",
                 stdout_json=[
@@ -1405,9 +1421,7 @@ def test_annex_copy_to(src, origin, clone):
                     {"command":"copy","note":"checking target ...",
                      "success":True, "key":"akey2", "file":"existed"},
                 ],
-                stderr=
-                    'git-annex: nonex1 not found\n'
-                    'git-annex: nonex2 not found\n'
+                stderr=stderr
             )
         else:
             return orig_run(command, **kwargs)
@@ -2178,15 +2192,26 @@ def test_annexjson_protocol(path):
     if logging.getLogger('datalad.annex').getEffectiveLevel() > 8:
         eq_(res['stderr'], '')
 
+    # Note: git-annex-find <non-existent-path> does not error with all annex
+    # versions. Fixed in annex commit
+    # ce91f10132805d11448896304821b0aa9c6d9845 (Feb 28, 2022).
+    if '10.20220127' < external_versions['cmd:annex'] < '10.20220322':
+        raise SkipTest("zero-exit annex-find bug")
+
     # now the same, but with a forced error
     with assert_raises(CommandError) as e:
-        res = ar._call_annex(
-            ['find', '.', 'error', '--json'],
-            protocol=AnnexJsonProtocol)
+        ar._call_annex(['find', '.', 'error', '--json'],
+                       protocol=AnnexJsonProtocol)
     # normal operation is not impaired
     eq_(e.exception.kwargs['stdout_json'], orig_j)
-    # we get a clue what went wrong
-    assert_in('error not found', e.exception.stderr)
+    # we get a clue what went wrong,
+    # but reporting depends on config + version (default changed):
+    msg = "pathspec 'error' did not match" if not dl_cfg.getbool(
+        section="annex", option="skipunknown",
+        # git-annex switched default for this config:
+        default=bool(external_versions['cmd:annex'] < '10.20220127')) else \
+        "error not found"
+    assert_in(msg, e.exception.stderr)
     # there should be no errors reported in an individual records
     # hence also no pointless statement in the str()
     assert_not_in('errors from JSON records', str(e.exception))


### PR DESCRIPTION
As of annex 10.20220127 we observed several failures on macOS, which at this point is the only build with that recent an git-annex.
These failures boil down to two issues:

- One issue became apparent (actually older), where the reporting of annex commands with respect to paths that are
unknown to git or not existent at all happens in different ways. This depends on annex' internal git calls (git itself appears to be inconsistent WRT this message) as well as on the value of 'annex.skipunknown' the default of which changed in said version. This results in both styles of reporting being used and as long as we rely on parsing that output, we need to account for both.
Moreover, annex commands don't always exit non-zero when that happens, which is why we need to check stderr output when the command doesn't fail, too. At least for `git-annex-find` but probably more commands the zero exit is fixed but unreleased in annex ([10.20220222-30-gce91f1013](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=ce91f10132805d11448896304821b0aa9c6d9845), Feb 28, 2022 - "fix annex.skipunknown false error propagation").
None of that actually depends on annex' version exactly. It's mostly just that the zero-exit bug in combination with the switch of default made those issues surface.

- The other issue seems to be an annex bug: https://git-annex.branchable.com/bugs/Change_to_annex.largefiles_leaves_repo_modified/
This patch simply skips the respective part of the test for this situation conditioned on the annex version.

Closes #6492
Closes #6570
Closes #6571

Please, review especially this change, @datalad/developers :

This will change behavior of some datalad commands. The change partially
only applies to annex version >= 10.20220322 and `annex.skipunknown=false`
(default since 10.20220127).

Assume following setup:

.
├── bar -> foo
├── bla
├── foo
│   └── f -> ../.git/annex/objects/ ...
└── untracked

Then, previously we had (all zero-exit):

```
$ datalad status --annex availability notexistent foo/f
1 annex'd file (0.0 B/0.0 B present/total size)
nothing to save, working tree clean
$ datalad status --annex availability bar/f foo/f
1 annex'd file (0.0 B/0.0 B present/total size)
nothing to save, working tree clean
$ datalad drop notexistent
$ datalad drop bar/f
$ datalad diff -f HEAD~2 --annex availability bar/f notexistent foo/f
    added: foo/f (file)
```

Now, with non-zero exit:

```
$ datalad status --annex availability notexistent foo/f
status(error): notexistent [File unknown to git]
1 annex'd file (0.0 B/0.0 B present/total size)
$ datalad status --annex availability bar/f foo/f
status(error): bar/f [File unknown to git]
1 annex'd file (0.0 B/0.0 B present/total size)
status(error): bar/f [File unknown to git]
$ datalad drop notexistent
drop(error): notexistent (file) [File unknown to git]
$ datalad drop bar/f
drop(error): bar/f (file) [File unknown to git]
$ datalad diff -f HEAD~2 --annex availability bar/f notexistent foo/f
    added: foo/f (file)
  unknown: bar/f ()
  unknown: notexistent ()
```

Note, that this only has an effect when the command goes through
`AnnexRepo.get_content_annexinfo`. Calls, that are only assessing things
based on plain git are not affected. This may be desirable to add,
though, since the reporting is somewhat similar.
Also note, that we can't distinguish the `bar/f` and `notexistent` case anymore, since this is reported on equally by git-annex, which in turn now relies on `git ls-files --error-unmatch`.

- [ ] add changed results to changelog, if confirmed by review


### Changelog
#### 🐛 Bug Fixes
- Fixes DataLad's parsing of git-annex' reporting on unknown paths
#### 🛡 Tests
- Skip a test on annex>=10.20220127 due to a bug in annex. See https://git-annex.branchable.com/bugs/Change_to_annex.largefiles_leaves_repo_modified/