### PR TITLE
Deduplicate top-level CLI exception handler output

### DIFF
--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -182,7 +182,7 @@ def _run_with_exception_handler(cmdlineargs):
             exit_code = 3
         else:
             # some unforeseen problem
-            lgr.error('%s (%s)', ce, exc.__class__.__name__)
+            lgr.error('%s (%s)', ce.message, exc.__class__.__name__)
         sys.exit(exit_code)
 
 

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -182,7 +182,7 @@ def _run_with_exception_handler(cmdlineargs):
             exit_code = 3
         else:
             # some unforeseen problem
-            lgr.error('%s (%s)', ce.message, exc.__class__.__name__)
+            lgr.error('%s (%s)', ce.message, ce.name)
         sys.exit(exit_code)
 
 


### PR DESCRIPTION
Whenever an exception reached the `main()` exception handler, it is
converted to a `CapturedException()` and `str(CapturedException)`,
plus the exception type is logged. However, the exception type
is already contained in the `__str__` output:

```
[ERROR  ] ValueError(Value or unset flag ":" missing for property [('ddd',)]) (ValueError)
```

With this change, this duplication is removed and changes the output to

```
[ERROR  ] Value or unset flag ":" missing for property [('ddd',)] (ValueError)
```

This is specifically not identical to the output of
`str(CapturedException())`, in order to maintain the previous spirit of
putting more emphasis on the user-facing message, rather than the
technicality of the specific exception name.

### Changelog
#### 🐛 Bug Fixes
- Remove duplicate exception type in reporting of top-level CLI exception handler. Fixes #6549
