### PR TITLE
Enable loading select extensions on CLI startup or API import 

### DIFF
--- a/datalad/coreapi.py
+++ b/datalad/coreapi.py
@@ -18,6 +18,14 @@ def _generate_func_api():
     """
     from importlib import import_module
 
+    # load extensions requested by configuration
+    import datalad
+    if datalad.get_apimode() == 'python':
+        # only do this in Python API mode, because the CLI main
+        # will have done this already
+        from datalad.support.entrypoints import load_extensions
+        load_extensions()
+
     from .interface.base import get_interface_groups
     from .interface.base import get_api_name
 

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -117,6 +117,20 @@ definitions = {
         'type': bool,
         'default': False,
     },
+    'datalad.extensions.load': {
+        'ui': ('question', {
+               'title': 'DataLad extension packages to load',
+               'text': 'Indicate which extension packages should be loaded '
+                       'unconditionally on CLI startup or on importing '
+                       "'datalad.[core]api'. This enables the "
+                       'respective extensions to customize DataLad with '
+                       'functionality and configurability outside the '
+                       'scope of extension commands. For merely running '
+                       'extension commands it is not necessary to load them '
+                       'specifically'}),
+        'destination': 'global',
+        'default': None,
+    },
     'datalad.externals.nda.dbserver': {
         'ui': ('question', {
                'title': 'NDA database server',


### PR DESCRIPTION
Performance impact when this feature is unused, is negligible. Otherwise it is determined by the import time of a particular extension's `__init__.py`.

### Changelog
#### 💫 Enhancements and new features
- A new configuration switch `datalad.extensions.load` can be used to load particular DataLad extension packages on startup. This enables extensions to also enhance core commands, such as teaching the `clone` command to handle additional types of URLs. To continue to use commands provided by extensions, this new configuration is not necessary. Fixes #6589