### PR TITLE
disable metalad tests

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -13,7 +13,6 @@ jobs:
         extension: [
             datalad-neuroimaging,
             datalad-container,
-            datalad-metalad,
             datalad-crawler,
             datalad-deprecated,
         ]


### PR DESCRIPTION
This PR will disable metalad tests. Currently metalad is changing a lot and CI does not seem to respect pinned versions of required pypi packages. That leads to environements with non-working metalad installations.
