### PR TITLE
Make `push` avoid refspec handling for special remote push targets

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -550,9 +550,11 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
     else:
         lgr.debug("No data transfer: %s is not a git annex repository", repo)
 
-    if not target_is_git_remote:
+    if not target_is_git_remote or not refspecs2push:
         # there is nothing that we need to push or sync with on the git-side
         # of things with this remote
+        lgr.debug('No git-remote or no refspecs found that need to be pushed')
+        # TODO ensure progress bar is ended properly
         return
 
     log_progress(
@@ -607,10 +609,6 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
         if "fatal: couldn't find remote ref git-annex" not in e.stderr.lower():
             raise
         lgr.debug('Remote does not have a git-annex branch: %s', e)
-
-    if not refspecs2push:
-        lgr.debug('No refspecs found that need to be pushed')
-        return
 
     # and push all relevant branches, plus the git-annex branch to announce
     # local availability info too

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -472,7 +472,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
     # (possibly redo) a push attempt to figure out what needs pushing
     # do this on the main target only, and apply the result to all
     # dependencies
-    if _target:
+    if _target and wannabe_gitpush is None:
         # only do it when an explicit target was given, otherwise
         # we can reuse the result from the auto-probing above
         wannabe_gitpush = _get_push_dryrun(repo, remote=target)
@@ -900,6 +900,11 @@ def _get_corresponding_remote_state(repo, to):
 
 def _get_push_dryrun(repo, remote=None):
     """
+    Returns
+    -------
+    list
+      The result of the dry-run. Will be an empty list of the dry-run
+      failed for any reason.
     """
     try:
         wannabe_gitpush = repo.push(remote=remote, git_options=['--dry-run'])
@@ -917,14 +922,15 @@ def _get_push_target(repo, target_arg):
     """
     Returns
     -------
-    str or None, str, str or None, list
+    str or None, str, str or None, list or None
       Target label, if determined; status label; optional message;
-      git-push-dryrun result for re-use
+      git-push-dryrun result for re-use or None, if no dry-run was
+      attempted.
     """
     # verified or auto-detected
     target = None
     # for re-use
-    wannabe_gitpush = []
+    wannabe_gitpush = None
     if not target_arg:
         # let Git figure out what needs doing
         # we will reuse the result further down again, so nothing is wasted

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -617,7 +617,7 @@ def test_gh1763(src, target1, target2):
 @with_tempfile()
 @with_tempfile()
 def test_gh1811(srcpath, clonepath):
-    orig = Dataset(srcpath).create()
+    orig = Dataset(srcpath).create(annex=False)
     (orig.pathobj / 'some').write_text('some')
     orig.save()
     clone = Clone.__call__(source=orig.path, path=clonepath)


### PR DESCRIPTION
This PR refactors `push.py:_push()` to make the flow more intelligible.

Importantly, it makes one behavior change, which is desirable IMHO. Instead of rejecting to git-push any refspec for a repo with a detached HEAD, it will attempt to push a `git-annex` branch for an `AnnexRepo`. The respective test that ensured this behavior beyond the particular conditions the original problem occurred in was adjusted accordingly.

### Changelog
#### 🐛 Bug Fixes
- `push` now only evaluates `refspecs` to push to a remote when the target remote is actually a Git remote. Fixes #6657
