### PR TITLE
ENH: include version of datalad in tests teardown Versions: report

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -351,6 +351,9 @@ def teardown_package():
     from datalad.ui import ui
 
     lgr.debug("Printing versioning information collected so far")
+    # Query for version of datalad, so it is included in ev.dumps below - useful while
+    # testing extensions where version of datalad might differ in the environment.
+    ev['datalad']
     print(ev.dumps(query=True))
     try:
         print("Obscure filename: str=%s repr=%r"


### PR DESCRIPTION
In particular useful while troubleshooting extensions, which would
typically reuse the same setup/teardown as of the core package.

Ran into such a desire while looking at https://github.com/mih/datalad-mihextras/issues/27
