### PR TITLE
BF: get_special_remotes - fix compatibility with git ~ 2.35.1 where error msg changed

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -804,8 +804,11 @@ class AnnexRepo(GitRepo, RepoInterface):
                 )
             )
         except CommandError as e:
-            if 'Not a valid object name git-annex:remote.log' in e.stderr:
-                # no special remotes configures - might still be in the journal
+            if (
+                ('Not a valid object name git-annex:remote.log' in e.stderr) or  # e.g. git 2.30.2
+                ("fatal: path 'remote.log' does not exist in 'git-annex'" in e.stderr)  # e.g. 2.35.1+next.20220211-1
+            ):
+                # no special remotes configured - might still be in the journal
                 pass
             else:
                 # some unforeseen error


### PR DESCRIPTION
older git

   $> git -c diff.ignoreSubmodules=none cat-file blob git-annex:remote.log
   fatal: Not a valid object name git-annex:remote.log

2.35.1+next.20220211-1

   $> git -c diff.ignoreSubmodules=none cat-file blob git-annex:remote.log
   fatal: path 'remote.log' does not exist in 'git-annex'

Closes #6559

Checked two other spots of 

```shell
(git)lena:~datalad/datalad-maint[bf-newgit]git
$> git grep 'Not a valid object'                                      
datalad/support/annexrepo.py:                ('Not a valid object name git-annex:remote.log' in e.stderr) or  # e.g. git 2.30.2
datalad/support/gitrepo.py:            if "fatal: Not a valid object name" in exc.stderr:
datalad/support/gitrepo.py:            if "fatal: Not a valid object name" in exc.stderr:
```
and they seems to be ok