### PR TITLE
RF special remote base classes

### DIFF
--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -91,7 +91,6 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
     URL_SCHEME = SUPPORTED_SCHEMES[0]
     URL_PREFIX = URL_SCHEME + ":"
 
-    AVAILABILITY = "local"
     COST = 500
 
     def __init__(self, annex, path=None, persistent_cache=True, **kwargs):

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -32,7 +32,7 @@ URI_PREFIX = "dl"
 class AnnexCustomRemote(SpecialRemote):
     # default properties
     COST = 100
-    AVAILABILITY = "LOCAL"
+    AVAILABILITY = "local"
 
     def __init__(self, annex):  # , availability=DEFAULT_AVAILABILITY):
         super().__init__(annex)
@@ -122,7 +122,7 @@ class AnnexCustomRemote(SpecialRemote):
         return self.COST
 
     def getavailability(self):
-        return self.AVAILABILITY.lower()
+        return self.AVAILABILITY
 
 
 # this function only has anecdotal value and is not used anywhere

--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -24,8 +24,6 @@ from annexremote import (
 )
 from datalad.customremotes import SpecialRemote
 
-from datalad.ui import ui
-
 URI_PREFIX = "dl"
 
 
@@ -37,10 +35,6 @@ class AnnexCustomRemote(SpecialRemote):
     def __init__(self, annex):  # , availability=DEFAULT_AVAILABILITY):
         super().__init__(annex)
         # TODO self.info = {}, self.configs = {}
-
-        # instruct annex backend UI to use this remote
-        if ui.backend == 'annex':
-            ui.set_specialremote(self)
 
         # OPT: a counter to increment upon successful encounter of the scheme
         # (ATM only in gen_URLS but later could also be used in other
@@ -75,35 +69,6 @@ class AnnexCustomRemote(SpecialRemote):
                     nurls += 1
                     yield url
         self.annex.debug("Processed %d URL(s) for key %s", nurls, key)
-
-    def send_progress(self, progress):
-        """Indicates the current progress of the transfer (in bytes).
-
-        May be repeated any number of times during the transfer process.
-
-        Too frequent updates are wasteful but bear in mind that this is used
-        both to display a progress meter for the user, and for
-        ``annex.stalldetection``. So, sending an update on each 1% of the file
-        may not be frequent enough, as it could appear to be a stall when
-        transferring a large file.
-
-        Parameters
-        ----------
-        progress : int
-            The current progress of the transfer in bytes.
-        """
-        # This method is called by AnnexSpecialRemoteProgressBar through an
-        # obscure process that involves multiple layers of abstractions for
-        # UIs, providers, downloaders, progressbars, which is only happening
-        # within the environment of a running special remote process though
-        # a combination of circumstances.
-        #
-        # The main purpose of this method is to have a place to leave this
-        # comment within the code base of the special remotes, in order to
-        # aid future souls having to sort this out.
-        # (and to avoid having complex code make direct calls to internals
-        # of this class, making things even more complex)
-        self.annex.progress(progress)
 
     # Protocol implementation
     def initremote(self):

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -20,6 +20,9 @@ from datalad.cli.parser import (
 from datalad.cli.utils import setup_exceptionhook
 from datalad.ui import ui
 
+import logging
+lgr = logging.getLogger('datalad.customremotes')
+
 
 def setup_parser(remote_name, description):
     # setup cmdline args parser
@@ -74,6 +77,8 @@ def main(args=None, cls=None, remote_name=None, description=None):
         try:
             _main(args, cls)
         except Exception as exc:
+            lgr.debug('%s (%s) - passing ERROR to git-annex and exiting',
+                      str(exc), exc.__class__.__name__)
             # `SpecialRemote` classes are supposed to catch everything and
             # turn it into a `RemoteError` resulting in an ERROR message to
             # annex. If we end up here, something went wrong outside of the

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -18,7 +18,6 @@ from datalad.cli.parser import (
     parser_add_version_opt,
 )
 from datalad.cli.utils import setup_exceptionhook
-from datalad.log import lgr
 from datalad.ui import ui
 
 
@@ -75,5 +74,12 @@ def main(args=None, cls=None, remote_name=None, description=None):
         try:
             _main(args, cls)
         except Exception as exc:
-            lgr.error('%s (%s)', str(exc), exc.__class__.__name__)
+            # `SpecialRemote` classes are supposed to catch everything and
+            # turn it into a `RemoteError` resulting in an ERROR message to
+            # annex. If we end up here, something went wrong outside of the
+            # `master.Listen()` call in `_main`.
+            # In any case, exiting the special remote process should be
+            # accompanied by such an ERROR message to annex rather than a log
+            # message.
+            print("ERROR %s (%s)" % (str(exc), exc.__class__.__name__))
             sys.exit(1)

--- a/datalad/customremotes/tests/test_main.py
+++ b/datalad/customremotes/tests/test_main.py
@@ -1,0 +1,39 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Tests for the "main" driver of the special remotes"""
+
+import logging
+import os
+
+from ..main import main
+
+from ..base import AnnexCustomRemote
+
+from datalad.tests.utils_pytest import (
+    swallow_logs,
+    swallow_outputs,
+)
+
+import pytest
+
+
+def test_erroring_out():
+    class TooAbstract(AnnexCustomRemote):
+        pass
+
+    with swallow_logs(new_level=logging.DEBUG) as cml, \
+        swallow_outputs() as cmo:
+        with pytest.raises(SystemExit) as cme:
+            main(args=[], cls=TooAbstract)
+        assert cme.value.code == 1
+        assert 'passing ERROR to git-annex' in cml.out
+        # verify basic correct formatting of string to git-annex
+        assert cmo.out.startswith('ERROR ')
+        assert os.linesep not in cmo.out.rstrip()
+        assert cmo.out.endswith('\n')  # This is the case even on Windows.


### PR DESCRIPTION
This is refactoring our `SpecialRemote` and `AnnexCustomRemote` classes. The latter only serves as base class for the `datalad` and `datalad-archives` special remotes, whereas the former is the more general one. Hence, move functionality that isn't specific to those two.
Two minor fixes along the way:
- Implementation of availability was a bit inconsistent
- Possible failure at the outermost layer wasn't sending an ERROR message to annex, but only logging.

I don't think this needs a changelog.