### PR TITLE
Sanitize AppVeyor's known_hosts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -275,6 +275,10 @@ init:
   # Temporary keys for localhost access in default place
   - cmd: ssh-keygen -f C:\Users\appveyor\.ssh\id_rsa -N ""
   - sh: ssh-keygen -f ~/.ssh/id_rsa -N ""
+  # Remove AppVeyor's known_hosts entries for gitlab, since they are matching
+  # `*` as the IP (see https://github.com/appveyor/ci/issues/3792)
+  - cmd: ssh-keygen -f C:\Users\appveyor\.ssh\known_hosts -R "gitlab.com"
+  - sh: ssh-keygen -f ~/.ssh/known_hosts -R "gitlab.com"
 
 
 install:


### PR DESCRIPTION
Remove AppVeyor's world-matching default entries for gitlab.com in `known_hosts`, that led to `Remote host identification changed` with pretty much every SSH invocation.

See https://github.com/datalad/datalad/issues/6599#issuecomment-1085744290