### PR TITLE
RF: set allowed-url/http in test HOME .git/config instead of config calls per instance

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -233,6 +233,11 @@ def setup_package():
 	askPass =
 [datalad "log"]
 	exc = 1
+[annex "security"]
+	# from annex 6.20180626 file:/// and http://localhost access isn't
+	# allowed by default
+	allowed-url-schemes = http https file
+	allowed-http-addresses = all
 """
         # TODO: split into a function + context manager
         with make_tempfile(mkdir=True) as new_home:
@@ -277,11 +282,6 @@ def setup_package():
         if ev in os.environ and not (os.environ[ev]):
             lgr.debug("Removing %s from the environment since it is empty", ev)
             os.environ.pop(ev)
-
-    # During tests we allow for "insecure" access to local file:// and
-    # http://localhost URLs since all of them either generated as tests
-    # fixtures or cloned from trusted sources
-    AnnexRepo._ALLOW_LOCAL_URLS = True
 
     DATALAD_LOG_LEVEL = os.environ.get('DATALAD_LOG_LEVEL', None)
     if DATALAD_LOG_LEVEL is None:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -143,11 +143,6 @@ class AnnexRepo(GitRepo, RepoInterface):
     repository_versions = None
     _version_kludges = {}
 
-    # Class wide setting to allow insecure URLs. Used during testing, since
-    # git annex 6.20180626 those will by default be not allowed for security
-    # reasons
-    _ALLOW_LOCAL_URLS = False
-
     def __init__(self, path, runner=None,
                  backend=None, always_commit=True,
                  create=True, create_sanity_checks=True,
@@ -302,9 +297,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         if backend:
             self.set_default_backend(backend, persistent=True)
 
-        if self._ALLOW_LOCAL_URLS:
-            self._allow_local_urls()
-
         # will be evaluated lazily
         self._n_auto_jobs = None
 
@@ -316,20 +308,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         # and thereby preventing it from being collected at all.
         self._finalizer = finalize(self, AnnexRepo._cleanup, self.path,
                                    self._batched)
-
-    def _allow_local_urls(self):
-        """Allow URL schemes and addresses which potentially could be harmful.
-
-        For now it is internal method used within tests only
-        """
-        # from annex 6.20180626 file:/// and http://localhost access isn't
-        # allowed by default
-        self.config.add(
-            'annex.security.allowed-url-schemes', 'http https file',
-            'local')
-        self.config.add(
-            'annex.security.allowed-http-addresses', 'all',
-            'local')
 
     def set_default_backend(self, backend, persistent=True, commit=True):
         """Set default backend


### PR DESCRIPTION
This is inspired as a possible workaround for the
https://github.com/datalad/datalad/issues/6482
which is probably sufferring from another issue, but looking
at this code, I do not see why just not to set it in the fixture.

Since it seems to workaround reliably, announcing that Fixes #6482 

The only cons I can foresee is the test scenario where in fixture
we do not prepare our home whenever GIT_HOME is set.  IIRC it
was the case in debian package building case, but if needed,
we could set those up in debian/rules.

I also foresee that tests might run a little faster since we should then avoid `git config` call(s) for every temp annex repo -- aren't we?

- [ ] decide may be it should be CPed or even rebased to `maint`
- [x] see that may be it does work around #6482 -- ran 100 iterations of a loop in Windows VM without fail. Doing another 100 ATM