### PR TITLE
Remove two too prominent create() INFO log message that duplicate DEBUG log and harmonize some other log messages

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -723,7 +723,7 @@ def clone_dataset(
     # must happen prior git-annex-init, where we can cheaply alter the repo
     # setup through safe re-init'ing
     if reckless and reckless.startswith('shared-'):
-        lgr.debug('Reinit %s to enable shared access permissions', destds)
+        lgr.debug('Reinitializing %s to enable shared access permissions', destds)
         destds.repo.call_git(['init', '--shared={}'.format(reckless[7:])])
 
     # In case of RIA stores we need to prepare *before* annex is called at all

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -256,7 +256,7 @@ class Push(Interface):
         matched_anything = False
         for dspath, dsrecords in ds_spec:
             matched_anything = True
-            lgr.debug('Attempt push of Dataset at %s', dspath)
+            lgr.debug('Pushing Dataset at %s', dspath)
             pbars = {}
             yield from _push(
                 dspath, dsrecords, to, data, force, jobs, res_kwargs.copy(), pbars,
@@ -650,7 +650,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
         # server-side git-annex branch updates (and git-annex does
         # not trigger the hook on copy), but we know we have
         # full access via the push url -- we have just used it to copy.
-        lgr.debug("Fetch 'git-annex' branch updates from '%s'", target)
+        lgr.debug("Fetching 'git-annex' branch updates from '%s'", target)
         fetch_cmd = ['fetch', target, 'git-annex']
         pushurl = repo.config.get(
             'remote.{}.pushurl'.format(target), None)
@@ -851,7 +851,7 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
         # if we force, we do not trust local knowledge and do the checks
         cmd.append('--fast')
 
-    lgr.debug("Push data from %s to '%s'", ds, target)
+    lgr.debug("Pushing data from %s to '%s'", ds, target)
 
     # input has type=dataset, but now it is about files
     res_kwargs.pop('type', None)

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -473,7 +473,6 @@ def _setup_git_repo(path, initopts=None, fake_dates=False):
       Created repository and records for any repo component that needs to be
       passed to git-add as a result of the setup procedure.
     """
-    lgr.info("Creating a new git repo at %s", path)
     tbrepo = GitRepo(
         path,
         create=True,
@@ -516,7 +515,6 @@ def _setup_annex_repo(path, initopts=None, fake_dates=False,
       passed to git-add as a result of the setup procedure.
     """
     # always come with annex when created from scratch
-    lgr.info("Creating a new annex repo at %s", path)
     tbrepo = AnnexRepo(
         path,
         create=True,

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -159,7 +159,7 @@ def yield_dataset_status(ds, paths, annexinfo, untracked, recursion_limit,
     # take the dataset that went in first
     repo = ds.repo
     repo_path = repo.pathobj
-    lgr.debug('query %s.diffstatus() for paths: %s', repo, paths)
+    lgr.debug('Querying %s.diffstatus() for paths: %s', repo, paths)
     # recode paths with repo reference for low-level API
     paths = [repo_path / p.relative_to(ds.pathobj) for p in paths] if paths else None
     status = repo.diffstatus(
@@ -170,7 +170,7 @@ def yield_dataset_status(ds, paths, annexinfo, untracked, recursion_limit,
         eval_submodule_state=eval_submodule_state,
         _cache=cache)
     if annexinfo and hasattr(repo, 'get_content_annexinfo'):
-        lgr.debug('query %s.get_content_annexinfo() for paths: %s', repo, paths)
+        lgr.debug('Querying %s.get_content_annexinfo() for paths: %s', repo, paths)
         # this will amend `status`
         repo.get_content_annexinfo(
             paths=paths,

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -142,7 +142,7 @@ def init_datalad_remote(repo, remote, encryption=None, autoenable=False,
                         opts=[]):
     """Initialize datalad special remote"""
     from datalad.consts import DATALAD_SPECIAL_REMOTES_UUIDS
-    lgr.info("Initiating special remote %s", remote)
+    lgr.info("Initializing special remote %s", remote)
     remote_opts = [
         'encryption=%s' % str(encryption).lower(),
         'type=external',

--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -566,7 +566,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         cmd = ['-C', path, 'init']
         cmd.extend(ensure_list(init_options))
         lgr.debug(
-            "Initialize empty Git repository at '%s'%s",
+            "Initializing empty Git repository at '%s'%s",
             path,
             ' %s' % cmd[3:] if cmd[3:] else '')
 


### PR DESCRIPTION
Every invocation produces this INFO-level message:

```
% datalad create myds
[INFO   ] Creating a new annex repo at /tmp/myds
create(ok): /tmp/myds (dataset)
```
This is not a long-running operation. In most cases, the INFO log and the result arrive near-simultaneously.
It also duplicates DEBUG messages:

```
[INFO   ] Creating a new annex repo at /tmp/demo12
[DEBUG  ] Initialize empty Git repository at '/tmp/demo12'
[DEBUG  ] Initializing annex repository at /tmp/demo12...
```

Removed for a cleaner user experience.

Fixes #6633 

### Changelog
Not needed.
