### PR TITLE
Stop advertising a broken quoting solution for remote commands.

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -79,7 +79,7 @@ from datalad.support.network import (
     PathRI,
     RI,
 )
-from datalad.support.sshconnector import sh_quote
+from datalad.utils import quote_cmdlinearg as sh_quote
 from datalad.support.param import Parameter
 from datalad.utils import (
     make_tempfile,

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -352,7 +352,7 @@ class NoMultiplexSSHConnection(BaseSSHConnection):
 
         It is the callers responsibility to properly quote commands
         for remote execution (e.g. filename with spaces of other special
-        characters). Use the `sh_quote()` from the module for this purpose.
+        characters).
 
         Parameters
         ----------


### PR DESCRIPTION
`quote_cmdlinearg()` uses the local platform to decide on the quoting
style, not the remote.

This change also adjusts an import to make more obvious what helper is being
used.

See datalad/datalad#6522 for details.

### Changelog
Not needed