### PR TITLE
Demote (to level 1 from DEBUG) and speed-up API doc logging (parseParameters)

### DIFF
--- a/datalad/dochelpers.py
+++ b/datalad/dochelpers.py
@@ -173,8 +173,11 @@ def _parse_parameters(paramdoc):
     entries = __re_spliter1.split(paramdoc)
     result = [(__re_spliter2.split(e)[0].strip(), e)
               for e in entries if e != '']
-    lgr.debug('parseParameters: Given "%s", we split into %s' %
-              (paramdoc, result))
+    lgr.log(
+        1,
+        'parseParameters: Given "%s", we split into %s',
+        paramdoc, result,
+    )
     return result
 
 


### PR DESCRIPTION
Previously, log messages like this would appear at DEBUG level:

```
[DEBUG] parseParameters: Given "exclude_special_remotes: bool, optional
  if True, don't return annex special remotes", we split into [('exclude_special_remotes', "exclude_special_remotes: bool, optional\n  if True, don't return annex special remotes")]
```

These are very verbose and large in number, making debug
output needlessly complicated to read.

Moreover, they log the outcome of a trivial operation that practically
never fails in production code, at a comparatively high level (DEBUG),
and they did it in an expensive way that actually built the log string
unconditionally of the effective log level.

This change demote the log level to the lowest possible, and uses a proper
logging pattern that avoid needless string operations.

### Changelog
Not needed