### PR TITLE
Add datalad-metalad to tested extensions

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -13,6 +13,7 @@ jobs:
         extension: [
             datalad-neuroimaging,
             datalad-container,
+            datalad-metalad,
             datalad-crawler,
             datalad-deprecated,
         ]


### PR DESCRIPTION
Metalad version 0.3.0 has been released. The released version passes the datalad-metalad extension tests. The tests should therefore be enabled again.

### Changelog
#### 🛡 Tests
- re-enable datalad-metalad extension tests after datalad-metalad release `0.3.0`.
