### PR TITLE
BF: Catch KeyErrors from unavailable WTF infos

### DIFF
--- a/datalad/local/tests/test_wtf.py
+++ b/datalad/local/tests/test_wtf.py
@@ -126,6 +126,10 @@ def test_wtf(topdir):
         wtf(flavor='short', sections='*')
         assert_greater(len(cmo.out.splitlines()), 10)  #  many more
 
+    # check that wtf of an unavailable section yields impossible result (#6712)
+    res = wtf(sections=['murkie'], on_failure='ignore')
+    eq_(res[0]["status"], "impossible")
+
     # should result only in '# WTF'
     skip_if_no_module('pyperclip')
 

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -463,8 +463,18 @@ class WTF(Interface):
                 raise ValueError(flavor)
 
         for s in sections:
-            infos[s] = section_callables[s]()
-
+            try:
+                infos[s] = section_callables[s]()
+            except KeyError:
+                yield get_status_dict(
+                    action='wtf',
+                    path=Path.cwd(),
+                    status='impossible',
+                    message=(
+                      'Requested section <%s> was not found among the '
+                      'available infos. Skipping report.', s),
+                    logger=lgr
+                    )
         if clipboard:
             external_versions.check(
                 'pyperclip', msg="It is needed to be able to use clipboard")


### PR DESCRIPTION
When unavailble WTF sections are requested, e.g., '-S dataset'
outside of any dataset, the command errors with a KeyError
(#6711). This change catches this and reports an impossible
result for the affected section, such that the problem is
communicated orderly, and that the reporting of other sections
is not impacted

PS: Is `maint` the correct target for this?

### Changelog
#### 🐛 Bug Fixes
- ``wtf`` now reports on unavailable info sections with an 'impossible' result record instead of failing with a KeyError. Fixes #6711
