### PR TITLE
UX/BF: Poking in the dark to enable transfer progress from datalad remote

### DIFF
--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -46,7 +46,10 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
             urls.append(url)
             try:
                 downloaded_path = self._providers.download(
-                    url, path=file, overwrite=True
+                    url, path=file, overwrite=True,
+                    # this is adswa poking in the dark, trying to get progress
+                    # reporting and succeeding for unknown reasons
+                    progress_handler=self.annex.progress
                 )
                 assert(downloaded_path == file)
                 return


### PR DESCRIPTION
I tried to get back a progress bar for file retrieval from ``datalad`` special remotes. This was a purely blind operation (I really don't know special remotes well), but somehow worked, at least for my usecase in #6572.

```
datalad containers-run  --container-name code/containers/repronim-reproin
[INFO   ] Making sure inputs are available (this may take some time) 
Total:   0%|                                    | 0.00/374M [00:00<?, ? Bytes/s]
Get images/r .. --0.9.0.sing:   2%|    | 5.76M/374M [00:04<03:54, 1.57M Bytes/s]
```

Could @yarikoptic and/or @bpoldrack take a look at this, provided it doesn't break the tests?