### PR TITLE
BF: Wrong annex version tested

### DIFF
--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -303,13 +303,13 @@ def test_status_symlinked_dir_within_repo(path):
         # TODO: on windows even with a recent annex -- no CommandError is
         # raised, TODO
         assert_result_count(call(), 0)
-    elif ds.repo.git_annex_version < '10.20220127':
+    elif ds.repo.git_annex_version < '10.20220222':
         # As of 2a8fdfc7d (Display a warning message when asked to operate on a
         # file inside a symlinked directory, 2020-05-11), git-annex will error.
         with assert_raises(CommandError):
             call()
-    elif '10.20220127' <= ds.repo.git_annex_version < '10.20220322':
-        # No error on annex' side since 10.20220127;
+    elif '10.20220222' <= ds.repo.git_annex_version < '10.20220322':
+        # No error on annex' side since 10.20220222;
         # However, we'd now get something like this:
         # > git annex find bar/f
         # error: pathspec 'bar/f' did not match any file(s) known to git

--- a/datalad/support/annex_utils.py
+++ b/datalad/support/annex_utils.py
@@ -49,7 +49,7 @@ def _get_non_existing_from_annex_output(output):
 
     # Output largely depends on annex config annex.skipunknown
     # (see https://github.com/datalad/datalad/pull/6510#issuecomment-1054499339)
-    # and git-annex' default of annex.skipunknown changed as of 10.20220127.
+    # and git-annex' default of annex.skipunknown changed as of 10.20220222.
     # However, that appears to not be true for all commands. annex-add would
     # still report in the "git-annex: ... not found" fashion rather than
     # "error:  ... did not match any file(s) known to git". Depends on

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1096,7 +1096,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         # git-annex fails to non-zero exit when reporting an error on
         # non-existing paths in some versions and/or commands.
         # Hence, check for it on non-failure, too. This became apparent with
-        # annex 10.20220127, but was a somewhat "hidden" issue for longer.
+        # annex 10.20220222, but was a somewhat "hidden" issue for longer.
         #
         # Note, that this may become unnecessary after annex'
         # ce91f10132805d11448896304821b0aa9c6d9845 (Feb 28, 2022)

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1403,7 +1403,7 @@ def test_annex_copy_to(src, origin, clone):
                     section="annex", option="skipunknown",
                     # git-annex switched default for this config:
                     default=bool(
-                        external_versions['cmd:annex'] < '10.20220127')):
+                        external_versions['cmd:annex'] < '10.20220222')):
 
                 stderr = "error: pathspec 'nonex1' did not match any file(s) " \
                          "known to git\n" \
@@ -2196,7 +2196,7 @@ def test_annexjson_protocol(path):
     # Note: git-annex-find <non-existent-path> does not error with all annex
     # versions. Fixed in annex commit
     # ce91f10132805d11448896304821b0aa9c6d9845 (Feb 28, 2022).
-    if '10.20220127' < external_versions['cmd:annex'] < '10.20220322':
+    if '10.20220222' < external_versions['cmd:annex'] < '10.20220322':
         raise SkipTest("zero-exit annex-find bug")
 
     # now the same, but with a forced error
@@ -2210,7 +2210,7 @@ def test_annexjson_protocol(path):
     msg = "pathspec 'error' did not match" if not dl_cfg.getbool(
         section="annex", option="skipunknown",
         # git-annex switched default for this config:
-        default=bool(external_versions['cmd:annex'] < '10.20220127')) else \
+        default=bool(external_versions['cmd:annex'] < '10.20220222')) else \
         "error not found"
     assert_in(msg, e.exception.stderr)
     # there should be no errors reported in an individual records


### PR DESCRIPTION
Commit 7c4a5437bb35afa72e0f70e78196103144c9ec73 was wrong about when
exactly annex' default for `annex.skipunknown` changed to false.


### Changelog
#### 🛡 Tests
- Fix test conditions referring to an incorrect annex version
