### PR TITLE
BF/RF: create-sibling follow diff with constant_refs=False + operate on committed subds

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -687,8 +687,10 @@ class CreateSibling(Interface):
                     ds,
                     fr=since,
                     to='HEAD',
-                    # make explicit, but doesn't matter, no recursion in diff()
-                    constant_refs=True,
+                    # w/o False we might not follow into new subdatasets
+                    # which do not have that remote yet setup,
+                    # see https://github.com/datalad/datalad/issues/6596
+                    constant_refs=False,
                     # save cycles, we are only looking for datasets
                     annex=None,
                     untracked='no',

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -731,6 +731,7 @@ def _test_target_ssh_inherit(standardgroup, ui, use_ssh, src_path, target_path):
     # but just issue a warning for the top level dataset which has no super,
     # so cannot inherit anything - use case is to fixup/establish the full
     # hierarchy on the remote site
+    ds.save(recursive=True)  # so we have committed hierarchy for create_sibling
     with swallow_logs(logging.WARNING) as cml:
         out = ds.create_sibling(
             None, name=remote, existing="reconfigure", inherit=True,

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -32,6 +32,7 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.network import urlquote
 from datalad.tests.utils import (
     DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
     SkipTest,
     assert_dict_equal,
     assert_false,
@@ -485,9 +486,39 @@ def check_target_ssh_since(use_ssh, origin, src_path, target_path):
         sshurl=sshurl,
         recursive=True,
         existing='skip')
-    # verify that it created the sub and sub/sub
+    # verify that it created the immediate subdataset
+    ok_(Dataset(_path_(target_path, 'brandnew2')).is_installed())
+    # but not the subs since they were not saved, thus even push would not operate
+    # on them yet, so no reason for us to create them until subdatasets are saved
+    ok_(not Dataset(_path_(target_path, 'brandnew2/sub')).is_installed())
+
+    source.save(recursive=True)
+
+    # and if repeated now -- will create those sub/sub
+    assert_create_sshwebserver(
+        name='dominique_carrera',
+        dataset=source,
+        sshurl=sshurl,
+        recursive=True,
+        existing='skip')
+    # verify that it created the immediate subdataset
     ok_(Dataset(_path_(target_path, 'brandnew2/sub')).is_installed())
     ok_(Dataset(_path_(target_path, 'brandnew2/sub/sub')).is_installed())
+
+    # now we will try with --since while creating even deeper nested one, and ensuring
+    # it is created -- see https://github.com/datalad/datalad/issues/6596
+    brandnewsubsub.create('sub')
+    source.save(recursive=True)
+    # and now we create a sibling for the new subdataset only
+    assert_create_sshwebserver(
+        name='dominique_carrera',
+        dataset=source,
+        sshurl=sshurl,
+        recursive=True,
+        existing='skip',
+        since=f'{DEFAULT_REMOTE}/{DEFAULT_BRANCH}')
+    # verify that it created the sub and sub/sub
+    ok_(Dataset(_path_(target_path, 'brandnew2/sub/sub/sub')).is_installed())
 
     # we installed without web ui - no hooks should be created/enabled
     assert_postupdate_hooks(_path_(target_path, 'brandnew'), installed=False)


### PR DESCRIPTION
Initial motivation for this change was fixing

   https://github.com/datalad/datalad/issues/6596

where while specifying --since, create-sibling  did not detect needing to
create a sibling for a subdataset.  A stale (missed during #6528 OPT/RF)
comment said that value of constant_refs=True should not matter since it was
not recursive originally. But now here we do recurse and it does matter since
we migth completely skip subtree where such refs are not yet known.  Changing
to False resulted in the test failing which made me realize that sibling was
created even for not yet committed changes to submodules.  Since for push it
would really not work to push something which is not yet saved, I think the
change in behavior for create-sibling is also desired.  And it fixes #6596.
So I have "fixed" and expanded test with the problematic case I had
discovered.

### Changelog
#### 🐛 Bug Fixes
- `create-sibling` will no longer create siblings for not yet saved new subdatasets, and 
   will now create sub-datasets nested in the subdatasets which did not yet have those
   siblings. Fixes #6596
