### PR TITLE
MNT: Require importlib-metadata >=3.6 for Python < 3.10 for entry_points taking kwargs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requires = {
         'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
-        'importlib-metadata; python_version < "3.10"',
+        'importlib-metadata >=3.6; python_version < "3.10"',
         'iso8601',
         'humanize',
         'fasteners>=0.14',


### PR DESCRIPTION
Datalad now depends on entry_points taking kwargs, introduced in https://github.com/python/importlib_metadata/commit/8320adef797d5f14d9fff7b58ebc2a31a2a6a437, first released in importlib-metadata 3.6.

Apologies for ignoring your PR template, but it's unclear where this fits in your changelog set.