### PR TITLE
Enforce system ssh client usage on Windows

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -35,9 +35,11 @@ def get_default_ssh():
     from datalad.utils import on_windows
     from pathlib import Path
 
-    windows_openssh_path = r'C:\Windows\System32\OpenSSH\ssh.exe'
-    if on_windows and Path(windows_openssh_path).exists():
-        return windows_openssh_path
+    if on_windows:
+        windows_openssh_path = \
+            environ.get("WINDIR", r"C:\Windows") + r"\System32\OpenSSH\ssh.exe"
+        if Path(windows_openssh_path).exists():
+            return windows_openssh_path
     return "ssh"
 
 

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -579,7 +579,7 @@ definitions = {
         'ui': ('question', {
             'title': "Name of ssh executable for 'datalad sshrun'",
             'text': "Specifies the name of the ssh-client executable that"
-                    "'datalad sshrun' will use. This might be an absolute "
+                    "datalad will use. This might be an absolute "
                     "path. On Windows systems it is currently by default set "
                     "to point to the ssh executable of OpenSSH for Windows, "
                     "if OpenSSH for Windows is installed. On other systems it "

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -30,6 +30,17 @@ from datalad.utils import on_windows
 
 dirs = AppDirs("datalad", "datalad.org")
 
+
+def get_default_ssh():
+    from datalad.utils import on_windows
+    from pathlib import Path
+
+    windows_openssh_path = r'C:\Windows\System32\OpenSSH\ssh.exe'
+    if on_windows and Path(windows_openssh_path).exists():
+        return windows_openssh_path
+    return "ssh"
+
+
 subst_rule_docs = """\
 A substitution specification is a string with a match and substitution
 expression, each following Python's regular expression syntax. Both expressions
@@ -564,16 +575,18 @@ definitions = {
         'default': 'warning',
 
     },
-    'datalad.windows.ssh.client': {
+    'datalad.ssh.executable': {
         'ui': ('question', {
-            'title': "Location of OpenSSH for Windows' ssh.exe",
-            'text': "To use git with ssh on Windows the Windows system ssh"
-                    "client, i.e. OpenSSH for Windows, has to be installed. "
-                    "If it is not installed in the default location, its "
-                    "location can be set in this variable."}),
+            'title': "Name of ssh executable for 'datalad sshrun'",
+            'text': "Specifies the name of the ssh-client executable that"
+                    "'datalad sshrun' will use. This might be an absolute "
+                    "path. On Windows systems it is currently be default set "
+                    "to point to the ssh executable of OpenSSH for Windows, "
+                    "if OpenSSH for Windows is installed. On other systems it "
+                    "defaults to 'ssh'."}),
         'destination': 'global',
         'type': EnsureStr(),
-        'default': r'C:\Windows\System32\OpenSSH\ssh.exe',
+        'default_fn': get_default_ssh,
     }
 }
 

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -580,7 +580,7 @@ definitions = {
             'title': "Name of ssh executable for 'datalad sshrun'",
             'text': "Specifies the name of the ssh-client executable that"
                     "'datalad sshrun' will use. This might be an absolute "
-                    "path. On Windows systems it is currently be default set "
+                    "path. On Windows systems it is currently by default set "
                     "to point to the ssh executable of OpenSSH for Windows, "
                     "if OpenSSH for Windows is installed. On other systems it "
                     "defaults to 'ssh'."}),

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -564,6 +564,17 @@ definitions = {
         'default': 'warning',
 
     },
+    'datalad.windows.ssh.client': {
+        'ui': ('question', {
+            'title': "Location of OpenSSH for Windows' ssh.exe",
+            'text': "To use git with ssh on Windows the Windows system ssh"
+                    "client, i.e. OpenSSH for Windows, has to be installed. "
+                    "If it is not installed in the default location, its "
+                    "location can be set in this variable."}),
+        'destination': 'global',
+        'type': EnsureStr(),
+        'default': r'C:\Windows\System32\OpenSSH\ssh.exe',
+    }
 }
 
 

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -167,12 +167,9 @@ class BaseSSHConnection(object):
         """determine which ssh client should be used.
 
         On Windows OpenSSH for Windows is required. It is searched in its
-        default location. This can be overriden by setting the datalad
+        default location. This can be overridden by setting the datalad
         config variable 'datalad.windows.ssh.client' to the path of the
         system ssh client.
-
-        If a location is stored in the config variable, it takes precedence
-        over the default location.
         """
         if self._ssh_command:
             return self._ssh_command
@@ -183,9 +180,7 @@ class BaseSSHConnection(object):
         if on_windows:
             from datalad import cfg
 
-            cmd = cfg.get(self.cfg_datalad_windows_ssh_client)
-            if cmd is None:
-                cmd = r"C:\Windows\System32\OpenSSH\ssh.exe"
+            cmd = cfg.obtain(self.cfg_datalad_windows_ssh_client)
             if not Path(cmd).exists():
                 lgr.error(
                     f"SSH client ({cmd}) was not found.\nPlease "

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -163,7 +163,7 @@ class BaseSSHConnection(object):
         raise NotImplementedError
 
     @property
-    def ssh_command(self):
+    def ssh_executable(self):
         """determine which ssh client should be used.
 
         On Windows OpenSSH for Windows is required. It is searched in its

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -577,7 +577,9 @@ class MultiplexSSHConnection(BaseSSHConnection):
 
         # start control master:
         lgr.debug("Opening %s by calling %s", self, cmd)
-        proc = Popen(cmd)
+        # The following call is exempt from bandit's security checks because
+        # we/the user control the content of 'cmd'.
+        proc = Popen(cmd)  # nosec
         stdout, stderr = proc.communicate(input="\n")  # why the f.. this is necessary?
 
         # wait till the command exits, connection is conclusively

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -98,7 +98,7 @@ class BaseSSHConnection(object):
     """Representation of an SSH connection.
     """
 
-    cfg_datalad_windows_ssh_client = "datalad.windows.ssh.client"
+    cfg_datalad_windows_ssh_client = "datalad.ssh.executable"
 
     def __init__(self, sshri, identity_file=None,
                  use_remote_annex_bundle=None, force_ip=False):


### PR DESCRIPTION
This PR fixes #5829 

This PR enforces the use of the system windows ssh client (OpenSSH for Windows) in `sshconnector.py`. The reason for this restriction is that other ssh clients, namely the ssh client that is bundled with git for windows, do not properly work when called by git (see the discussions in issue #5829).

The PR introduces the new environment variable `DATALAD_WINDOWS_SSH_CLIENT` that can be set to inform `datalad` about an alternative location of the system ssh client.

Possible future improvements:
- We do not currently verify that the ssh-client is indeed the system windows ssh-client.
- This PR requires the installation of OpenSSH for Windows in order to use datalad with ssh on windows. We might want to investigate why other ssh clients do not properly work and fix the root cause.


### Changelog
#### 🐛 Bug Fixes
- Description... Fixes #5829 by allowing to explicitly specify a compatible ssh client-executable
#### 💫 Enhancements and new features
- Introduces the configuration key `datalad.ssh.executable`. This key allows specifying an ssh-client executable that should be used by datalad to establish ssh-connections. The default value is `ssh` unless on a Windows system where `$WINDIR\System32\OpenSSH\ssh.exe` exists. In this case, the value defaults to `$WINDIR\System32\OpenSSH\ssh.exe`.

