### PR TITLE
BF: account for "No such password" in addition to not found returned by keyring

### DIFF
--- a/datalad/support/keyring_.py
+++ b/datalad/support/keyring_.py
@@ -82,7 +82,8 @@ class Keyring(object):
         try:
             return self.__keyring.delete_password(self._get_service_name(name), field)
         except self.__keyring_mod.errors.PasswordDeleteError as exc:
-            if 'not found' in str(exc):
+            exc_str = str(exc).lower()
+            if 'not found' in exc_str or 'no such password' in exc_str:
                 return
             raise
 


### PR DESCRIPTION
Closes #6552
