### PR TITLE
BF: Sanitize keys before checking content availability

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -20,6 +20,7 @@ from datalad.customremotes import (
     SpecialRemote,
 )
 from datalad.customremotes.main import main as super_main
+from datalad.support.annex_utils import _sanitize_key
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import (
     AccessDeniedError,
@@ -1478,35 +1479,6 @@ class RIARemote(SpecialRemote):
             self._last_keypath[1]
 
     # TODO: implement method 'error'
-
-
-def _sanitize_key(key):
-    """Returns a sanitized key that is a suitable directory/file name
-
-    Documentation from the analog implementation in git-annex
-    Annex/Locations.hs
-
-    Converts a key into a filename fragment without any directory.
-
-    Escape "/" in the key name, to keep a flat tree of files and avoid
-    issues with keys containing "/../" or ending with "/" etc.
-
-    "/" is escaped to "%" because it's short and rarely used, and resembles
-        a slash
-    "%" is escaped to "&s", and "&" to "&a"; this ensures that the mapping
-        is one to one.
-    ":" is escaped to "&c", because it seemed like a good idea at the time.
-
-    Changing what this function escapes and how is not a good idea, as it
-    can cause existing objects to get lost.
-    """
-    esc = {
-        '/': '%',
-        '%': '&s',
-        '&': '&a',
-        ':': '&c',
-    }
-    return ''.join(esc.get(c, c) for c in key)
 
 
 def main():

--- a/datalad/support/annex_utils.py
+++ b/datalad/support/annex_utils.py
@@ -65,3 +65,32 @@ def _get_non_existing_from_annex_output(output):
             unknown_paths.append(line[11:-10])
 
     return unknown_paths
+
+
+def _sanitize_key(key):
+    """Returns a sanitized key that is a suitable directory/file name
+
+    Documentation from the analog implementation in git-annex
+    Annex/Locations.hs
+
+    Converts a key into a filename fragment without any directory.
+
+    Escape "/" in the key name, to keep a flat tree of files and avoid
+    issues with keys containing "/../" or ending with "/" etc.
+
+    "/" is escaped to "%" because it's short and rarely used, and resembles
+        a slash
+    "%" is escaped to "&s", and "&" to "&a"; this ensures that the mapping
+        is one to one.
+    ":" is escaped to "&c", because it seemed like a good idea at the time.
+
+    Changing what this function escapes and how is not a good idea, as it
+    can cause existing objects to get lost.
+    """
+    esc = {
+        '/': '%',
+        '%': '&s',
+        '&': '&a',
+        ':': '&c',
+    }
+    return ''.join(esc.get(c, c) for c in key)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -60,6 +60,7 @@ from datalad.support.exceptions import CapturedException
 from datalad.support.annex_utils import (
     _fake_json_for_non_existing,
     _get_non_existing_from_annex_output,
+    _sanitize_key,
 )
 from datalad.ui import ui
 import datalad.utils as ut
@@ -3231,7 +3232,11 @@ class AnnexRepo(GitRepo, RepoInterface):
             # TODO optimize order based on some check that reveals
             # what scheme is used in a given annex
             r['has_content'] = False
-            key = r['key']
+            # some keys like URL-s700145--https://arxiv.org/pdf/0904.3664v1.pdf
+            # require sanitization to be able to mark content availability
+            # correctly. Can't limit to URL backend only; custom key backends
+            # may need it, too
+            key = _sanitize_key(r['key'])
             for testpath in (
                     # ATM git-annex reports hashdir in native path
                     # conventions and the actual file path `f` in

--- a/datalad/support/tests/test_fileinfo.py
+++ b/datalad/support/tests/test_fileinfo.py
@@ -233,6 +233,23 @@ def test_report_absent_keys(path):
                 eval_availability=True)):
         assert_in(testfile, ai)
         assert_equal(ai[testfile]['has_content'], False)
+    # make sure files with URL keys are correctly reported:
+    from datalad import test_http_server
+    remote_file_name = 'imaremotefile.dat'
+    local_file_name = 'mehasurlkey'
+    (Path(test_http_server.path) / remote_file_name).write_text("weee")
+    remote_file_url = f'{test_http_server.url}/{remote_file_name}'
+    # we need to get a file with a URL key and check its local availability
+    ds.repo.call_annex(['addurl', '--relaxed', remote_file_url, '--file',
+                        local_file_name])
+    ds.save("URL keys!")
+    # should not be there
+    res = ds.repo.get_file_annexinfo(local_file_name, eval_availability=True)
+    assert_equal(res['has_content'], False)
+    ds.get(local_file_name)
+    # should be there
+    res = ds.repo.get_file_annexinfo(local_file_name, eval_availability=True)
+    assert_equal(res['has_content'], True)
 
 
 @with_tempfile


### PR DESCRIPTION
In #6630 I noticed wrong reporting of ``datalad status --annex all`` for https://github.com/datalad-datasets/machinelearning-books - even though all content was retrieved, only a fraction of it was reported as being locally available by DataLad. git-annex' own reports were fine, and matched file system reports.

```
adina@muninn in /tmp/machinelearning-books on git:master
❱ git annex info
trusted repositories: 0
semitrusted repositories: 8
	00000000-0000-0000-0000-000000000001 -- web
 	00000000-0000-0000-0000-000000000002 -- bittorrent
 	51d4ba52-edfc-4505-bd36-21233a06f8cb -- yoh@lena:~/proj/datalad/datasets/machinelearning-books
 	7f1346f6-a5dd-485d-96dc-563d0a221a95 -- yoh@hopa:/tmp/mlbooks
 	c6bcd625-0a68-49bb-acd5-51c28e2e3073 -- yoh@hopa:~/proj/datalad/repos/mlbooks
 	d5f231e1-6901-456a-9398-39299242baf6 -- mih@meiner:/tmp/machinelearning-books
 	dcfeee85-513e-43fb-bbac-cbbeb8ccad30 -- adina@muninn:/tmp/machinelearning-books [here]
 	fb0fcdc2-d42d-44e9-beac-74c684962ddd -- adina@muninn:/tmp/machinelearning-books
untrusted repositories: 0
transfers in progress: none
available local disk space: 156.44 gigabytes (+1 megabyte reserved)
local annex keys: 10
local annex size: 77.97 megabytes (+ 1 unknown size)
annexed files in working tree: 10
size of annexed files in working tree: 77.97 megabytes (+ 1 unknown size)
bloom filter size: 32 mebibytes (0% full)
backend usage: 
	MD5E: 2
	URL: 8
adina@muninn in /tmp/machinelearning-books on git:master
❱ datalad status --annex all
9 annex'd files (28.8 MB/74.4 MB present/total size)
nothing to save, working tree clean
adina@muninn in /tmp/machinelearning-books on git:master
❱ du -sh .       
78M	.
adina@muninn in /tmp/machinelearning-books on git:master
❱ du -shLc *.pdf
684K	A.Shashua-Introduction_to_Machine_Learning.pdf
8.5M	B.Efron_T.Hastie-Computer_Age_Statistical_Inference.pdf
3.9M	C.E.Rasmussen_C.K.I.Williams-Gaussian_Processes_for_Machine_Learning.pdf
14M	D.Barber-Bayesian_Reasoning_and_Machine_Learning.pdf
12M	D.C.C.MacKay-Information_Theory_Inference_and_Learning_Algorithms.pdf
1.8M	D.Michie_D.J.Spiegelhalter-Machine_Learning_Neural_and_Statistical_Classification.pdf
21M	G.James_D.Witten_T.Hastie_R.Tibshirani-An_Introduction_to_Statistical_Learning_with_Applications_in_R.pdf
2.6M	H.DaumeIII-A_Course_in_Machine_Learning.pdf
1.9M	N.J.Nilsson-Introduction_to_Machine_Learning.pdf
13M	T.Hastie_R.Tibshirani_J.Friedman-The_Elements_of_Statistical_Learning_Data_Mining_Inference_and_Prediction.pdf
77M	total
```

This problem did not occur in other datasets, and closer investigation brought to light that the problem occurred only with files that had a URL backend: <details><summary>files with URL-keys were universally reported with has_content: false </summary>

```
adina@muninn in /tmp/machinelearning-books on git:master
❱ datalad -f json status --annex all | grep has_content          
{"action": "status", "backend": "URL", "bytesize": 700145, "error-messages": [], "gitshasum": "4656c6e860767799a64c37b472f8c5147a25f1e0", "has_content": false, "hashdirlower": "59f/b1c/", "hashdirmixed": "xK/7m/", "humansize": "700.14 kB", "key": "URL-s700145--https://arxiv.org/pdf/0904.3664v1.pdf", "keyname": "https://arxiv.org/pdf/0904.3664v1.pdf", "mtime": "unknown", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/A.Shashua-Introduction_to_Machine_Learning.pdf", "prev_gitshasum": "4656c6e860767799a64c37b472f8c5147a25f1e0", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "MD5E", "bytesize": 8908337, "error-messages": [], "gitshasum": "200821070bf66e071340eaccbe620b17be284fd1", "has_content": true, "humansize": "8.91 MB", "key": "MD5E-s8908337--379ca0649dacbad93f3557b4410cc5ce.pdf", "keyname": "379ca0649dacbad93f3557b4410cc5ce.pdf", "mtime": "unknown", "objloc": "/tmp/machinelearning-books/.git/annex/objects/Jw/V0/MD5E-s8908337--379ca0649dacbad93f3557b4410cc5ce.pdf/MD5E-s8908337--379ca0649dacbad93f3557b4410cc5ce.pdf", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/B.Efron_T.Hastie-Computer_Age_Statistical_Inference.pdf", "prev_gitshasum": "200821070bf66e071340eaccbe620b17be284fd1", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "URL", "bytesize": 4052292, "error-messages": [], "gitshasum": "c1bf87ea673d87be8c2780e302b69a0fc3d1478c", "has_content": false, "hashdirlower": "492/acd/", "hashdirmixed": "99/pg/", "humansize": "4.05 MB", "key": "URL-s4052292--http://www.gaussianprocess.org/gpml/chapters/RW.pdf", "keyname": "http://www.gaussianprocess.org/gpml/chapters/RW.pdf", "mtime": "unknown", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/C.E.Rasmussen_C.K.I.Williams-Gaussian_Processes_for_Machine_Learning.pdf", "prev_gitshasum": "c1bf87ea673d87be8c2780e302b69a0fc3d1478c", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "URL", "bytesize": 14324939, "error-messages": [], "gitshasum": "f16d7d403ead4853d2e23b46f756d84e7230f2c5", "has_content": false, "hashdirlower": "85c/cbd/", "hashdirmixed": "g5/mW/", "humansize": "14.32 MB", "key": "URL-s14324939--http://web4.cs.ucl.ac.uk/staff/D.Barber/textbook/240415.pdf", "keyname": "http://web4.cs.ucl.ac.uk/staff/D.Barber/textbook/240415.pdf", "mtime": "unknown", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/D.Barber-Bayesian_Reasoning_and_Machine_Learning.pdf", "prev_gitshasum": "f16d7d403ead4853d2e23b46f756d84e7230f2c5", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "URL", "bytesize": 11675219, "error-messages": [], "gitshasum": "288c0b228d5fdb87c80276949299d8a7e5044b66", "has_content": false, "hashdirlower": "0c6/c78/", "hashdirmixed": "vj/P6/", "humansize": "11.68 MB", "key": "URL-s11675219--http://www.inference.phy.cam.ac.uk/itprnn/book.pdf", "keyname": "http://www.inference.phy.cam.ac.uk/itprnn/book.pdf", "mtime": "unknown", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/D.C.C.MacKay-Information_Theory_Inference_and_Learning_Algorithms.pdf", "prev_gitshasum": "288c0b228d5fdb87c80276949299d8a7e5044b66", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "URL", "bytesize": 1787416, "error-messages": [], "gitshasum": "033368d1d23a5ba543660f3d7e47cea248937124", "has_content": false, "hashdirlower": "b1f/a73/", "hashdirmixed": "zw/WF/", "humansize": "1.79 MB", "key": "URL-s1787416--http://www1.maths.leeds.ac.uk/,126charles/statlog/whole.pdf", "keyname": "http://www1.maths.leeds.ac.uk/,126charles/statlog/whole.pdf", "mtime": "unknown", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/D.Michie_D.J.Spiegelhalter-Machine_Learning_Neural_and_Statistical_Classification.pdf", "prev_gitshasum": "033368d1d23a5ba543660f3d7e47cea248937124", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "MD5E", "bytesize": 21322662, "error-messages": [], "gitshasum": "7d7476bd567d98e435f5fbe801da3f7594461848", "has_content": true, "humansize": "21.32 MB", "key": "MD5E-s21322662--8689c3c26c3a1ceb60c1ba995d638677.pdf", "keyname": "8689c3c26c3a1ceb60c1ba995d638677.pdf", "mtime": "unknown", "objloc": "/tmp/machinelearning-books/.git/annex/objects/jQ/GM/MD5E-s21322662--8689c3c26c3a1ceb60c1ba995d638677.pdf/MD5E-s21322662--8689c3c26c3a1ceb60c1ba995d638677.pdf", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/G.James_D.Witten_T.Hastie_R.Tibshirani-An_Introduction_to_Statistical_Learning_with_Applications_in_R.pdf", "prev_gitshasum": "7d7476bd567d98e435f5fbe801da3f7594461848", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "URL", "error-messages": [], "gitshasum": "fce89a7c7c64b30b6ec47b409b01b51a26817cfb", "has_content": false, "hashdirlower": "49c/39f/", "hashdirmixed": "x9/7W/", "humansize": "unknown", "key": "URL--http://ciml.info/dl/v0_9/ciml-v0_9-all.pdf", "keyname": "http://ciml.info/dl/v0_9/ciml-v0_9-all.pdf", "mtime": "unknown", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/H.DaumeIII-A_Course_in_Machine_Learning.pdf", "prev_gitshasum": "fce89a7c7c64b30b6ec47b409b01b51a26817cfb", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "URL", "bytesize": 1899248, "error-messages": [], "gitshasum": "9dcb1126925e8bf8b522c52c6fc9998ed75eac50", "has_content": false, "hashdirlower": "7b7/576/", "hashdirmixed": "ZV/G7/", "humansize": "1.9 MB", "key": "URL-s1899248--http://ai.stanford.edu/,126nilsson/MLBOOK.pdf", "keyname": "http://ai.stanford.edu/,126nilsson/MLBOOK.pdf", "mtime": "unknown", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/N.J.Nilsson-Introduction_to_Machine_Learning.pdf", "prev_gitshasum": "9dcb1126925e8bf8b522c52c6fc9998ed75eac50", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
{"action": "status", "backend": "URL", "bytesize": 13303613, "error-messages": [], "gitshasum": "56f06acd6e44aa436897a188672f8e16f0a9f849", "has_content": false, "hashdirlower": "320/9ef/", "hashdirmixed": "4g/Vv/", "humansize": "13.3 MB", "key": "URL-s13303613--http://statweb.stanford.edu/,12-04e98153e096973a0e94d05ae90fce26", "keyname": "http://statweb.stanford.edu/,12-04e98153e096973a0e94d05ae90fce26", "mtime": "unknown", "parentds": "/tmp/machinelearning-books", "path": "/tmp/machinelearning-books/T.Hastie_R.Tibshirani_J.Friedman-The_Elements_of_Statistical_Learning_Data_Mining_Inference_and_Prediction.pdf", "prev_gitshasum": "56f06acd6e44aa436897a188672f8e16f0a9f849", "refds": "/tmp/machinelearning-books", "state": "clean", "status": "ok", "type": "file"}
```
</details>

The reason turned out to be an encoding issue. While git annex escapes keys (``URL-s700145--https://arxiv.org/pdf/0904.3664v1.pdf``) to file name fragments without any directory component (``URL-s700145--https&c%%arxiv.org%pdf%0904.3664v1.pdf``), DataLad's internal ``_mark_content_availability`` used unsanitized keys when it looked for available content in the object tree, failing to find them at all times.

This PR moves ORA's ``_sanitize_key`` helper into a domain agnostic location and reuses it to safe-guard ``_mark_content_availability`` against unusual key formats or URL backends or other custom backends. This change fixes ``datalad status --annex all`` reporting in the original issue.

Fixes #6630


#### 🐛 Bug Fixes
- Sanitize keys before checking content availability to ensure that the content availability of files with URL- or custom backend is correctly determined and marked Fixes #6630

