### PR TITLE
ENH: Rudimentary CODEOWNERS file to test assigning code responsibility

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a 
+# pull request.
+*       @datalad/developers
+
+# The Runner
+*cmd.py             christian.moench@web.de
+/datalad/runner/*   christian.moench@web.de
+
+*foreach_dataset.py @yarikoptic
+
+# See CODEOWNERS syntax here: https://help.github.com/articles/about-codeowners/#codeowners-syntax


### PR DESCRIPTION
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
for more info.  I have spotted that file in

https://github.com/w3c-ccg/markdown-to-spec  template

and decided to give it a shot

Suggest your additions etc but might be worth first merging and seeing what it would give us if anything