### PR TITLE
Ensure that assertion helpers in `utils_pytest.py` get rewritten by pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,8 @@ markers =
     with_sameas_remotes
     with_testrepos
     without_http_proxy
+# Ensure that assertion helpers in utils_pytest.py get rewritten by pytest:
+python_files = test_*.py *_test.py utils_pytest.py
 
 [flake8]
 #show-source = True


### PR DESCRIPTION
In order to provide useful information when a test fails, pytest rewrites `assert` statements in test code so that failures will show the values involved.  However, this only applies to code in test files, which, by default, are files with names of the form `test_*.py` or `*_test.py`.  This PR adds `utils_pytest.py` to the set of files considered test files so that the assertions in the assertion helpers within will be rewritten; without this change, a failing, say, `assert_equal(x, y)` will just show "`AssertionError`" but not `x` or `y`.

Note that this only affects tests run on datalad itself; other projects that use assertion helpers in `utils_pytest.py` will not benefit from assertion rewriting (unless we instead rename `utils_pytest.py`).