### PR TITLE
Fix `GitRepo.get_branch_commits_()` to handle branch names conflicts with paths

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2190,6 +2190,9 @@ class GitRepo(CoreGitRepo):
         if not branch:
             branch = self.get_active_branch()
         cmd.append(branch)
+        # and trailing -- marker to make sure that Git never confused the branch
+        # with a potentially existing directory of the same name
+        cmd.append('--')
         for r in self.call_git_items_(cmd):
             if stop and stop == r:
                 return

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -903,6 +903,9 @@ def test_GitRepo_git_get_branch_commits_(src):
         f.write('load')
     repo.add('*')
     repo.commit('committing')
+    # go in a branch with a name that matches the file to require
+    # proper disambiguation
+    repo.call_git(['checkout', '-b', 'file.txt'])
 
     commits_default = list(repo.get_branch_commits_())
     commits = list(repo.get_branch_commits_(DEFAULT_BRANCH))


### PR DESCRIPTION
Specifically, conflicts of branch name with branch content.

### Changelog
#### 🐛 Bug Fixes
- `GitRepo.get_branch_commits_()` crashed when the given branch name also matched a file or directory in the active branch. Fixes #6650