### PR TITLE
Prevent internal download functionality from logging at INFO level

### DIFF
--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -632,7 +632,7 @@ class BaseDownloader(object, metaclass=ABCMeta):
         bytes
           content
         """
-        lgr.info("Fetching %r", url)
+        lgr.debug("Fetching %r", url)
         # Do not return headers, just content
         out = self.access(self._fetch, url, **kwargs)
         return out[0]


### PR DESCRIPTION
See #6545 for the rational. #6545 was unfortunately filed as compound issue, hence
cannot be solved here.

Logging is maintained, but at DEBUG level. This enables using the
downloader functionality when the download is a technical detail (fetch
remote state info) rather then the primary goal (as with data downloads)
-- without unconditionally polluting user-facing output with traced of
internal processing.

It is unclear for which functionality the INFO level message would be or
was possibly essential, but any such functionality should either use
progress logging, or result reporting nowadays.

This remove a line like:

```
[INFO   ] [INFO] Fetching '<URL>/ria-layout-version' 
```

from every attempt to enable a `ria+http` special remote.

### Changelog
#### 🪓 Deprecations and removals
- `BaseDownloader.fetch()` is logging download attempts on DEBUG (previously INFO) level to avoid polluting output of higher-level commands. See #6545
