### PR TITLE
BF: Fix wrong key name of annex' JSON records

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3395,8 +3395,8 @@ class AnnexRepo(GitRepo, RepoInterface):
                 else:
                     rec = {}
             rec.update({'{}{}'.format(key_prefix, k): j[k]
-                       for k in j if k != 'file' and k != 'error_messages'})
-            # change annex' `error_messages` into singular to match result
+                       for k in j if k != 'file' and k != 'error-messages'})
+            # change annex' `error-messages` into singular to match result
             # records:
             if j.get('error-messages', None):
                 rec['error_message'] = '\n'.join(m.strip() for m in j['error-messages'])


### PR DESCRIPTION
Annex uses a `-` instead of `_` in its JSON key names.
This correction should only have a minor impact on behavior. Instead of
the intended replacement of a list of messages under `error-messages`
with a joined message under `error_message`, the created record
unintentionally had both.

Fixes #6621


### Changelog
#### 🏠 Internal
- Fix misspelled use of a key name in annex' JSON records.
