### PR TITLE
add an auto_repr_long decorator to BatchedAnnex

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -60,7 +60,7 @@ from datalad.support.exceptions import CapturedException
 from datalad.ui import ui
 import datalad.utils as ut
 from datalad.utils import (
-    auto_repr,
+    auto_repr_long,
     ensure_list,
     on_windows,
     Path,
@@ -3800,7 +3800,7 @@ class AnnexInitOutput(WitlessProtocol, AssemblingDecoderMixIn):
             lgr.info(line.strip())
 
 
-@auto_repr
+@auto_repr_long
 class BatchedAnnex(BatchedCommand):
     """Container for an annex process which would allow for persistent communication
     """

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -42,6 +42,7 @@ from datalad.utils import (
     all_same,
     any_re_search,
     auto_repr,
+    auto_repr_long,
     better_wraps,
     CMD_MAX_ARG,
     Path,
@@ -475,6 +476,23 @@ def test_auto_repr():
         "buga(a=1, b=<<[0, 1, 2, 3, 4++372 chars++ 99]>>, c=<WithoutReprClass>)"
     )
     assert_equal(buga().some(), "some")
+
+    @auto_repr_long
+    class luga:
+        def __init__(self):
+            self.a = 1
+            self.b = list(range(100))
+            self.c = WithoutReprClass()
+            self._c = "protect me"
+
+        def some(self):
+            return "some"
+
+    ok_startswith(
+        repr(luga()),
+        f"luga(a=1, b={list(range(100))}, c="
+    )
+    assert_equal(luga().some(), "some")
 
 
 def test_assure_iter():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -323,7 +323,7 @@ def shortened_repr(value, l=30):
     return value_repr
 
 
-def __auto_repr__(obj):
+def __auto_repr__(obj, shortened: bool = True):
     attr_names = tuple()
     if hasattr(obj, '__dict__'):
         attr_names += tuple(obj.__dict__.keys())
@@ -339,7 +339,8 @@ def __auto_repr__(obj):
         # such as of URL?
         #if value is None:
         #    continue
-        items.append("%s=%s" % (attr, shortened_repr(value)))
+        items.append("%s=%s" % (
+            attr, shortened_repr(value) if shortened else value))
 
     return "%s(%s)" % (obj.__class__.__name__, ', '.join(items))
 
@@ -353,6 +354,18 @@ def auto_repr(cls):
     """
 
     cls.__repr__ = __auto_repr__
+    return cls
+
+
+def auto_repr_long(cls):
+    """Decorator to add an unabbreviated automagic quick and dirty __repr__
+
+    It uses public class attributes to prepare repr of a class
+
+    Original idea: http://stackoverflow.com/a/27799004/1265472
+    """
+
+    cls.__repr__ = lambda obj: __auto_repr__(obj, False)
     return cls
 
 


### PR DESCRIPTION
This PR fixes #6479 

The PR adds a new decorator `auto_repr_long` which provides a similar representation as `auto_repr` but does not abbreviate attribute values.

I have chosen to use `auto_repr_long` instead of changing `auto_repr` to a function with a `abbreviate`-flag in order to keep changes to a minimum

### Changelog
#### 🏠 Internal
- Show full `BatchedAnnex`-attribute values in debug messages
