### PR TITLE
RF/OPT: do not call get_git_environ_adjusted twice for BatchedCommand

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -264,7 +264,6 @@ class BatchedCommand(SafeDelCloseMixin):
             protocol=BatchedCommandProtocol,
             stdin=self.stdin_queue,
             cwd=self.path,
-            env=GitRunnerBase.get_git_environ_adjusted(),
             # This mimics the behavior of the old implementation w.r.t
             # timeouts when waiting for the closing process
             timeout=self.timeout or 11.0,


### PR DESCRIPTION
WitlessRunner created with env populated from that call, so the .run
could just use it if env is not provided to its invocation.
There is no reason to call that function twice AFAIK.
