### PR TITLE
Use yielding annex record calls for `drop`

### DIFF
--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -785,7 +785,6 @@ def _drop_files(ds, repo, paths, force=False, jobs=None):
 
 
 def _postproc_annexdrop_result(res, respath_by_status, ds, **kwargs):
-    # TODO this should extract any error messages and report them!
     res = annexjson2result(
         # annex reports are always about files
         res, ds, type='file', **kwargs)

--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -732,7 +732,7 @@ def _drop_allkeys(ds, repo, force=False, jobs=None):
         cmd.extend(['--jobs', str(jobs)])
 
     try:
-        yield from repo._call_annex_records(cmd)
+        yield from repo._call_annex_records_items_(cmd)
     except CommandError as e:
         # pick up the results captured so far and yield them
         # the error will be amongst them
@@ -765,7 +765,7 @@ def _drop_files(ds, repo, paths, force=False, jobs=None):
     try:
         yield from (
             _postproc_annexdrop_result(res, respath_by_status, ds)
-            for res in repo._call_annex_records(cmd, files=paths)
+            for res in repo._call_annex_records_items_(cmd, files=paths)
         )
     except CommandError as e:
         # pick up the results captured so far and yield them

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1143,6 +1143,93 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         return return_objects
 
+    def _call_annex_records_items_(self,
+                                   args,
+                                   files=None,
+                                   jobs=None,
+                                   git_options=None,
+                                   stdin=None,
+                                   merge_annex_branches=True,
+                                   progress=False,
+                                   **kwargs):
+        """Yielding git-annex command execution with JSON result processing
+
+        `_call_annex()` is used for git-annex command execution, using
+        GeneratorAnnexJsonProtocol. This means _call_annex() will yield
+        results as soon as they are available.
+
+        For a description of the parameters and raised exceptions, please
+        refer to _call_annex_records().
+
+        Returns
+        -------
+        Generator(something)
+        list(dict)
+          List of parsed result records.
+        """
+        protocol_class = GeneratorAnnexJsonProtocol
+
+        args = args[:] + ['--json', '--json-error-messages']
+        if progress:
+            args += ['--json-progress']
+
+        json_objects_received = False
+        try:
+            for json_object in self._call_annex(
+                                      args,
+                                      files=files,
+                                      jobs=jobs,
+                                      protocol=protocol_class,
+                                      git_options=git_options,
+                                      stdin=stdin,
+                                      merge_annex_branches=merge_annex_branches,
+                                      **kwargs):
+                if tuple(json_object) == 1 and json_object.get('info', None):
+                    lgr.info(json_object['info'])
+                else:
+                    json_objects_received = True
+                    yield json_object
+
+        except CommandError as e:
+            # Note: Workaround for not existing files as long as annex doesn't
+            # report it within JSON response:
+            # see http://git-annex.branchable.com/bugs/copy_does_not_reflect_some_failed_copies_in_--json_output/
+            not_existing = [
+                # cut the file path from the middle, no useful delimiter
+                # need to deal with spaces too!
+                line[11:-10] for line in e.stderr.splitlines()
+                if line.startswith('git-annex:') and
+                line.endswith(' not found')
+            ]
+
+            yield from (
+                {
+                    "command": args[0],
+                    "file": f,
+                    "note": "not found",
+                    "success": False,
+                }
+                for f in not_existing
+            )
+
+            # Note: insert additional code here to analyse failure and possibly
+            # raise a custom exception
+
+            # if we didn't raise before, just depend on whether or not we seem
+            # to have some json to return. It should contain information on
+            # failure in keys 'success' and 'note'
+            # TODO: This is not entirely true. 'annex status' may return empty,
+            # while there was a 'fatal:...' in stderr, which should be a
+            # failure/exception
+            # Or if we had empty stdout but there was stderr
+            if json_objects_received is False and e.stderr:
+                raise e
+
+        # In contrast to _call_annex_records, this method does not warn about
+        # additional non-JSON data on stdout, nor does is raise a RuntimeError
+        # if only non-JSON data was received on stdout.
+        return
+
     def call_annex_records(self, args, files=None):
         """Call annex with `--json*` to request structured result records
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1194,23 +1194,8 @@ class AnnexRepo(GitRepo, RepoInterface):
             # Note: Workaround for not existing files as long as annex doesn't
             # report it within JSON response:
             # see http://git-annex.branchable.com/bugs/copy_does_not_reflect_some_failed_copies_in_--json_output/
-            not_existing = [
-                # cut the file path from the middle, no useful delimiter
-                # need to deal with spaces too!
-                line[11:-10] for line in e.stderr.splitlines()
-                if line.startswith('git-annex:') and
-                line.endswith(' not found')
-            ]
-
-            yield from (
-                {
-                    "command": args[0],
-                    "file": f,
-                    "note": "not found",
-                    "success": False,
-                }
-                for f in not_existing
-            )
+            not_existing = _get_non_existing_from_annex_output(e.stderr)
+            yield from _fake_json_for_non_existing(not_existing, args[0])
 
             # Note: insert additional code here to analyse failure and possibly
             # raise a custom exception

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1184,7 +1184,7 @@ class AnnexRepo(GitRepo, RepoInterface):
                                       stdin=stdin,
                                       merge_annex_branches=merge_annex_branches,
                                       **kwargs):
-                if tuple(json_object) == 1 and json_object.get('info', None):
+                if len(json_object) == 1 and json_object.get('info', None):
                     lgr.info(json_object['info'])
                 else:
                     json_objects_received = True

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3857,7 +3857,7 @@ class GeneratorAnnexJsonProtocol(GeneratorMixIn, AnnexJsonProtocol):
         self.send_result(json_object)
 
 
-class GeneratorAnnexJsonNoStderrProtocol(GeneratorMixIn, AnnexJsonProtocol):
+class GeneratorAnnexJsonNoStderrProtocol(GeneratorAnnexJsonProtocol):
     def __init__(self,
                  done_future=None,
                  total_nbytes=None):
@@ -3871,15 +3871,12 @@ class GeneratorAnnexJsonNoStderrProtocol(GeneratorMixIn, AnnexJsonProtocol):
             # let the base class decide what to do with it
         super().pipe_data_received(fd, data)
 
-    def add_to_output(self, json_object):
-        self.send_result(json_object)
-
     def process_exited(self):
         super().process_exited()
         if self.stderr_output:
             raise CommandError(
                 msg="Unexpected stderr output",
-                stderr=self.stderr_output)
+                stderr=self.stderr_output.decode())
 
 
 class AnnexInitOutput(WitlessProtocol, AssemblingDecoderMixIn):

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2653,7 +2653,7 @@ def test_captured_exception():
         assert_raises(CommandError, gen.send, None)
 
 
-@known_failure_windows
+@skip_if_on_windows
 def test_stderr_rejecting_protocol_trigger():
     result_generator = GitWitlessRunner().run(
         "echo ssss >&2",
@@ -2667,7 +2667,7 @@ def test_stderr_rejecting_protocol_trigger():
     assert_true(False)
 
 
-@known_failure_windows
+@skip_if_on_windows
 def test_stderr_rejecting_protocol_ignore():
 
     result_generator = GitWitlessRunner().run(

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2662,7 +2662,7 @@ def test_stderr_rejecting_protocol_trigger():
     try:
         tuple(result_generator)
     except CommandError as e:
-        assert_in(b"ssss", e.stderr)
+        assert_in("ssss", e.stderr)
         return
     assert_true(False)
 


### PR DESCRIPTION
This PR introduces the method `AnnexRepo._call_annex_items_()`, which returns a generator that yields the same results as `AnnexRepo._call_annex()`, but as soon as they are available. The new method is used by `datalad drop`.

Fixes #6578 

- [x] verify error handling is compatible with `AnnexRepo._call_annex()`.

### Changelog
#### 💫 Enhancements and new features
- Improve responsiveness of `datalad drop` in datasets with a large annex.
