### PR TITLE
ENH: Better feedback when create-sibling-gitlab is called with non-existing path

### DIFF
--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -54,6 +54,15 @@ def test_dryrun(path):
     ctlg = _get_nested_collections(path)
     # no site config -> error
     assert_raises(ValueError, ctlg['root'].create_sibling_gitlab)
+    # wrong path specification -> impossible result
+    res = ctlg['root'].create_sibling_gitlab(
+        dry_run=True, on_failure='ignore',
+        site='dummy', path='imaghost'
+    )
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1, path=ctlg['root'].pathobj / 'imaghost', type='dataset',
+                          status='impossible')
     # single project vs multi-dataset call
     assert_raises(
         ValueError,


### PR DESCRIPTION
When create-sibling-gitlab receives a path to a non-existing or non-dataset location, it does not provide any feedback to the user about this (#6700). This PR makes ``create-sibling-gitlab`` yield an impossible result whenever a provided path does not point to a subdataset:

```
$ datalad create-sibling-gitlab --site https://jugit.fz-juelich.de thisismyproject                    1 !
create_sibling_gitlab(impossible): thisismyproject (dataset) [No dataset found under /tmp/some/thisismyproject]
```

### Changelog

#### 💫 Enhancements and new features
- When ``create-sibling-gitlab`` is called on non-existing subdatasets or paths it now returns an impossible result instead of no feedback at all