### PR TITLE
Consolidate entrypoint processing on importlib.metadata

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -43,32 +43,20 @@ if not datalad.in_librarymode():
 def _generate_extension_api():
     """Auto detect all available extensions and generate an API from them
     """
-    from importlib import import_module
-    from pkg_resources import iter_entry_points
-    from .interface.base import get_api_name
-    from datalad.support.exceptions import CapturedException
+    from datalad.support.entrypoints import iter_entrypoints
+    from datalad.interface.base import (
+        get_api_name,
+        load_interface,
+    )
 
     import logging
     lgr = logging.getLogger('datalad.api')
 
-    for entry_point in iter_entry_points('datalad.extensions'):
-        try:
-            lgr.debug(
-                'Loading entrypoint %s from datalad.extensions for API building',
-                entry_point.name)
-            grp_descr, interfaces = entry_point.load()
-            lgr.debug(
-                'Loaded entrypoint %s from datalad.extensions',
-                entry_point.name)
-        except Exception as e:
-            ce = CapturedException(e)
-            lgr.warning('Failed to load entrypoint %s: %s', entry_point.name, ce)
-            continue
-
+    for _, _, (grp_descr, interfaces) in iter_entrypoints(
+            'datalad.extensions', load=True):
         for intfspec in interfaces:
             # turn the interface spec into an instance
-            mod = import_module(intfspec[0])
-            intf = getattr(mod, intfspec[1])
+            intf = load_interface(intfspec[:2])
             api_name = get_api_name(intfspec)
             if api_name in globals():
                 lgr.debug(

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -187,25 +187,13 @@ class LogLevelAction(argparse.Action):
 
 
 def add_entrypoints_to_interface_groups(interface_groups):
-    lgr.debug("Loading entrypoints")
-    from pkg_resources import iter_entry_points  # delay expensive import
-    for ep in iter_entry_points('datalad.extensions'):
-        lgr.debug(
-            'Loading entrypoint %s from datalad.extensions',
-            ep.name)
-        try:
-            spec = ep.load()
-            if len(spec) < 2 or not spec[1]:
-                lgr.debug(
-                    'Extension does not provide a command suite: %s',
-                    ep.name)
-                continue
-            interface_groups.append((ep.name, spec[0], spec[1]))
-            lgr.debug('Loaded entrypoint %s', ep.name)
-        except Exception as e:
-            ce = CapturedException(e)
-            lgr.warning('Failed to load entrypoint %s: %s', ep.name, ce)
+    from datalad.support.entrypoints import iter_entrypoints
+    for name, _, spec in iter_entrypoints('datalad.extensions', load=True):
+        if len(spec) < 2 or not spec[1]:
+            # entrypoint identity was logged by the iterator already
+            lgr.debug('Extension does not provide a command suite')
             continue
+        interface_groups.append((name, spec[0], spec[1]))
 
 
 def get_commands_from_groups(groups):

--- a/datalad/interface/test.py
+++ b/datalad/interface/test.py
@@ -58,9 +58,10 @@ class Test(Interface):
     @staticmethod
     def __call__(module=None, *, verbose=False, nocapture=False, pdb=False, stop=False):
         if not module:
-            from pkg_resources import iter_entry_points
+            from datalad.support.entrypoints import iter_entrypoints
             module = ['datalad']
-            module.extend(ep.module_name for ep in iter_entry_points('datalad.tests'))
+            module.extend(
+                module for _, module, _ in iter_entrypoints('datalad.tests'))
         module = ensure_list(module)
         lgr.info('Starting test run for module(s): %s', module)
         for mod in module:

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -146,19 +146,17 @@ def _get_procedure_implementation(name='*', ds=None):
                 yield m, n, f, h
 
     # 3. check extensions for procedure
+    from datalad.support.entrypoints import iter_entrypoints
     # delay heavy import until here
     from pkg_resources import (
-        iter_entry_points,
         resource_filename,
         resource_isdir,
     )
-    for entry_point in iter_entry_points('datalad.extensions'):
+    for epname, epmodule, _ in iter_entrypoints('datalad.extensions'):
         # use of '/' here is OK wrt to platform compatibility
-        if resource_isdir(entry_point.module_name, 'resources/procedures'):
+        if resource_isdir(epmodule, 'resources/procedures'):
             for m, n in _get_file_match(
-                    resource_filename(
-                        entry_point.module_name,
-                        'resources/procedures'),
+                    resource_filename(epmodule, 'resources/procedures'),
                     name):
                 yield (m, n,) + _get_proc_config(n)
     # 4. at last check datalad itself for procedure

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -13,6 +13,7 @@ __docformat__ = 'restructuredtext'
 import logging
 import os
 import os.path as op
+import sys
 from functools import partial
 from collections import OrderedDict
 
@@ -171,18 +172,18 @@ def _describe_configuration(cfg, sensitive):
 
 def _describe_extensions():
     infos = {}
-    from pkg_resources import iter_entry_points
+    from datalad.support.entrypoints import iter_entrypoints
     from importlib import import_module
 
-    for e in iter_entry_points('datalad.extensions'):
+    for ename, emod, eload in iter_entrypoints('datalad.extensions'):
         info = {}
-        infos[e.name] = info
+        infos[ename] = info
         try:
-            ext = e.load()
+            ext = eload()
             info['load_error'] = None
             info['description'] = ext[0]
-            info['module'] = e.module_name
-            mod = import_module(e.module_name, package='datalad')
+            info['module'] = emod
+            mod = import_module(emod, package='datalad')
             info['version'] = getattr(mod, '__version__', None)
         except Exception as e:
             ce = CapturedException(e)
@@ -208,18 +209,28 @@ def _describe_extensions():
 
 def _describe_metadata_elements(group):
     infos = {}
-    from pkg_resources import iter_entry_points
+    from datalad.support.entrypoints import iter_entrypoints
     from importlib import import_module
+    if sys.version_info < (3, 10):
+        # 3.10 is when it was no longer provisional
+        from importlib_metadata import distribution
+    else:
+        from importlib.metadata import distribution
 
-    for e in iter_entry_points(group):
+
+    for ename, emod, eload in iter_entrypoints(group):
         info = {}
-        infos['%s (%s)' % (e.name, str(e.dist))] = info
+        infos[f'{ename}'] = info
         try:
-            info['module'] = e.module_name
-            info['distribution'] = str(e.dist)
-            mod = import_module(e.module_name, package='datalad')
-            info['version'] = getattr(mod, '__version__', None)
-            e.load()
+            info['module'] = emod
+            dist = distribution(emod.split('.', maxsplit=1)[0])
+            info['distribution'] = f'{dist.name} {dist.version}'
+            mod = import_module(emod, package='datalad')
+            version = getattr(mod, '__version__', None)
+            if version:
+                # no not clutter the report with no version
+                info['version'] = version
+            eload()
             info['load_error'] = None
         except Exception as e:
             ce = CapturedException(e)

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -473,8 +473,11 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
     # enforce size limits
     max_fieldsize = ds.config.obtain('datalad.metadata.maxfieldsize')
     # keep local, who knows what some extractors might pull in
-    from pkg_resources import iter_entry_points  # delayed heavy import
-    extractors = {ep.name: ep for ep in iter_entry_points('datalad.metadata.extractors')}
+    from datalad.support.entrypoints import iter_entrypoints
+    extractors = {
+        ename: eload
+        for ename, _, eload in iter_entrypoints('datalad.metadata.extractors')
+    }
 
     # we said that we want to fail, rather then just moan about less metadata
     # Do an early check if all extractors are available so not to wait hours
@@ -505,7 +508,7 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
             update=1,
             increment=True)
         try:
-            extractor_cls = extractors[mtype_key].load()
+            extractor_cls = extractors[mtype_key]()
             extractor = extractor_cls(
                 ds,
                 paths=paths if extractor_cls.NEEDS_CONTENT else fullpathlist)

--- a/datalad/support/entrypoints.py
+++ b/datalad/support/entrypoints.py
@@ -1,0 +1,65 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Core utilities"""
+
+import logging
+import sys
+
+from datalad.support.exceptions import CapturedException
+
+lgr = logging.getLogger('datalad.support.entrypoints')
+
+
+def iter_entrypoints(group, load=False):
+    """Iterate over all entrypoints of a given group
+
+    Parameters
+    ----------
+    group: str
+      Name of the entry point group to iterator over, such as
+      'datalad.extensions'.
+    load: bool, optional
+      Whether to execute the entry point loader internally in a
+      protected manner that only logs a possible exception and emits
+      a warning, but otherwise skips over "broken" entrypoints.
+      If False, the loader callable is returned unexecuted.
+
+    Yields
+    -------
+    (name, module, loade(r|d))
+      The first item in each yielded tuple is the entry point name (str).
+      The second is the name of the module that contains the entry point
+      (str). The type of the third items depends on the load parameter.
+      It is either a callable that can be used to load the entrypoint
+      (this is the default behavior), or the outcome of executing the
+      entry point loader.
+    """
+    lgr.debug("Processing entrypoints")
+
+    if sys.version_info < (3, 10):
+        # 3.10 is when it was no longer provisional
+        from importlib_metadata import entry_points
+    else:
+        from importlib.metadata import entry_points
+    for ep in entry_points(group=group):
+        if not load:
+            yield ep.name, ep.module, ep.load
+            continue
+
+        try:
+            lgr.debug('Loading entrypoint %s from %s', ep.name, group)
+            yield ep.name, ep.module, ep.load()
+            lgr.debug('Loaded entrypoint %s from %s', ep.name, group)
+        except Exception as e:
+            ce = CapturedException(e)
+            lgr.warning(
+                'Failed to load entrypoint %s from %s: %s',
+                ep.name, group, ce)
+            continue
+    lgr.debug("Done processing entrypoints")

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requires = {
         'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
-        'importlib-metadata; python_version < "3.8"',
+        'importlib-metadata; python_version < "3.10"',
         'iso8601',
         'humanize',
         'fasteners>=0.14',


### PR DESCRIPTION
This approach is now an offiical part of the standard lib (since 3.10), and is available for earlier version in a provisional module and also a separate package.

This change introduces `datalad.support.entrypoints` with `iter_entrypoints()` that is now used as a uniform implementation.

As previously shown in https://github.com/datalad/datalad/issues/6584 this brings significant performance improvements for internal processing. Moreover, they translate to outward-facing speed gains. On a system with 10 extensions installed a `datalad -h` now completes in ~300ms, whereas current mainline after the CLI update needs ~650ms, and the latest release 0.15.6 needs ~1200ms -- so overall a 4x speed-up.

Importantly, the new `iter_entrypoints()` helper does not return complex entrypoint instances anymore, which previously contaminated DataLad code with the internals of `pkg_resources`. This is also the reason for one occurrence of a `pkg_resources`-based entrypoint iteration being left in the code (in `search` and its tests). It specifically relies on these
internals and even mocks them in the tests.

This code is likely to change entirely soon, and is also slow enough to not make the require effort to switch it over felt by users.

This change implies no necessary modifications of any extensions.

### Changelog
#### 💫 Enhancements and new features
- Loading DataLad extension packages has been sped-up leading to between 2x and 4x faster run times for loading individual extensions and reporting help output across all installed extensions. Fixes #6584
#### 🏠 Internal
- Entrypoint processing for extensions and metadata extractors has been consolidated on a uniform helper that is about twice as fast as the previous implementations. Fixes #6585

