### PR TITLE
Change a key-value pair in drop result record

### DIFF
--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -415,7 +415,9 @@ def _drop_dataset(ds, paths, what, reckless, recursive, recursion_limit, jobs):
                 res['message'] = message
             error_messages = r.get('error-messages')
             if error_messages:
-                res['error_messages'] = error_messages
+                res['error_message'] = '\n'.join(
+                    m.strip() for m in error_messages
+                )
             # play safe, if there is no status, assume error
             if res.get('status', 'error') != 'ok':
                 drop_all_errored = True

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -9,6 +9,7 @@
 
 import os
 import os.path as op
+from unittest.mock import patch
 
 from datalad.api import (
     Dataset,
@@ -548,3 +549,21 @@ def test_drop_uninit_annexrepo(origpath, path):
     ds = Dataset(path)
     assert_status('ok', ds.drop(what='datasets'))
     nok_(ds.is_installed())
+
+
+# https://github.com/datalad/datalad/issues/6577
+@with_tempfile
+def test_drop_allkeys_result_contains_annex_error_messages(path):
+    # when calling drop with allkeys, expect git-annex error
+    # message(s) to be present in the result record error_message
+    ds = Dataset(path).create()
+    # mock annex call always yielding error-messages in this dataset
+    with patch.object(ds.repo, '_call_annex_records_items_') as mock_call:
+        mock_call.return_value = iter([{
+            'command': 'drop',
+            'success': False,
+            'error-messages': ['git-annex error message here']}])
+        assert_in_results(
+            ds.drop(what='allkeys', on_failure='ignore'),
+            error_message='git-annex error message here',
+        )


### PR DESCRIPTION
When used with `what=(allkeys/datasets/all)` and `reckless != kill`, `drop` created a result record in which a list of error messages coming from git-annex was placed in the field named `error_messages`. This led to the generic results renderer (which expects `error_message` and/or `message` instead) not showing the error message to the user, as described in #6577.

This PR rewrites the error messages into a string under `res['error_message']` (if there are multiple messages, they are joined into one multiline string, following `annexjson2result` from `datalad.interface.results`). With that, results renderer behaves as expected.

Before (I'm mocking both note and error-messages produced by git-annex, although in the original issue the note was empty):
```
❱ datalad drop --what all -d bar --reckless availability
drop(error): . (key) [git-annex note here]
```
and after:
```
❱ datalad drop --what all -d bar --reckless availability
drop(error): . (key) [git-annex note here] [git-annex error message here]
```

Note. An alternative solution (taking #6577 literally) would be to equip the results renderer with the ability to understand a list of error messages, but I think the solution above is more in line with the rest of the code (`error_messages` is not used anywhere else, `error-messages` is, but usually to process git annex output, often converted into `error_message` as above), and good as an immediate UX fix.

Note 2. The added test is fairly specific - it tests directly for the thing I wanted to change (annex's `error-messages` being rewritten to result's `error_message` so that the renderer gets what it wants) but I'm not 100% sure if that's *the* thing to be tested in the long run.

Note 3. Should this PR be against master or maint?

TODO:
- [x] verify the old/new behaviour by temporarily patching the call to annex (`_drop_allkeys` / `_call_annex_record_items`) to always return an error
- [x] do the above in a formal test using `patch` context manager

### Changelog
#### 🐛 Bug Fixes
- Fix error messages coming from git-annex during `drop` not being shown under some circumstances. Fixes #6577 
