### PR TITLE
NF: Teach WTF to report the filesystem of CWD, TMP, and HOME

### DIFF
--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -512,13 +512,23 @@ class WTF(Interface):
         from datalad.ui import ui
         out = _render_report(res)
         ui.message(out)
-        # if the record lacks file system information, hint at a psutil problem
-        if res['infos']['system']['filesystem']['TMP'].get('type') is None:
-            from datalad.support import ansi_colors
-            ui.message("{}".format(
-                ansi_colors.color_word(
-                    'Hint: Failed to file system information with psutil',
-                    ansi_colors.YELLOW)))
+        # add any necessary hints afterwards
+        maybe_show_hints(res)
+
+
+def maybe_show_hints(res):
+    """Helper to add hints to custom result rendering"""
+    # check for missing file system info
+    # if the system record lacks file system information, hint at a psutil
+    # problem. Query for TMP should be safe, is included in system info
+    from datalad.ui.utils import show_hint
+
+    if 'system' in res.get('infos', {}) and \
+        'type' not in res['infos']['system']['filesystem']['TMP']:
+        try:
+            import psutil
+        except ImportError:
+            show_hint('Hint: install psutil to get filesystem information')
 
 
 def _render_report(res):

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -139,13 +139,14 @@ def _describe_system():
                                   _t2s(pl.win32_ver())]).rstrip(),
         'max_path_length': get_max_path_length(getpwd()),
         'encoding': get_encoding_info(),
-        'filesystem': [_get_fs_type(p) for p in [os.getcwd(),
-                                                 tempfile.gettempdir(),
-                                                 str(Path.home())]]
+        'filesystem': {l: _get_fs_type(l, p) for l, p in
+                       [('CWD', os.getcwd()),
+                        ('TMP', tempfile.gettempdir()),
+                        ('HOME', str(Path.home()))]}
     }
 
 
-def _get_fs_type(path):
+def _get_fs_type(loc, path):
     try:
         from psutil import disk_partitions
         match = ""
@@ -159,7 +160,8 @@ def _get_fs_type(path):
         ce = CapturedException(exc)
         lgr.warning("Failed to get filesystem information: %s", ce)
         fs = tuple()
-    return f'{path}: {fs}'
+    return {'path': path,
+            'type': fs}
 
 
 def _describe_environment():

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -147,6 +147,8 @@ def _describe_system():
 
 
 def _get_fs_type(loc, path):
+    global fs_hint
+    fs_hint = None
     try:
         from psutil import disk_partitions
         match = ""
@@ -158,7 +160,7 @@ def _get_fs_type(loc, path):
                 match = part.mountpoint
     except Exception as exc:
         ce = CapturedException(exc)
-        lgr.warning("Failed to get filesystem information: %s", ce)
+        fs_hint = "Hint: Install psutils to get file system type information"
         fs = tuple()
     return {'path': path,
             'type': fs}
@@ -504,7 +506,10 @@ class WTF(Interface):
         from datalad.ui import ui
         out = _render_report(res)
         ui.message(out)
-
+        if fs_hint is not None:
+            from datalad.support import ansi_colors
+            ui.message("{}".format(
+                ansi_colors.color_word(fs_hint, ansi_colors.YELLOW)))
 
 def _render_report(res):
     report = u'# WTF'

--- a/datalad/ui/utils.py
+++ b/datalad/ui/utils.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Various utils oriented to UI"""
 
+from datalad.support import ansi_colors
 from datalad.utils import on_windows
 import struct
 
@@ -65,3 +66,11 @@ def get_console_width(default_min=20):
         # to prevent crashes below guarantee that it is at least 20
         console_width = 20
     return console_width
+
+
+def show_hint(msg):
+    from datalad.ui import ui
+    ui.message("{}".format(
+            ansi_colors.color_word(
+                msg,
+                ansi_colors.YELLOW)))


### PR DESCRIPTION
This PR teaches ``datalad wtf`` to report the file systems of ``TMP``, ``CWD``, and ``HOME`` as suggested in  #6294 using ``psutil``. On my Debian system, the output looks like this

```
(handbook) adina@muninn in ~/Documents
❱ datalad wtf -S system
# WTF
## system 
  - distribution: debian/11-updates/n/a
  - encoding: 
    - default: utf-8
    - filesystem: utf-8
    - locale.prefered: UTF-8
  - filesystem: 
    - /home/adina/Documents: ext4
    - /tmp: ext4
    - /home/adina: ext4
  - max_path_length: 277
  - name: Linux
  - release: 5.16.0-3-amd64
  - type: posix
  - version: #1 SMP PREEMPT Debian 5.16.11-1 (2022-02-25)
```

On my Windows machine it looks like this:

```
C:\Users\adina\repos\datalad>datalad wtf -S system
# WTF
## system
  - distribution:   10/10.0.19044/SP0/Multiprocessor Free
  - encoding:
    - default: utf-8
    - filesystem: utf-8
    - locale.prefered: cp1252
  - filesystem:
    - C:\Users\adina\repos\datalad: NTFS
    - C:\Users\adina\AppData\Local\Temp: NTFS
    - C:\Users\adina: NTFS
  - max_path_length: 284
  - name: Windows
  - release: 10
  - type: nt
  - version: 10.0.19044
```

We might need to consider moving ``psutil`` from a development requirement into a standard requirement if we want to ensure this is reported everywhere (if it isn't installed, the file system info is an empty tuple). However, I've read that psutil is quite "heavy", so I wanted to discuss this here first.

Fixes #6294

### Changelog
#### 💫 Enhancements and new features
- ``datalad wtf`` includes a report on file system types of commonly used paths



