### PR TITLE
Factor out actual data transfer in push

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -45,6 +45,7 @@ from datalad.support.exceptions import CommandError
 from datalad.utils import (
     Path,
     ensure_list,
+    todo_interface_for_extensions,
 )
 
 from datalad.distribution.dataset import (
@@ -401,18 +402,19 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
         yield (cur_ds, ds_res)
 
 
+@todo_interface_for_extensions
 def _transfer_data(repo, ds, target, content, data, force, jobs, res_kwargs,
                    got_path_arg):
-        yield from _push_data(
-            ds,
-            target,
-            content,
-            data,
-            force,
-            jobs,
-            res_kwargs.copy(),
-            got_path_arg=got_path_arg,
-        )
+    yield from _push_data(
+        ds,
+        target,
+        content,
+        data,
+        force,
+        jobs,
+        res_kwargs.copy(),
+        got_path_arg=got_path_arg,
+    )
 
 
 def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -401,6 +401,20 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
         yield (cur_ds, ds_res)
 
 
+def _transfer_data(repo, ds, target, content, data, force, jobs, res_kwargs,
+                   got_path_arg):
+        yield from _push_data(
+            ds,
+            target,
+            content,
+            data,
+            force,
+            jobs,
+            res_kwargs.copy(),
+            got_path_arg=got_path_arg,
+        )
+
+
 def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
           got_path_arg=False):
     force_git_push = force in ('all', 'gitpush')
@@ -593,7 +607,8 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
             log_progress(
                 lgr.info, pbar_id, "Transfer data",
                 label="Transfer data to '{}'".format(target), update=2, total=4)
-            yield from _push_data(
+            yield from _transfer_data(
+                repo,
                 ds,
                 target,
                 content,

--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -37,6 +37,8 @@ from datalad.support.constraints import (
 )
 from datalad.support.param import Parameter
 from datalad.ui import ui
+from datalad.utils import todo_interface_for_extensions
+
 
 lgr = logging.getLogger('datalad.distributed.create_sibling_ghlike')
 
@@ -152,6 +154,7 @@ class _GitHubLike(object):
             require_token,
         )
 
+    @todo_interface_for_extensions
     def _set_request_headers(self, credential_name, auth_info, require_token):
         if credential_name is None:
             credential_name = urlparse(self.api_url).netloc

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -82,6 +82,7 @@ from datalad.utils import (
     split_cmdline,
     swallow_logs,
     swallow_outputs,
+    todo_interface_for_extensions,
     unique,
     unlink,
     updated,
@@ -490,6 +491,15 @@ def test_auto_repr():
         f"buga_long(a=1, b=[{', '.join(map(str, range(20)))}])"
     )
     assert_equal(buga_long().some(), "some")
+
+
+def test_todo_interface_for_extensions():
+
+    @todo_interface_for_extensions
+    def f(i, j):
+        return i*j
+
+    assert_equal(f(2, 3), 6)
 
 
 def test_assure_iter():

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1285,6 +1285,10 @@ def auto_repr(cls, short=True):
     return cls
 
 
+def todo_interface_for_extensions(f):
+    return f
+
+
 #
 # Context Managers
 #


### PR DESCRIPTION
This commit delegates the actual data transfer in
push to a new method: _transfer_data. This is done
to simplify monkey-patching via "datalad_next", in
order to implement export to git-annex special remotes
with type webdav and exporttree enabled.

This is a first step to address issue #3127 
### Changelog
#### 🐛 Bug Fixes
#### 🏠 Internal
- factor out actual data transfer in push, in order to make it "patchable".
