### PR TITLE
Add released plugin to .autorc to annotate PRs on when released

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -11,7 +11,8 @@
                 "afterChangelog": "make update-changelog && git add docs/source/changelog.rst && git commit -m '[skip ci] Update RST changelog'",
                 "afterRelease": "python -m build && twine upload dist/*"
             }
-        ]
+        ],
+        "released"
     ],
   "labels": [
     { "releaseType": "major", "name": "semver-major" },


### PR DESCRIPTION
[ci skip]

@jwodder - do you think we need any custom settings given we use custom github labels in this repo?