### PR TITLE
OPT: AnnexJsonProtocol - avoid dragging possibly long data around

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3684,13 +3684,15 @@ class AnnexJsonProtocol(WitlessProtocol):
         # json_loads() is already logging any error, which is OK, because
         # under no circumstances we would expect broken JSON
         lines = data.splitlines()
+        data_ends_with_eol = data.endswith(os.linesep.encode())
+        del data
         for iline, line in enumerate(lines):
             try:
                 j = json_loads(line)
             except Exception as exc:
                 if line.strip():
                     # do not complain on empty lines
-                    if iline == len(lines) - 1 and not data.endswith(os.linesep.encode()):
+                    if iline == len(lines) - 1 and not data_ends_with_eol:
                         lgr.debug("Caught %s while trying to parse JSON line %s which might "
                                   "be not yet a full line", exc, line)
                         # it is the last line and fails to parse -- it can/likely


### PR DESCRIPTION
Identified this place while troubleshooting "out of memory" primarily due to pytest also swallowing all logs, and thus our "DATALAD_LOG_LEVEL=2" run on travis was causing out of memory for some tests. Using the --memray pytest plugin, identified this line of code where up to 1GB was kept at some point in time, and realized that code would hold to it in addition to lines because there was that check inside the loop.  So I have moved out the condition and explicitly `del data`.  Shouldn't hurt and shouldn't consume twice more RAM (`lines` + `data`) for long period of time in some cases ;)

CPed from #6273 