### PR TITLE
New credentials() command and CredentialManager

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""
-"""
+"""Unified configuration management and query"""
 
 import json
 import logging

--- a/datalad/credman.py
+++ b/datalad/credman.py
@@ -1,0 +1,710 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See LICENSE file distributed along with the datalad_osf package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Credential management and query"""
+
+__docformat__ = 'restructuredtext'
+
+__all__ = ['CredentialManager']
+
+from datetime import datetime
+import logging
+import re
+
+import datalad
+from datalad.support.exceptions import (
+    CapturedException,
+    CommandError,
+)
+from datalad.ui import ui
+
+lgr = logging.getLogger('datalad.credman')
+
+
+class CredentialManager(object):
+    """Facility to get, set, remove and query credentials.
+
+    A credential in this context is a set of properties (key-value pairs)
+    associated with exactly one secret.
+
+    At present, the only backend for secret storage is the Python keyring
+    package, as interfaced via a custom DataLad wrapper. Store for credential
+    properties is implemented using DataLad's (i.e. Git's) configuration
+    system. All properties are stored in the `global` (i.e., user) scope
+    under configuration items following the pattern::
+
+      datalad.credential.<name>.<property>
+
+    where ``<name>`` is a credential name/identifier, and ``<property>`` is an
+    arbitrarily named credential property, whose name must follow the
+    git-config syntax for variable names (case-insensitive, only alphanumeric
+    characters and ``-``, and must start with an alphabetic character).
+
+    Create a ``CredentialManager`` instance is fast, virtually no initialization
+    needs to be performed. All internal properties are lazily evaluated.
+    This facilitate usage of this facility in code where it is difficult
+    to incorporate a long-lived central instance.
+
+    API
+
+    With one exception, all parameter names of methods in the main API
+    outside ``**kwargs`` must have a ``_`` prefix that distinguishes credential
+    properties from method parameters. The one exception is the ``name``
+    parameter, which is used as a primary identifier (albeit being optional
+    for some operations).
+    """
+    valid_property_names_regex = re.compile(r'[a-z0-9]+[a-z0-9-]*$')
+
+    def __init__(self, cfg=None):
+        """
+
+        Parameters
+        ----------
+        cfg: ConfigManager, optional
+          If given, all configuration queries are performed using this
+          ``ConfigManager`` instance. Otherwise ``datalad.cfg`` is used.
+        """
+        self.__cfg = cfg
+        self.__cred_types = None
+        self.__keyring = None
+
+    # main API
+    #
+    def get(self, name=None, _prompt=None, _type_hint=None, **kwargs):
+        """Get properties and secret of a credential.
+
+        This is a read-only method that never modifies information stored
+        on a credential in any backend.
+
+        Credential property lookup is supported via a number approaches.  When
+        providing ``name``, all existing corresponding configuration items are
+        found and reported, and an existing secret is retrieved from name-based
+        secret backends (presently ``keyring``). When providing a ``type``
+        property or a ``_type_hint`` the lookup of additional properties in the
+        keyring-backend is enabled, using predefined property name lists
+        for a number of known credential types.
+
+        For all given property keys that have no value assigned after the
+        initial lookup, manual/interactive entry is attempted, whenever
+        a custom ``_prompt`` was provided. This include requesting a secret.
+        If manually entered information is contained in the return credential
+        record, the record contains an additional ``_edited`` property with a
+        value of ``True``.
+
+        If no secret is known after lookup and a potential manual data entry,
+        a plain ``None`` is returned instead of a full credential record.
+
+        Parameters
+        ----------
+        name: str, optional
+          Name of the credential to be retrieved
+        _prompt: str or None
+          Instructions for credential entry to be displayed when missing
+          properties are encountered. If ``None``, manual entry is disabled.
+        _type_hint: str or None
+          In case no ``type`` property is included in ``kwargs``, this parameter
+          is used to determine a credential type, to possibly enable further
+          lookup/entry of additional properties for a known credential type
+        **kwargs:
+          Credential property name/value pairs. For any property with a value
+          of ``None``, manual data entry will be performed, unless a value
+          could be retrieved on lookup, or prompting was not enabled.
+
+        Returns
+        -------
+        dict or None
+          Return ``None``, if no secret for the credential was found or entered.
+          Otherwise returns the complete credential record, comprising all
+          properties and the secret. An additional ``_edited`` key with a
+          value of ``True`` is added whenever the returned record contains
+          manually entered information.
+
+        Raises
+        ------
+        ValueError
+          When the method is called without any information that could be
+          used to identify a credential
+        """
+        if name is None and _type_hint is None and not kwargs:
+            # there is no chance that this could work
+            raise ValueError(
+                'CredentialManager.get() called without any identifying '
+                'information')
+        if name is None:
+            # there is no chance we can retrieve any stored properties
+            # but we can prompt for some below
+            cred = {}
+        else:
+            # if we have a chance to query for stored legacy credentials
+            # we do this first to have the more modern parts of the
+            # system overwrite them reliably
+            cred = self._get_legacy_field_from_keyring(
+                name, kwargs.get('type', _type_hint)) or {}
+
+            var_prefix = _get_cred_cfg_var(name, '')
+            # get related info from config
+            cred.update({
+                k[len(var_prefix):]: v
+                for k, v in self._cfg.items()
+                if k.startswith(var_prefix)
+            })
+
+        # final word on the credential type
+        _type_hint = cred.get('type', kwargs.get('type', _type_hint))
+        if _type_hint:
+            # import the definition of expected fields from the known
+            # credential types
+            cred_type = self._cred_types.get(
+                _type_hint,
+                dict(fields=[], secret=None))
+            for k in (cred_type['fields'] or []):
+                if k == cred_type['secret'] or k in kwargs:
+                    # do nothing, if this is the secret key
+                    # or if we have an incoming value for this key already
+                    continue
+                # otherwise make sure we prompt for the essential
+                # fields
+                kwargs[k] = None
+
+        prompted = False
+        for k, v in kwargs.items():
+            if k == 'secret':
+                # handled below
+                continue
+            if _prompt and v is None and cred.get(k) is None:
+                # ask if enabled, no value was provided,
+                # and no value is already on record
+                v = self._ask_property(k, None if prompted else _prompt)
+                if v is not None:
+                    prompted = True
+            if v:
+                cred[k] = v
+
+        # start locating the secret at the method parameters
+        secret = kwargs.get('secret')
+        if secret is None and name:
+            # get the secret, from the effective config, not just the keystore
+            secret = self._get_secret(name, type_hint=_type_hint)
+        if _prompt and secret is None:
+            secret = self._ask_secret(
+                type_hint=self._cred_types.get(
+                    _type_hint, {}).get('secret'),
+                prompt=None if prompted else _prompt,
+            )
+            if secret:
+                prompted = True
+
+        if not secret:
+            # nothing
+            return
+
+        cred['secret'] = secret
+        if 'type' not in cred and kwargs.get('type'):
+            # enhance legacy credentials
+            cred['type'] = kwargs.get('type')
+
+        # report whether there were any edits to the credential record
+        # (incl. being entirely new), such that consumers can decide
+        # to save a credentials, once battle-tested
+        if prompted:
+            cred['_edited'] = True
+        return cred
+
+    def set(self, name, _lastused=False, **kwargs):
+        """Set credential properties and secret
+
+        Presently, all supported backends require the specification of
+        a credential ``name`` for storage. This may change in the future,
+        when support for alternative backends is added, at which point
+        the ``name`` parameter would become optional.
+
+        All properties provided as `kwargs` with values that are not ``None``
+        will be stored. If ``kwargs`` do not contain a ``secret`` specification,
+        manual entry will be attempted. The associated prompt with be either
+        the name of the ``secret`` field of a known credential (as identified via
+        a ``type`` property), or the label ``'secret'``.
+
+        All properties with an associated value of ``None`` will be removed
+        (unset).
+
+        Parameters
+        ----------
+        name: str
+          Credential name
+        _lastused: bool, optional
+          If set, automatically add an additional credential property
+          ``'last-used'`` with the current timestamp in ISO 8601 format.
+        **kwargs:
+          Any number of credential property key/value pairs. Values of
+          ``None`` indicate removal of a property from a credential.
+
+        Returns
+        -------
+        dict
+          key/values of all modified credential properties with respect
+          to their previously recorded values.
+
+        Raises
+        ------
+        RuntimeError
+          This exception is raised whenever a property cannot be removed
+          successfully. Likely cause is that it is defined in a configuration
+          scope or backend for which write-access is not supported.
+        ValueError
+          When property names in kwargs are not syntax-compliant.
+        """
+        verify_property_names(kwargs)
+        # if we know the type, hence we can do a query for legacy secrets
+        # and properties. This will migrate them to the new setup
+        # over time
+        type_hint = kwargs.get('type')
+        cred = self._get_legacy_field_from_keyring(name, type_hint) or {}
+        if _lastused:
+            cred['last-used'] = datetime.now().isoformat()
+        # amend with given properties
+        cred.update(**kwargs)
+
+        # remove props
+        #
+        remove_props = [
+            k for k, v in cred.items() if v is None and k != 'secret']
+        self._unset_credprops_anyscope(name, remove_props)
+        updated = {k: None for k in remove_props}
+
+        # set non-secret props
+        #
+        set_props = {
+            k: v for k, v in cred.items()
+            if v is not None and k != 'secret'
+        }
+        for k, v in set_props.items():
+            var = _get_cred_cfg_var(name, k)
+            if self._cfg.get(var) == v:
+                # desired value already exists, we are not
+                # storing again to preserve the scope it
+                # was defined in
+                continue
+            # we always write to the global scope (ie. user config)
+            # credentials are typically a personal, not a repository
+            # specific entity -- likewise secrets go into a personal
+            # not repository-specific store
+            # for custom needs users can directly set the respective
+            # config
+            self._cfg.set(var, v, scope='global', force=True, reload=False)
+            updated[k] = v
+        if set_props:
+            self._cfg.reload()
+
+        # set secret
+        #
+        # we aim to update the secret in the store, hence we must
+        # query for a previous setting in order to reliably report
+        # updates
+        prev_secret = self._get_secret_from_keyring(name, type_hint)
+        if 'secret' not in cred:
+            # we have no removal directive, reuse previous secret
+            cred['secret'] = prev_secret
+        if cred.get('secret') is None:
+            # we want to reset the secret, consider active config
+            cred['secret'] = \
+                self._cfg.get(_get_cred_cfg_var(name, 'secret'))
+
+        if cred.get('secret') is None:
+            # we have no secret specified or in the store already: ask
+            # typically we would end up here with an explicit attempt
+            # to set a credential in a context that is known to an
+            # interactive user, hence the messaging here can be simple
+            cred['secret'] = self._ask_secret(type_hint=type_hint or 'secret')
+        # at this point we will have a secret. it could be from ENV
+        # or provided, or entered. we always want to put it in the
+        # store
+        self._keyring.set(name, 'secret', cred['secret'])
+        if cred['secret'] != prev_secret:
+            # only report updated if actually different from before
+            updated['secret'] = cred['secret']
+        return updated
+
+    def remove(self, name, type_hint=None):
+        """Remove a credential, including all properties and secret
+
+        Presently, all supported backends require the specification of
+        a credential ``name`` for lookup. This may change in the future,
+        when support for alternative backends is added, at which point
+        the ``name`` parameter would become optional, and additional
+        parameters would be added.
+
+        Returns
+        -------
+        bool
+          True if a credential was removed, and False if not (because
+          no respective credential was found).
+
+        Raises
+        ------
+        RuntimeError
+          This exception is raised whenever a property cannot be removed
+          successfully. Likely cause is that it is defined in a configuration
+          scope or backend for which write-access is not supported.
+        """
+        # prefix for all config variables of this credential
+        prefix = _get_cred_cfg_var(name, '')
+
+        def _get_props():
+            return (k[len(prefix):] for k in self._cfg.keys()
+                    if k.startswith(prefix))
+
+        to_remove = [
+            k[len(prefix):] for k in self._cfg.keys()
+            if k.startswith(prefix)
+        ]
+        removed = False
+        if to_remove:
+            self._unset_credprops_anyscope(name, to_remove)
+            removed = True
+
+        # delete the secret from the keystore, if there is any
+        def del_field(name, field):
+            global removed
+            try:
+                self._keyring.delete(name, field)
+                removed = True
+            except Exception as e:
+                if self._keyring.get(name, field) is None:
+                    # whatever it was, the target is reached
+                    CapturedException(e)
+                else:
+                    # we could not delete the field
+                    raise
+
+        del_field(name, 'secret')
+        if type_hint:
+            # remove legacy records too
+            for field in self._cred_types.get(
+                    type_hint, {}).get('fields', []):
+                del_field(name, field)
+        return removed
+
+    def query_(self, **kwargs):
+        """Query for all (matching) credentials.
+
+        Credentials are yielded in no particular order.
+
+        This method cannot find credentials for which only a secret
+        was deposited in the keyring.
+
+        This method does support lookup of credentials defined in DataLad's
+        "provider" configurations.
+
+        Parameters
+        ----------
+        **kwargs
+          If not given, any found credential is yielded. Otherwise,
+          any credential must match all property name/value
+          pairs
+
+        Yields
+        ------
+        tuple(str, dict)
+          The first element in the tuple is the credential name, the second
+          element is the credential record as returned by ``get()`` for any
+          matching credential.
+        """
+        done = set()
+        known_credentials = set(
+            (k.split('.')[2], None) for k in self._cfg.keys()
+            if k.startswith('datalad.credential.')
+        )
+        from itertools import chain
+        for name, type_hint in chain(
+                _yield_legacy_credential_names(),
+                known_credentials):
+            if name in done:
+                continue
+            done.add(name)
+            cred = self.get(name, _prompt=None, _type_hint=type_hint)
+            if not cred:
+                continue
+            if not kwargs:
+                yield (name, cred)
+            else:
+                if all(cred.get(k) == v for k, v in kwargs.items()):
+                    yield (name, cred)
+                else:
+                    continue
+
+    def query(self, _sortby=None, _reverse=True, **kwargs):
+        """Query for all (matching) credentials, sorted by a property
+
+        This method is a companion of ``query_()``, and the same limitations
+        regarding credential discovery apply.
+
+        In contrast to ``query_()``, this method return a list instead of
+        yielding credentials one by one. This returned list is optionally
+        sorted.
+
+        Parameters
+        ----------
+        _sortby: str, optional
+          Name of a credential property to provide a value to sort by.
+          Credentials that do not carry the specified property always
+          sort last, regardless of sort order.
+        _reverse: bool, optional
+          Flag whether to sort ascending or descending when sorting.
+          By default credentials are return in descending property
+          value order. This flag does not impact the fact that credentials
+          without the property to sort by always sort last.
+        **kwargs
+          Pass on as-is to ``query_()``
+
+        Returns
+        -------
+        list(str, dict)
+          Each item is a 2-tuple. The first element in each tuple is the
+          credential name, the second element is the credential record
+          as returned by ``get()`` for any matching credential.
+        """
+        matches = self.query_(**kwargs)
+        if _sortby is None:
+            return list(matches)
+
+        # this makes sure that any credential that does not have the
+        # sort-by property name sorts to the very end of the list
+        # regardless of whether the sorting is ascending or descending
+        def get_sort_key(x):
+            # x is a tuple as returned by query_()
+            prop_indicator = _sortby in x[1]
+            if not _reverse:
+                prop_indicator = not prop_indicator
+            return (prop_indicator, x[1].get(_sortby))
+
+        return sorted(matches, key=get_sort_key, reverse=_reverse)
+
+
+    # internal helpers
+    #
+    def _prompt(self, prompt):
+        if not prompt:
+            return
+        ui.message(prompt)
+
+    def _ask_property(self, name, prompt=None):
+        if not ui.is_interactive:
+            return
+        self._prompt(prompt)
+        return ui.question(name, title=None)
+
+    def _ask_secret(self, type_hint=None, prompt=None):
+        if not ui.is_interactive:
+            return
+        self._prompt(prompt)
+        return ui.question(
+            type_hint or 'secret',
+            title=None,
+            repeat=self._cfg.obtain(
+                'datalad.credentials.repeat-secret-entry'),
+            hidden=self._cfg.obtain(
+                'datalad.credentials.hidden-secret-entry'),
+        )
+
+    def _props_defined_in_cfg(self, name, keys):
+        return [
+            k for k in keys
+            if _get_cred_cfg_var(name, k) in self._cfg
+        ]
+
+    def _unset_credprops_anyscope(self, name, keys):
+        """Reloads the config after unsetting all relevant variables
+
+        This method does not modify the keystore.
+        """
+        nonremoved_vars = []
+        for k in keys:
+            var = _get_cred_cfg_var(name, k)
+            if var not in self._cfg:
+                continue
+            try:
+                self._cfg.unset(var, scope='global', reload=False)
+            except CommandError as e:
+                CapturedException(e)
+                try:
+                    self._cfg.unset(var, scope='local', reload=False)
+                except CommandError as e:
+                    CapturedException(e)
+                    nonremoved_vars.append(var)
+        if nonremoved_vars:
+            raise RuntimeError(
+                f"Cannot remove configuration items {nonremoved_vars} "
+                f"for credential, defined outside global or local "
+                "configuration scope. Remove manually")
+        self._cfg.reload()
+
+    def _get_legacy_field_from_keyring(self, name, type_hint):
+        if not type_hint or type_hint not in self._cred_types:
+            return
+
+        cred = {}
+        lc = self._cred_types[type_hint]
+        for field in (lc['fields'] or []):
+            if field == lc['secret']:
+                continue
+            val = self._keyring.get(name, field)
+            if val:
+                # legacy credentials used property names with underscores,
+                # but this is no longer syntax-compliant -- fix on read
+                cred[field.replace('_', '-')] = val
+        if 'type' not in cred:
+            cred['type'] = type_hint
+        return cred
+
+    def _get_secret(self, name, type_hint=None):
+        secret = self._cfg.get(_get_cred_cfg_var(name, 'secret'))
+        if secret is not None:
+            return secret
+        return self._get_secret_from_keyring(name, type_hint)
+
+    def _get_secret_from_keyring(self, name, type_hint=None):
+        """
+        Returns
+        -------
+        str or None
+          None is return when no secret for the given credential name
+          could be found. Otherwise, the secret is returned.
+        """
+        # always get the uniform
+        secret = self._keyring.get(name, 'secret')
+        if secret:
+            return secret
+        # fall back on a different "field" that is inferred from the
+        # credential type
+        secret_field = self._cred_types.get(
+            type_hint, {}).get('secret')
+        if not secret_field:
+            return
+        secret = self._keyring.get(name, secret_field)
+        return secret
+
+    @property
+    def _cfg(self):
+        """Return a ConfigManager given to __init__() or the global datalad.cfg
+        """
+        if self.__cfg:
+            return self.__cfg
+        return datalad.cfg
+
+    @property
+    def _keyring(self):
+        """Returns the DataLad keyring wrapper
+
+        This internal property may vanish whenever changes to the supported
+        backends are made.
+        """
+        if self.__keyring:
+            return self.__keyring
+        from datalad.support.keyring_ import keyring
+        self.__keyring = keyring
+        return keyring
+
+    @property
+    def _cred_types(self):
+        """Internal property for mapping of credential type names to fields.
+
+        Returns
+        -------
+        dict
+          Legacy credential type name ('token', 'user_password', etc.) as keys,
+          and dictionaries as values. Each of these dicts has two keys:
+          'fields' (the complete list of "fields" that the credential
+          comprises), and 'secret' (the name of the field that represents the
+          secret. If there is no secret, the value associated with that key is
+          ``None``.
+        """
+        # at present the credential type specifications are built from the
+        # legacy credential types, but this may change at any point in the
+        # future
+        # here is what that was in Mar 2022
+        # 'user_password': {'fields': ['user', 'password'],
+        #                   'secret': 'password'},
+        # 'token':  {'fields': ['token'], 'secret': 'token'},
+        # 'git':    {'fields': ['user', 'password'], 'secret': 'password'}
+        # 'aws-s3': {'fields': ['key_id', 'secret_id', 'session', 'expiration'],
+        #            'secret': 'secret_id'},
+        # 'nda-s3': {'fields': None, 'secret': None},
+        # 'loris-token': {'fields': None, 'secret': None},
+
+        if self.__cred_types:
+            return self.__cred_types
+
+        from datalad.downloaders import CREDENTIAL_TYPES
+        mapping = {}
+        for cname, ctype in CREDENTIAL_TYPES.items():
+            secret_fields = [
+                f for f in (ctype._FIELDS or {})
+                if ctype._FIELDS[f].get('hidden')
+            ]
+            mapping[cname] = dict(
+                fields=list(ctype._FIELDS.keys()) if ctype._FIELDS else None,
+                secret=secret_fields[0] if secret_fields else None,
+            )
+        self.__cred_types = mapping
+        return mapping
+
+def _yield_legacy_credential_names():
+    # query is constrained by non-secrets, no constraints means report all
+    # a constraint means *exact* match on all given properties
+    from datalad.downloaders.providers import (
+        Providers,
+        CREDENTIAL_TYPES,
+    )
+    type_hints = {v: k for k, v in CREDENTIAL_TYPES.items()}
+
+    legacy_credentials = set(
+        (p.credential.name, type(p.credential))
+        for p in Providers.from_config_files()
+        if p.credential
+    )
+    for name, type_ in legacy_credentials:
+        yield (name, type_hints.get(type_))
+
+
+def verify_property_names(names):
+    """Check credential property names for syntax-compliance.
+
+    Parameters
+    ----------
+    names: iterable
+
+    Raises
+    ------
+    ValueError
+      When any non-compliant property names were found
+    """
+    invalid_names = [
+        k for k in names
+        if not CredentialManager.valid_property_names_regex.match(k)
+    ]
+    if invalid_names:
+        raise ValueError(
+            f'Unsupported property names {invalid_names}, '
+            'must match git-config variable syntax (a-z0-9 and - characters)')
+
+
+def _get_cred_cfg_var(name, prop):
+    """Return a config variable name for a credential property
+
+    Parameters
+    ----------
+    name : str
+      Credential name
+    prop : str
+      Property name
+
+    Returns
+    -------
+    str
+    """
+    return f'datalad.credential.{name}.{prop}'

--- a/datalad/distributed/tests/test_create_sibling_ghlike.py
+++ b/datalad/distributed/tests/test_create_sibling_ghlike.py
@@ -35,10 +35,6 @@ def test_invalid_call(path):
     # no dataset
     assert_raises(ValueError, create_sibling_gin, 'bogus', dataset=path)
     ds = Dataset(path).create()
-    # without authorization
-    # force disable any configured token
-    with patch('datalad.distributed.create_sibling_ghlike.Token', None):
-        assert_raises(ValueError, ds.create_sibling_gin, 'bogus')
     # unsupported name
     assert_raises(
         ValueError,

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -80,6 +80,7 @@ _group_3misc = (
     'Miscellaneous commands',
     [
         ('datalad.local.configuration', 'Configuration'),
+        ('datalad.local.credentials', 'Credentials'),
         ('datalad.local.wtf', 'WTF'),
         ('datalad.local.clean', 'Clean'),
         ('datalad.local.add_archive_content', 'AddArchiveContent'),

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -107,6 +107,19 @@ definitions = {
         'type': EnsureBool(),
         'default': False,
     },
+    'datalad.credentials.repeat-secret-entry': {
+        'ui': ('yesno', {
+               'title': 'Require entering secrets twice for interactive '
+                        'specification?'}),
+        'type': EnsureBool(),
+        'default': True,
+    },
+    'datalad.credentials.hidden-secret-entry': {
+        'ui': ('yesno', {
+               'title': 'Hide secret in interactive entry?'}),
+        'type': EnsureBool(),
+        'default': True,
+    },
     'datalad.credentials.githelper.noninteractive':{
         'ui': ('yesno', {
                'title': 'Non-interactive mode for git-credential helper',

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -452,34 +452,36 @@ def eval_results(wrapped):
 
 
 def generic_result_renderer(res):
-    if res.get('status', None) != 'notneeded':
-        path = res.get('path', None)
-        if path and res.get('refds'):
-            try:
-                path = relpath(path, res['refds'])
-            except ValueError:
-                # can happen, e.g., on windows with paths from different
-                # drives. just go with the original path in this case
-                pass
-        ui.message('{action}({status}):{path}{type}{msg}{err}'.format(
-            action=ac.color_word(
-                res.get('action', '<action-unspecified>'),
-                ac.BOLD),
-            status=ac.color_status(res.get('status', '<status-unspecified>')),
-            path=' {}'.format(path) if path else '',
-            type=' ({})'.format(
-                ac.color_word(res['type'], ac.MAGENTA)
-            ) if 'type' in res else '',
-            msg=' [{}]'.format(
-                res['message'][0] % res['message'][1:]
-                if isinstance(res['message'], tuple) else res[
-                    'message'])
-            if res.get('message', None) else '',
-            err=ac.color_word(' [{}]'.format(
-                res['error_message'][0] % res['error_message'][1:]
-                if isinstance(res['error_message'], tuple) else res[
-                    'error_message']), ac.RED)
-            if res.get('error_message', None) and res.get('status', None) != 'ok' else ''))
+    if res.get('status', None) == 'notneeded':
+        return
+
+    path = res.get('path', None)
+    if path and res.get('refds'):
+        try:
+            path = relpath(path, res['refds'])
+        except ValueError:
+            # can happen, e.g., on windows with paths from different
+            # drives. just go with the original path in this case
+            pass
+    ui.message('{action}({status}):{path}{type}{msg}{err}'.format(
+        action=ac.color_word(
+            res.get('action', '<action-unspecified>'),
+            ac.BOLD),
+        status=ac.color_status(res.get('status', '<status-unspecified>')),
+        path=' {}'.format(path) if path else '',
+        type=' ({})'.format(
+            ac.color_word(res['type'], ac.MAGENTA)
+        ) if 'type' in res else '',
+        msg=' [{}]'.format(
+            res['message'][0] % res['message'][1:]
+            if isinstance(res['message'], tuple) else res[
+                'message'])
+        if res.get('message', None) else '',
+        err=ac.color_word(' [{}]'.format(
+            res['error_message'][0] % res['error_message'][1:]
+            if isinstance(res['error_message'], tuple) else res[
+                'error_message']), ac.RED)
+        if res.get('error_message', None) and res.get('status', None) != 'ok' else ''))
 
 
 # keep for legacy compatibility

--- a/datalad/local/configuration.py
+++ b/datalad/local/configuration.py
@@ -33,7 +33,7 @@ from datalad.interface.common_opts import (
 )
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import (
-    default_result_renderer,
+    generic_result_renderer,
     eval_results,
 )
 from datalad.support.constraints import (
@@ -237,7 +237,7 @@ class Configuration(Interface):
                 res['message'] = '{}{}'.format(
                     res['name'],
                     suffix)
-            default_result_renderer(res)
+            generic_result_renderer(res)
             return
         # TODO source
         from datalad.ui import ui

--- a/datalad/local/credentials.py
+++ b/datalad/local/credentials.py
@@ -342,15 +342,24 @@ class Credentials(Interface):
         # renderer can be used
         if 'name' in res:
             res['action'] = res['name']
-        res['status'] = res.get('cred_type', 'secret')
+        res['status'] = '{} {}'.format(
+            res.get('cred_type', 'secret'),
+            '✓' if res.get('cred_secret') else '✗',
+        )
+
         if 'message' not in res:
             # give the names of all properties
             # but avoid duplicating the type, hide the prefix,
             # add removal marker for vanished properties
             res['message'] = ','.join(
-                p[5:] if res[p] else f':{p[5:]}' for p in res
-                if p.startswith('cred_') and p not in (
-                    'cred_secret', 'cred_type'))
+                '{}{}{}{}'.format(
+                    f':{p[5:]}' if res[p] is None else p[5:],
+                    '' if res[p] is None else '=',
+                    '' if res[p] is None else res[p][:25],
+                    '…' if res[p] and len(res[p]) > 25 else '',
+                )
+                for p in sorted(res)
+                if p.startswith('cred_') and p not in ('cred_type', 'cred_secret'))
         generic_result_renderer(res)
 
 

--- a/datalad/local/credentials.py
+++ b/datalad/local/credentials.py
@@ -59,6 +59,7 @@ class Credentials(Interface):
 
     The command provides four basic actions:
 
+
     QUERY
 
     When executed without any property specification, all known credentials
@@ -73,15 +74,6 @@ class Credentials(Interface):
     used, for example, to discover all suitable credentials for a specific
     "realm", if credentials were annotated with such information.
 
-    GET
-
-    This is a read-only action that will never alter credential properties or
-    secrets. Given properties will amend/overwrite those already on record.
-    When properties with no value are given, and also no value for the
-    respective properties is on record yet, their value will be requested
-    interactively, if a ``prompt||--prompt`` text was provided too. This can be
-    used to ensure a complete credential record, comprising any number of
-    properties.
 
     SET
 
@@ -94,10 +86,26 @@ class Credentials(Interface):
 
     Only changed properties will be contained in the result record.
 
+    The appearance of the interactive secret entry can be configured with
+    the two settings `datalad.credentials.repeat-secret-entry` and
+    `datalad.credentials.hidden-secret-entry`.
+
+
     REMOVE
 
     This action will remove any secret and properties associated with a
     credential identified by its name.
+
+
+    GET (plumbing operation)
+
+    This is a *read-only* action that will never store (updates of) credential
+    properties or secrets. Given properties will amend/overwrite those already
+    on record.  When properties with no value are given, and also no value for
+    the respective properties is on record yet, their value will be requested
+    interactively, if a ``prompt||--prompt`` text was provided too. This can be
+    used to ensure a complete credential record, comprising any number of
+    properties.
 
 
     Details on credentials
@@ -148,7 +156,8 @@ class Credentials(Interface):
     DataLad credentials not configured via this command may not be fully
     discoverable (i.e., including all their properties). Discovery of
     such legacy credentials can be assisted by specifying a dedicated
-    'type' property    """
+    'type' property.
+    """
     result_renderer = 'tailored'
 
     _params_ = dict(
@@ -196,25 +205,29 @@ class Credentials(Interface):
     )
 
     _examples_ = [
-        dict(text="List known credentials",
-             code_py="credentials(action='query')",
-             code_cmd="datalad credentials query"),
+        dict(text="Report all discoverable credentials",
+             code_py="credentials()",
+             code_cmd="datalad credentials"),
         dict(
             text="Set a new credential mycred & input its secret interactively",
-            code_py="credentials(action='set', name='mycred')",
+            code_py="credentials('set', name='mycred')",
             code_cmd="datalad credentials set mycred"),
-        dict(text="""Specify the 'type' property of a legacy credential to make it discoverable""",
-             code_py="""credentials(action='set', name='legacycred', spec={'type': 'user_password')""",
-             code_cmd="""datalad credentials set legacycred type='user_password'"""),
-        dict(text="Remove a credentials' type property",
-             code_py="""credentials(action='set', name='mycred', spec={'type': None})""",
+        dict(text="Remove a credential's type property",
+             code_py="credentials('set', name='mycred', spec={'type': None})",
              code_cmd="datalad credentials set mycred :type"),
-        dict(text="Get all information on a specific credential",
-             code_py="credentials(action='query', name='mycred')",
-             code_cmd="datalad -f json_pp credentials get mycred"),
-        dict(text="""Interactively query for a secret and an additional property for a yet unknown credential (useful for further use by an application, will not be stored in the credential manager!)""",
-             code_py="credentials(action='get', prompt='Can I haz info plz?', name='newcred', spec={'newproperty': None)",
-             code_cmd="""datalad credentials --prompt 'can I haz info plz?' get newcred :newproperty"""),
+        dict(text="Get all information on a specific credential in a structured record",
+             code_py="credentials('get', name='mycred')",
+             code_cmd="datalad -f json credentials get mycred"),
+        dict(text="Upgrade a legacy credential by annotating it with a 'type' property",
+             code_py="credentials('set', name='legacycred', spec={'type': 'user_password')",
+             code_cmd="datalad credentials set legacycred type=user_password"),
+        dict(text="Obtain a (possibly yet undefined) credential with a minimum set of "
+                  "properties. All missing properties and secret will be "
+                  "prompted for, no information will be stored! "
+                  "This is mostly useful for ensuring availability of an "
+                  "appropriate credential in an application context",
+             code_py="credentials('get', prompt='Can I haz info plz?', name='newcred', spec={'newproperty': None})",
+             code_cmd="datalad credentials --prompt 'can I haz info plz?' get newcred :newproperty"),
     ]
 
     @staticmethod

--- a/datalad/local/credentials.py
+++ b/datalad/local/credentials.py
@@ -1,0 +1,390 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See LICENSE file distributed along with the datalad_osf package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Credential management and query"""
+
+__docformat__ = 'restructuredtext'
+
+import json
+import logging
+import re
+
+from datalad import (
+    cfg as dlcfg,
+)
+from datalad.credman import (
+    CredentialManager,
+    verify_property_names,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.support.exceptions import CapturedException
+from datalad.support.param import Parameter
+from datalad.distribution.dataset import (
+    datasetmethod,
+    EnsureDataset,
+    require_dataset,
+)
+from datalad.interface.results import (
+    get_status_dict,
+)
+from datalad.interface.utils import (
+    eval_results,
+    generic_result_renderer,
+)
+from datalad.support.constraints import (
+    EnsureChoice,
+    EnsureNone,
+    EnsureStr,
+)
+
+lgr = logging.getLogger('datalad.local.credentials')
+
+credential_actions = ('query', 'get', 'set', 'remove')
+
+
+@build_doc
+class Credentials(Interface):
+    """Credential management and query
+
+    This command enables inspection and manipulation of credentials used
+    throughout DataLad.
+
+    The command provides four basic actions:
+
+    QUERY
+
+    When executed without any property specification, all known credentials
+    with all their properties will be yielded. Please note that this may not
+    include credentials that only comprise of a secret and no other properties,
+    or legacy credentials for which no trace in the configuration can be found.
+    Therefore, the query results are not guaranteed to contain all credentials
+    ever configured by DataLad.
+
+    When additional property/value pairs are specified, only credentials that
+    have matching values for all given properties will be reported. This can be
+    used, for example, to discover all suitable credentials for a specific
+    "realm", if credentials were annotated with such information.
+
+    GET
+
+    This is a read-only action that will never alter credential properties or
+    secrets. Given properties will amend/overwrite those already on record.
+    When properties with no value are given, and also no value for the
+    respective properties is on record yet, their value will be requested
+    interactively, if a ``prompt||--prompt`` text was provided too. This can be
+    used to ensure a complete credential record, comprising any number of
+    properties.
+
+    SET
+
+    This is the companion to 'get', and can be used to store properties and
+    secret of a credential. Importantly, and in contrast to a 'get' operation,
+    given properties with no values indicate a removal request. Any matching
+    properties on record will be removed. If a credential is to be stored for
+    which no secret is on record yet, an interactive session will prompt a user
+    for a manual secret entry.
+
+    Only changed properties will be contained in the result record.
+
+    REMOVE
+
+    This action will remove any secret and properties associated with a
+    credential identified by its name.
+
+
+    Details on credentials
+
+    A credential comprises any number of properties, plus exactly one secret.
+    There are no constraints on the format or property values or the secret,
+    as long as they are encoded as a string.
+
+    Credential properties are normally stored as configuration settings in a
+    user's configuration ('global' scope) using the naming scheme:
+
+      `datalad.credential.<name>.<property>`
+
+    Therefore both credential name and credential property name must be
+    syntax-compliant with Git configuration items. For property names this
+    means only alphanumeric characters and dashes. For credential names
+    virtually no naming restrictions exist (only null-byte and newline are
+    forbidden). However, when naming credentials it is recommended to use
+    simple names in order to enable convenient one-off credential overrides
+    by specifying DataLad configuration items via their environment variable
+    counterparts (see the documentation of the ``configuration`` command
+    for details. In short, avoid underscores and special characters other than
+    '.' and '-'.
+
+    While there are no constraints on the number and nature of credential
+    properties, a few particular properties are recognized on used for
+    particular purposes:
+
+    - 'secret': always refers to the single secret of a credential
+    - 'type': identifies the type of a credential. With each standard type,
+      a list of mandatory properties is associated (see below)
+    - 'last-used': is an ISO 8601 format time stamp that indicated the
+      last (successful) usage of a credential
+
+    Standard credential types and properties
+
+    The following standard credential types are recognized, and their
+    mandatory field with their standard names will be automatically
+    included in a 'get' report.
+
+    - 'user_password': with properties 'user', and the password as secret
+    - 'token': only comprising the token as secret
+    - 'aws-s3': with properties 'key-id', 'session', 'expiration', and the
+      secret_id as the credential secret
+
+    Legacy support
+
+    DataLad credentials not configured via this command may not be fully
+    discoverable (i.e., including all their properties). Discovery of
+    such legacy credentials can be assisted by specifying a dedicated
+    'type' property    """
+    result_renderer = 'tailored'
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify a dataset whose configuration to inspect
+            rather than the global (user) settings""",
+            constraints=EnsureDataset() | EnsureNone()),
+        action=Parameter(
+            args=("action",),
+            nargs='?',
+            doc="""which action to perform""",
+            constraints=EnsureChoice(*credential_actions)),
+        name=Parameter(
+            # exclude from CLI
+            args=tuple(),
+            doc="""name of a credential to set, get, or remove.""",
+            constraints=EnsureStr() | EnsureNone()),
+        spec=Parameter(
+            args=("spec",),
+            doc="""specification of[CMD:  a credential name and CMD]
+            credential properties. Properties are[CMD:  either CMD] given as
+            name/value pairs[CMD:  or as a property name prefixed
+            by a colon CMD].
+            Properties with [CMD: no CMD][PY: a `None` PY] value
+            indicate a property to be deleted (action 'set'), or a
+            property to be entered interactively, when no value is set
+            yet, and a prompt text is given (action 'get').
+            All property names are case-insensitive, must start with
+            a letter or a digit, and may only contain '-' apart from
+            these characters.
+            [PY: Property specifications should be given a as dictionary.
+            However, a CLI-like list of string arguments is also
+            supported PY]""",
+            nargs='*',
+            metavar='[name] [:]property[=value]'),
+        prompt=Parameter(
+            args=("--prompt",),
+            doc="""message to display when entry of missing credential
+            properties is required for action 'get'. This can be used
+            to present information on the nature of a credential and
+            for instructions on how to obtain a credential""",
+            constraints=EnsureStr() | EnsureNone()),
+    )
+
+    @staticmethod
+    @datasetmethod(name='credentials')
+    @eval_results
+    def __call__(action='query', spec=None, *, name=None, prompt=None,
+                 dataset=None):
+        if action not in credential_actions:
+            raise ValueError(f"Unknown action {action!r}")
+
+        if action in ('get', 'set', 'remove') and not name and spec \
+                and isinstance(spec, list):
+            # spec came in like from the CLI (but doesn't have to be from
+            # there) and we have no name set
+            if spec[0][0] != ':' and '=' not in spec[0]:
+                name = spec[0]
+                spec = spec[1:]
+
+        # `spec` could be many things, make uniform dict
+        specs = normalize_specs(spec)
+
+        if action in ('set', 'remove') and not name:
+            raise ValueError(
+                f"Credential name must be provided for action {action!r}")
+        if action == 'get' and not name and not spec:
+            raise ValueError(
+                "Cannot get credential properties when no name and no "
+                "property specification is provided")
+
+        # which config manager to use: global or from dataset
+        cfg = require_dataset(
+            dataset,
+            # we do not actually need it
+            check_installed=False,
+            purpose='manage credentials').config if dataset else dlcfg
+
+        credman = CredentialManager(cfg)
+
+        if action == 'set':
+            try:
+                updated = credman.set(name, **specs)
+            except Exception as e:
+                yield get_status_dict(
+                    action='credentials',
+                    status='error',
+                    name=name,
+                    message='could not set credential properties',
+                    exception=CapturedException(e),
+                )
+                return
+            yield get_status_dict(
+                action='credentials',
+                status='ok',
+                name=name,
+                **_prefix_result_keys(updated),
+            )
+        elif action == 'get':
+            cred = credman.get(name=name, _prompt=prompt, **specs)
+            if not cred:
+                yield get_status_dict(
+                    action='credentials',
+                    status='error',
+                    name=name,
+                    message='credential not found',
+                )
+            else:
+                yield get_status_dict(
+                    action='credentials',
+                    status='ok',
+                    name=name,
+                    **_prefix_result_keys(cred),
+                )
+        elif action == 'remove':
+            try:
+                removed = credman.remove(name, type_hint=specs.get('type'))
+            except Exception as e:
+                yield get_status_dict(
+                    action='credentials',
+                    status='error',
+                    name=name,
+                    message='could not remove credential properties',
+                    exception=CapturedException(e),
+                )
+                return
+            yield get_status_dict(
+                action='credentials',
+                status='ok' if removed else 'notneeded',
+                name=name,
+            )
+        elif action == 'query':
+            for name, cred in credman.query_(**specs):
+                yield get_status_dict(
+                    action='credentials',
+                    status='ok',
+                    name=name,
+                    type='credential',
+                    **_prefix_result_keys(cred),
+                )
+        else:
+            raise RuntimeError('Impossible state reached')  # pragma: no cover
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        # we only handle our own stuff in a custom fashion, the rest is generic
+        if res['action'] != 'credentials':
+            generic_result_renderer(res)
+            return
+        # must make a copy, because we modify the record in-place
+        # https://github.com/datalad/datalad/issues/6560
+        res = res.copy()
+        # the idea here is to twist the result records such that the generic
+        # renderer can be used
+        if 'name' in res:
+            res['action'] = res['name']
+        res['status'] = res.get('cred_type', 'secret')
+        if 'message' not in res:
+            # give the names of all properties
+            # but avoid duplicating the type, hide the prefix,
+            # add removal marker for vanished properties
+            res['message'] = ','.join(
+                p[5:] if res[p] else f':{p[5:]}' for p in res
+                if p.startswith('cred_') and p not in (
+                    'cred_secret', 'cred_type'))
+        generic_result_renderer(res)
+
+
+def normalize_specs(specs):
+    """Normalize all supported `spec` argument values for `credentials`
+
+    Parameter
+    ---------
+    specs: JSON-formatted str or list
+
+    Returns
+    -------
+    dict
+        Keys are the names of any property (with removal markers stripped),
+        and values are `None` whenever property removal is desired, and
+        not `None` for any value to be stored.
+
+    Raises
+    ------
+    ValueError
+      For missing values, missing removal markers, and invalid JSON input
+    """
+    if not specs:
+        return {}
+    elif isinstance(specs, str):
+        try:
+            specs = json.loads(specs)
+        except json.JSONDecodeError as e:
+            raise ValueError('Invalid JSON input') from e
+    if isinstance(specs, list):
+        # convert property assignment list
+        specs = [
+            (str(s[0]), str(s[1]))
+            if isinstance(s, tuple) else
+            (str(s),)
+            if '=' not in s else
+            (tuple(s.split('=', 1)))
+            for s in specs
+        ]
+    if isinstance(specs, list):
+        missing = [
+            i for i in specs
+            if (len(i) == 1 and i[0][0] != ":") or (
+                len(i) > 1 and (i[0][0] == ':' and i[1] is not None))
+        ]
+    else:
+        missing = [
+            k for k, v in specs.items()
+            if k[0] == ":" and v is not None
+        ]
+    if missing:
+        raise ValueError(
+            f'Value or unset flag ":" missing for property {missing!r}')
+    if isinstance(specs, list):
+        # expand absent values in tuples to ease conversion to dict below
+        specs = [(i[0], i[1] if len(i) > 1 else None) for i in specs]
+    # apply "unset marker"
+    specs = {
+        # this stuff goes to git-config, is therefore case-insensitive
+        # and we should normalize right away
+        (k[1:] if k[0] == ':' else k).lower():
+        None if k[0] == ':' else v
+        for k, v in (specs.items() if isinstance(specs, dict) else specs)
+    }
+    verify_property_names(specs)
+    return specs
+
+
+def _prefix_result_keys(props):
+    return {
+        f'cred_{k}' if not k.startswith('_') else k[1:]: v
+        for k, v in props.items()
+    }

--- a/datalad/local/credentials.py
+++ b/datalad/local/credentials.py
@@ -180,9 +180,10 @@ class Credentials(Interface):
             All property names are case-insensitive, must start with
             a letter or a digit, and may only contain '-' apart from
             these characters.
-            [PY: Property specifications should be given a as dictionary.
+            [PY: Property specifications should be given a as dictionary,
+            e.g., spec={'type': 'user_password'}.
             However, a CLI-like list of string arguments is also
-            supported PY]""",
+            supported, e.g., spec=['type=user_password'] PY]""",
             nargs='*',
             metavar='[name] [:]property[=value]'),
         prompt=Parameter(

--- a/datalad/local/credentials.py
+++ b/datalad/local/credentials.py
@@ -169,7 +169,7 @@ class Credentials(Interface):
             constraints=EnsureStr() | EnsureNone()),
         spec=Parameter(
             args=("spec",),
-            doc="""specification of[CMD:  a credential name and CMD]
+            doc="""specification of[CMD: a credential name and CMD]
             credential properties. Properties are[CMD:  either CMD] given as
             name/value pairs[CMD:  or as a property name prefixed
             by a colon CMD].

--- a/datalad/local/credentials.py
+++ b/datalad/local/credentials.py
@@ -195,6 +195,28 @@ class Credentials(Interface):
             constraints=EnsureStr() | EnsureNone()),
     )
 
+    _examples_ = [
+        dict(text="List known credentials",
+             code_py="credentials(action='query')",
+             code_cmd="datalad credentials query"),
+        dict(
+            text="Set a new credential mycred & input its secret interactively",
+            code_py="credentials(action='set', name='mycred')",
+            code_cmd="datalad credentials set mycred"),
+        dict(text="""Specify the 'type' property of a legacy credential to make it discoverable""",
+             code_py="""credentials(action='set', name='legacycred', spec={'type': 'user_password')""",
+             code_cmd="""datalad credentials set legacycred type='user_password'"""),
+        dict(text="Remove a credentials' type property",
+             code_py="""credentials(action='set', name='mycred', spec={'type': None})""",
+             code_cmd="datalad credentials set mycred :type"),
+        dict(text="Get all information on a specific credential",
+             code_py="credentials(action='query', name='mycred')",
+             code_cmd="datalad -f json_pp credentials get mycred"),
+        dict(text="""Interactively query for a secret and an additional property for a yet unknown credential (useful for further use by an application, will not be stored in the credential manager!)""",
+             code_py="credentials(action='get', prompt='Can I haz info plz?', name='newcred', spec={'newproperty': None)",
+             code_cmd="""datalad credentials --prompt 'can I haz info plz?' get newcred :newproperty"""),
+    ]
+
     @staticmethod
     @datasetmethod(name='credentials')
     @eval_results

--- a/datalad/local/credentials.py
+++ b/datalad/local/credentials.py
@@ -173,7 +173,7 @@ class Credentials(Interface):
             credential properties. Properties are[CMD:  either CMD] given as
             name/value pairs[CMD:  or as a property name prefixed
             by a colon CMD].
-            Properties with [CMD: no CMD][PY: a `None` PY] value
+            Properties [CMD: prefixed with a colon CMD][PY: with a `None` value PY] 
             indicate a property to be deleted (action 'set'), or a
             property to be entered interactively, when no value is set
             yet, and a prompt text is given (action 'get').

--- a/datalad/local/tests/test_credentials.py
+++ b/datalad/local/tests/test_credentials.py
@@ -1,0 +1,194 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# -*- coding: utf-8 -*-
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+
+"""
+import logging
+from unittest.mock import patch
+
+from datalad.cli.tests.test_main import run_main
+from datalad.local.credentials import (
+    Credentials,
+    normalize_specs,
+)
+from datalad.support.keyring_ import MemoryKeyring
+from datalad.tests.utils import (
+    assert_in,
+    assert_in_results,
+    assert_raises,
+    eq_,
+    swallow_logs,
+    with_testsui,
+)
+
+
+# helper to test error handling
+class BrokenCredentialManager(object):
+    def __init__(*args, **kwargs):
+        pass
+
+    def set(self, *args, **kwargs):
+        raise RuntimeError('INTENTIONAL FAILURE')
+
+    def remove(self, *args, **kwargs):
+        raise RuntimeError('INTENTIONAL FAILURE')
+
+    def get(self, *args, **kwargs):
+        # if there is no secret
+        return None
+
+
+def test_normalize_specs():
+    for i, o in (
+            ('', {}),
+            ('{}', {}),
+            ([], {}),
+            # indicate removal
+            ([':mike'], {'mike': None}),
+            (['this=that'], {'this': 'that'}),
+            # not removal without : prefix
+            (['empty='], {'empty': ''}),
+            # multiple works
+            (['this=that', ':mike'], {'this': 'that', 'mike': None}),
+            # complete specs dict needs no removal marker
+            ('{"this":"that","mike":null}', {'this': 'that', 'mike': None}),
+            # list-spec, but as JSON
+            ('["this=that", ":mike"]', {'this': 'that', 'mike': None}),
+    ):
+        eq_(normalize_specs(i), o)
+
+    for error in (
+            # no removal marker
+            ['mike'],
+            # any string would be JSON and must be valid
+            'brokenjson'
+    ):
+        assert_raises(ValueError, normalize_specs, error)
+
+
+def test_credentials():
+    # we want all tests to bypass the actual system keyring
+    with patch('datalad.support.keyring_.keyring', MemoryKeyring()):
+        check_credentials_cli()
+        check_interactive_entry_set()
+        check_interactive_entry_get()
+
+
+def test_errorhandling_smoketest():
+    callcfg = dict(on_failure='ignore', result_renderer='disabled')
+
+    with patch('datalad.local.credentials.CredentialManager', BrokenCredentialManager):
+        cred = Credentials()
+        assert_in_results(
+            cred('set', name='dummy', **callcfg),
+            status='error', name='dummy')
+        assert_in_results(
+            cred('remove', name='dummy', **callcfg),
+            status='error', name='dummy')
+
+
+
+def check_credentials_cli():
+    # usable command
+    cred = Credentials()
+    # unknown action
+    assert_raises(ValueError, cred, 'levitate')
+    with swallow_logs(new_level=logging.ERROR) as cml:
+        # it is a shame that the error is not coming out on
+        # stderr
+        run_main(['credentials', 'set'], exit_code=1)
+        cml.assert_logged('.*name must be provided')
+    # catch missing `name` via Python call too
+    assert_raises(ValueError, cred, 'set', spec=[':mike'])
+    # no name and no property
+    assert_raises(ValueError, cred, 'get')
+
+    assert_in_results(
+        cred('get', name='donotexiststest', on_failure='ignore',
+             result_renderer='disabled'),
+        status='error',
+        name='donotexiststest',
+    )
+
+    # we are not getting a non-existing credential, and it is also
+    # not blocking for input with a non-interactive session
+    assert_in(
+        'credential not found',
+        run_main(['credentials', 'get', 'donotexiststest'], exit_code=1)[0]
+    )
+
+    # set a credential CLI
+    run_main(
+        ['credentials', 'set', 'mycred', 'secret=some', 'user=mike'],
+        exit_code=0)
+    # which we can retrieve
+    run_main(['credentials', 'get', 'mycred'], exit_code=0)
+    # query runs without asking for input, and comes back clean
+    assert_in(
+        'some',
+        run_main(['-f', 'json', 'credentials', 'query'], exit_code=0)[0])
+    # and remove
+    run_main(['credentials', 'remove', 'mycred'], exit_code=0)
+    # nothing bad on second attempt
+    run_main(['credentials', 'remove', 'mycred'], exit_code=0)
+    # query runs without asking for input, and comes back clean
+    run_main(['credentials', 'query'], exit_code=0)
+
+
+@with_testsui(responses=['attr1', 'attr2', 'secret'])
+def check_interactive_entry_get():
+    # should ask all properties in order and the secret last
+    cred = Credentials()
+    assert_in_results(
+        cred('get',
+             name='myinteractive_get',
+             # use CLI notation
+             spec=[':attr1', ':attr2'],
+             prompt='dummyquestion',
+             result_renderer='disabled'),
+        cred_attr1='attr1',
+        cred_attr2='attr2',
+        cred_secret='secret',
+    )
+
+
+@with_testsui(responses=['secretish'])
+def check_interactive_entry_set():
+    # should ask all properties in order and the secret last
+    cred = Credentials()
+    assert_in_results(
+        cred('set',
+             name='myinteractive_set',
+             prompt='dummyquestion',
+             result_renderer='disabled'),
+        cred_secret='secretish',
+    )
+
+
+def test_result_renderer():
+    # it must survive a result that is not from the command itself
+    Credentials.custom_result_renderer(dict(
+        action='weird',
+        status='broken',
+    ))
+
+
+def test_extreme_credential_name():
+    cred = Credentials()
+    extreme = 'ΔЙקم๗あ |/;&%b5{}"'
+    with patch('datalad.support.keyring_.keyring', MemoryKeyring()):
+        assert_in_results(
+            cred('set',
+                 name=extreme,
+                 # use CLI style spec to exercise more code
+                 spec=[f'someprop={extreme}', f'secret={extreme}'],
+            ),
+            cred_someprop=extreme,
+            cred_secret=extreme,
+        )

--- a/datalad/tests/test_credman.py
+++ b/datalad/tests/test_credman.py
@@ -1,0 +1,152 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# -*- coding: utf-8 -*-
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+
+"""
+from unittest.mock import patch
+
+from datalad.config import ConfigManager
+from datalad.distribution.dataset import Dataset
+from datalad.credman import (
+    CredentialManager,
+    _get_cred_cfg_var,
+)
+from datalad.support.keyring_ import MemoryKeyring
+from datalad.tests.utils import (
+    assert_in,
+    assert_not_in,
+    assert_raises,
+    eq_,
+    patch_config,
+    with_tempfile,
+)
+
+
+def test_credmanager():
+    # we want all tests to bypass the actual system keyring
+    with patch('datalad.support.keyring_.keyring', MemoryKeyring()):
+        check_credmanager()
+
+
+def check_credmanager():
+    cfg = ConfigManager()
+    credman = CredentialManager(cfg)
+    # doesn't work with thing air
+    assert_raises(ValueError, credman.get)
+    eq_(credman.get('donotexiststest'), None)
+    eq_(credman.get(crazy='empty'), None)
+    # smoke test for legacy credential retrieval code
+    eq_(credman.get('donotexiststest', type='user_password'), None)
+    # does not fiddle with a secret that is readily provided
+    eq_(credman.get('dummy', secret='mike', _type_hint='token'),
+        dict(type='token', secret='mike'))
+
+    # no instructions what to do, no legacy entry, nothing was changed
+    # but the secret was written to the keystore
+    eq_(credman.set('mycred', secret='some'), dict(secret='some'))
+    # redo but with timestep
+    assert_in('last-used',
+              credman.set('lastusedcred', _lastused=True, secret='some'))
+    # first property store attempt
+    eq_(credman.set('changed', secret='some', prop='val'),
+        dict(secret='some', prop='val'))
+    # second, no changing the secret, but changing the prop, albeit with
+    # the same value, change report should be empty
+    eq_(credman.set('changed', prop='val'), dict())
+    # change secret, with value pulled from config
+    try:
+        cfg.set('datalad.credential.changed.secret', 'envsec',
+                scope='override')
+        eq_(credman.set('changed', secret=None), dict(secret='envsec'))
+    finally:
+        cfg.unset('datalad.credential.changed.secret', scope='override')
+
+    # remove non-existing property, secret not report, because unchanged
+    eq_(credman.set('mycred', dummy=None), dict(dummy=None))
+    assert_not_in(_get_cred_cfg_var("mycred", "dummy"), cfg)
+
+    # set property
+    eq_(credman.set('mycred', dummy='good', this='that'),
+        dict(dummy='good', this='that'))
+    # ensure set
+    eq_(credman.get('mycred'), dict(dummy='good', this='that', secret='some'))
+    # remove individual property
+    eq_(credman.set('mycred', dummy=None), dict(dummy=None))
+    # ensure removal
+    eq_(credman.get('mycred'), dict(this='that', secret='some'))
+
+    # test full query and constrained query
+    q = list(credman.query_())
+    eq_(len(q), 3)
+    # now query for one of the creds created above
+    q = list(credman.query_(prop='val'))
+    eq_(len(q), 1)
+    eq_(q[0][0], 'changed')
+    eq_(q[0][1]['prop'], 'val')
+    # and now a query with no match
+    q = list(credman.query_(prop='val', funky='town'))
+    eq_(len(q), 0)
+
+    # remove complete credential
+    credman.remove('mycred')
+    eq_(credman.get('mycred'), None)
+
+
+@with_tempfile
+def test_credman_local(path):
+    ds = Dataset.create(path)
+    credman = CredentialManager(ds.config)
+
+    # deposit a credential into the dataset's config, and die trying to
+    # remove it
+    ds.config.set('datalad.credential.stupid.secret', 'really', scope='branch')
+    assert_raises(RuntimeError, credman.remove, 'stupid')
+
+    # but it manages for the local scope
+    ds.config.set('datalad.credential.notstupid.secret', 'really', scope='local')
+    credman.remove('notstupid')
+
+
+def test_query():
+    # we want all tests to bypass the actual system keyring
+    with patch('datalad.support.keyring_.keyring', MemoryKeyring()):
+        check_query()
+
+
+def check_query():
+    cfg = ConfigManager()
+    credman = CredentialManager(cfg)
+    # set a bunch of credentials with a common realm AND timestamp
+    for i in range(3):
+        credman.set(
+            f'cred{i}',
+            _lastused=True,
+            secret=f'diff{i}',
+            realm='http://ex.com/login',
+        )
+    # now a credential with the common realm, but without a timestamp
+    credman.set(
+        'crednotime',
+        _lastused=False,
+        secret='notime',
+        realm='http://ex.com/login',
+    )
+    # and the most recent one (with timestamp) is an unrelated one
+    credman.set('unrelated', _lastused=True, secret='unrelated')
+
+    # now we want all credentials that match the realm, sorted by
+    # last-used timestamp -- most recent first
+    slist = credman.query(realm='http://ex.com/login', _sortby='last-used')
+    eq_(['cred2', 'cred1', 'cred0', 'crednotime'],
+        [i[0] for i in slist])
+    # same now, but least recent first, importantly no timestamp stays last
+    slist = credman.query(realm='http://ex.com/login', _sortby='last-used',
+                          _reverse=False)
+    eq_(['cred0', 'cred1', 'cred2', 'crednotime'],
+        [i[0] for i in slist])

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -119,6 +119,7 @@ Helpers and support utilities
    datalad check-dates: Scan a dataset for dates and timestamps <generated/man/datalad-check-dates>
    datalad configuration: Get and set configuration <generated/man/datalad-configuration>
    datalad create-test-dataset: Test helper <generated/man/datalad-create-test-dataset>
+   datalad credentials: Get and set credentials <generated/man/datalad-credentials>
    datalad download-url: Download helper with support for DataLad's credential system <generated/man/datalad-download-url>
    datalad foreach-dataset: Run a command or Python code on the dataset and/or each of its sub-datasets <generated/man/datalad-foreach-dataset>
    datalad sshrun: Remote command execution using DataLad's connection management <generated/man/datalad-sshrun>

--- a/docs/source/modref.rst
+++ b/docs/source/modref.rst
@@ -96,6 +96,7 @@ Miscellaneous commands
    api.addurls
    api.check_dates
    api.configuration
+   api.credentials
    api.export_archive
    api.export_to_figshare
    api.no_annex
@@ -127,6 +128,7 @@ Configuration management
    :toctree: generated
 
    config
+   credman
 
 Test infrastructure
 ===================


### PR DESCRIPTION
This is a new subsystem aiming to factor out the management of credentials from the downloaders/providers concept into a
standalone system.
    
Importantly, the management of downloaders/providers credentials is supported by the new system, albeit requiring "type hints" for some operations, because downloader/provider credentials are only fully discoverable in the context of a provider (identified by the context of a request).
    
In contrast, the new system considers credentials as a standalone, request independent entity.
    
A credential is discoverable for any number of abitrarily named properties, but is typically (and right now exclusively) identified
by a name.
        
The system of provided operations/actions enables the implementation
of a confirm-function-function-before-storage pattern (see next commit,
ping datalad/datalad#3126).
    
### Demo

The second commit switches `create-sibling-ghlike` to new credential system.
    
The switch also makes the storage of a newly entered credential conditional on a successful authorization, in the spirit of
datalad/datalad#3126.
    
Moreover, stored credentials now contain a `realm` property that identified the API endpoint. This makes it possible to identify
candidates of suitable credentials without having to specific their name, similar to a request context url used by the old
providers setup. Such a lookup is now also implemented and makes the specification of a credential obsolete in most standard scenarios.

### Changelog
#### 💫 Enhancements and new features
- A new credential management system is introduced that enables storage and query of credentials with any number of properties associated with a secret. These properties are stored as regular configuration items, following the scheme `datalad.credential.<name>.<property>`. The special property `secret` lives in a keystore, but can be overriden using the normal configuration mechanisms. The new system continues to support the previous credential storage setup. Fixes #6519
- A new `credentials` command enables query, modification and storage of credentials. Legacy credentials are also supported, but may require the specification of a `type`, such as (`token`, or `user_password`) to be discoverable. Fixes #396
- Two new configuration settings enable controlling how the interactive entry of credential secrets is conducted for the new credential manager: `datalad.credentials.repeat-secret-entry` can be used to turn off the default double-entry of secrets, and `datalad.credentials.hidden-secret-entry` can turn off the default hidden entry of secrets. Fixes #2721