### PR TITLE
BF: require argcomplete version at least 1.12.3 to test/operate correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 # vim ft=yaml
 # travis-ci.org definition for DataLad build
 language: python
+
+# Do full clone (~10 extra seconds) to fetch all tags.
+# Otherwise we might be missing the tags for maint PRs
+# whenever those maint releases were not yet merged into master.
+# TODO: specify TRAVIS_BRANCH if ever would become possible
+#(support request was sent to Travis)
+git:
+  depth: false
+
 services:
   - docker
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ requires = {
         'python-gitlab',     # required for create-sibling-gitlab
     ],
     'misc': [
-        'argcomplete',       # optional CLI completion
+        'argcomplete>=1.12.3',  # optional CLI completion
         'pyperclip',         # clipboard manipulations
         'python-dateutil',   # add support for more date formats to check_dates
     ],


### PR DESCRIPTION
On debian stable bullseye and ubuntu 22.04 we have 1.8.1 and test_completion fails.

I will add corresponding version depend also for debian/control in debian branch. 