### PR TITLE
Make sure a download failure reason is always communicated

### DIFF
--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -52,7 +52,10 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
                 return
             except Exception as exc:
                 ce = CapturedException(exc)
-                cause = getattr(exc, '__cause__', None)
+                # if we have a cause, use it, but if not report the top-level
+                # exception, because otherwise user-facing messaging will simply
+                # say "failed"
+                cause = getattr(exc, '__cause__', None) or ce
                 debug_msg = f"Failed to download {url} for key {key}: {ce}"
                 if cause:
                     debug_msg += f' [{cause}]'


### PR DESCRIPTION
Previously, the datalad special remote would report the `__cause__` of an exception, if there was one set -- leading to uninformative error messages of the type:

```
  Failed to download from any of 1 locations [None]
```

for any exception without a declared `__cause__`.

This change falls back on the corresponding `CapturedException` for reporting, whenever no `__cause__` is available. This avoid non-specific error messages.

### Changelog
No needed, likely introduced with change in `master` only.