### PR TITLE
Color update

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -305,13 +305,13 @@ class Push(Interface):
         hints = [hint for hint in hints if hint is not None]
         if hints:
             from datalad.ui import ui
-            from datalad.support import ansi_colors
-            intro = ansi_colors.color_word(
+            from datalad.support.ansi_colors import formatter as ansi
+            intro = ansi.colorize(
                 "Hints: ",
-                ansi_colors.YELLOW)
+                ansi.color.YELLOW)
             ui.message(intro)
             [ui.message("{}: {}".format(
-                ansi_colors.color_word(id + 1, ansi_colors.YELLOW), hint))
+                ansi.colorize(id + 1, ansi.color.YELLOW), hint))
                 for id, hint in enumerate(hints)]
 
 

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 import datalad
-import datalad.support.ansi_colors as ac
+from datalad.support.ansi_colors import formatter as ansi
 from datalad.config import anything2bool
 from datalad.core.local.save import Save
 from datalad.core.local.status import Status
@@ -339,11 +339,11 @@ class Run(Interface):
 
 
 def _display_basic(res):
-    ui.message(ac.color_word("Dry run information", ac.MAGENTA))
+    ui.message(ansi.colorize("Dry run information", ansi.color.MAGENTA))
 
     def fmt_line(key, value, multiline=False):
         return (" {key}:{sep}{value}"
-                .format(key=ac.color_word(key, ac.BOLD),
+                .format(key=ansi.colorize(key, ansi.color.BOLD),
                         sep=os.linesep + "  " if multiline else " ",
                         value=value))
 

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -35,7 +35,7 @@ from datalad.interface.utils import (
     eval_results,
     generic_result_renderer,
 )
-import datalad.support.ansi_colors as ac
+from datalad.support.ansi_colors import formatter as ansi
 from datalad.support.param import Parameter
 from datalad.support.constraints import (
     EnsureChoice,
@@ -100,11 +100,11 @@ _common_diffstatus_params = dict(
 
 
 STATE_COLOR_MAP = {
-    'untracked': ac.RED,
-    'modified': ac.RED,
-    'deleted': ac.RED,
-    'added': ac.GREEN,
-    'unknown': ac.YELLOW,
+    'untracked': ansi.color.RED,
+    'modified': ansi.color.RED,
+    'deleted': ansi.color.RED,
+    'added': ansi.color.GREEN,
+    'unknown': ansi.color.YELLOW,
 }
 
 
@@ -444,12 +444,12 @@ class Status(Interface):
         state = res.get('state', 'unknown')
         ui.message(u'{fill}{state}: {path}{type_}'.format(
             fill=' ' * max(0, max_len - len(state)),
-            state=ac.color_word(
+            state=ansi.colorize(
                 state,
                 STATE_COLOR_MAP.get(res.get('state', 'unknown'))),
             path=path,
             type_=' ({})'.format(
-                ac.color_word(type_, ac.MAGENTA) if type_ else '')))
+                ansi.colorize(type_, ansi.color.MAGENTA) if type_ else '')))
 
     @staticmethod
     def custom_result_summary_renderer(results):  # pragma: more cover

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -16,7 +16,10 @@ import os
 import os.path as op
 from urllib.parse import urlparse
 
-import datalad.support.ansi_colors as ac
+from datalad.support.ansi_colors import (
+    formatter as ansi,
+    LOG_LEVEL_COLORS,
+)
 from datalad.distribution.dataset import (
     Dataset,
     require_dataset,
@@ -328,7 +331,9 @@ class Siblings(Interface):
         if res['status'] == 'notneeded' and res['action'] == 'remove-sibling':
             ui.message(
                 '{warn}: No sibling "{name}" in dataset {path}'.format(
-                    warn=ac.color_word('Warning', ac.LOG_LEVEL_COLORS['WARNING']),
+                    warn=ansi.colorize(
+                        'Warning',
+                        LOG_LEVEL_COLORS['WARNING']),
                     **res)
             )
             return

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -43,7 +43,10 @@ from datalad import cfg as dlcfg
 from datalad.dochelpers import single_or_plural
 
 from datalad.ui import ui
+# TODO the next import only exists, because the OSF extension
+# imports `ac` from here. Get that fixed and remove this import
 import datalad.support.ansi_colors as ac
+from datalad.support.ansi_colors import formatter as ansi
 
 from datalad.interface.base import default_logchannels
 from datalad.interface.base import get_allargs_as_kwargs
@@ -462,23 +465,23 @@ def generic_result_renderer(res):
                 # drives. just go with the original path in this case
                 pass
         ui.message('{action}({status}):{path}{type}{msg}{err}'.format(
-            action=ac.color_word(
+            action=ansi.colorize(
                 res.get('action', '<action-unspecified>'),
-                ac.BOLD),
-            status=ac.color_status(res.get('status', '<status-unspecified>')),
+                ansi.color.BOLD),
+            status=ansi.color_status(res.get('status', '<status-unspecified>')),
             path=' {}'.format(path) if path else '',
             type=' ({})'.format(
-                ac.color_word(res['type'], ac.MAGENTA)
+                ansi.colorize(res['type'], ansi.color.MAGENTA)
             ) if 'type' in res else '',
             msg=' [{}]'.format(
                 res['message'][0] % res['message'][1:]
                 if isinstance(res['message'], tuple) else res[
                     'message'])
             if res.get('message', None) else '',
-            err=ac.color_word(' [{}]'.format(
+            err=ansi.colorize(' [{}]'.format(
                 res['error_message'][0] % res['error_message'][1:]
                 if isinstance(res['error_message'], tuple) else res[
-                    'error_message']), ac.RED)
+                    'error_message']), ansi.RED)
             if res.get('error_message', None) and res.get('status', None) != 'ok' else ''))
 
 

--- a/datalad/local/check_dates.py
+++ b/datalad/local/check_dates.py
@@ -67,7 +67,6 @@ class CheckDates(Interface):
     of annotated tags.
     """
     from datalad.interface.utils import eval_results
-    import datalad.support.ansi_colors as ac
     from datalad.support.constraints import EnsureChoice, EnsureNone, EnsureStr
     from datalad.support.param import Parameter
 

--- a/datalad/local/clean.py
+++ b/datalad/local/clean.py
@@ -183,7 +183,7 @@ class Clean(Interface):
 
         from os import getcwd
 
-        import datalad.support.ansi_colors as ac
+        from datalad.support.ansi_colors import formatter as ansi
         from datalad.interface.utils import generic_result_renderer
         from datalad.utils import Path
 
@@ -211,7 +211,7 @@ class Clean(Interface):
                 else str(Path(res['path']).relative_to(refds))
 
             ui.message(u"{path}: {message}".format(
-                path=ac.color_word(path, ac.BOLD),
+                path=ansi.colorize(path, ansi.color.BOLD),
                 message=(res['message'][0] % res['message'][1:]
                          if isinstance(res['message'], tuple)
                          else res['message'])

--- a/datalad/local/configuration.py
+++ b/datalad/local/configuration.py
@@ -14,7 +14,7 @@ __docformat__ = 'restructuredtext'
 import logging
 from textwrap import wrap
 
-import datalad.support.ansi_colors as ac
+from datalad.support.ansi_colors import formatter as ansi
 from datalad import cfg as dlcfg
 from datalad.distribution.dataset import (
     Dataset,
@@ -281,7 +281,8 @@ class Configuration(Interface):
             if value in (True, False):
                 # normalize booleans for git-config syntax
                 value = str(value).lower()
-            ui.message(f'{prefix}{ac.color_word(name, ac.BOLD)}={value}')
+            ui.message(
+                f'{prefix}{ansi.colorize(name, ansi.color.BOLD)}={value}')
         else:
             ui.message('{}{}'.format(
                 prefix,

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -19,7 +19,7 @@ import sys
 from argparse import REMAINDER
 from glob import iglob
 
-import datalad.support.ansi_colors as ac
+from datalad.support.ansi_colors import formatter as ansi
 from datalad import cfg
 from datalad.core.local.run import Run
 from datalad.distribution.dataset import (
@@ -490,7 +490,7 @@ class RunProcedure(Interface):
         if kwargs.get('discover', None):
             ui.message('{name} ({path}){msg}'.format(
                 # bold-faced name, if active
-                name=ac.color_word(res['procedure_name'], ac.BOLD)
+                name=ansi.colorize(res['procedure_name'], ansi.color.BOLD)
                 if res['state'] == 'executable' else res['procedure_name'],
                 path=res['path'],
                 msg=' [{}]'.format(
@@ -501,7 +501,7 @@ class RunProcedure(Interface):
 
         elif kwargs.get('help_proc', None):
             ui.message('{name} ({path}){help}'.format(
-                name=ac.color_word(res['procedure_name'], ac.BOLD),
+                name=ansi.colorize(res['procedure_name'], ansi.color.BOLD),
                 path=op.relpath(
                     res['path'],
                     res['refds'])

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -22,7 +22,10 @@ from os.path import basename, dirname
 from collections import defaultdict
 
 from .utils import is_interactive, optional_args
-from .support import ansi_colors as colors
+from datalad.support.ansi_colors import (
+    formatter as ansi,
+    LOG_LEVEL_COLORS,
+)
 
 __all__ = ['ColorFormatter']
 
@@ -152,8 +155,9 @@ class ColorFormatter(logging.Formatter):
             # if 'auto' - use color only if all streams are tty
             use_color = is_interactive()
         self.use_color = use_color and platform.system() != 'Windows'  # don't use color on windows
-        msg = colors.format_msg(self._get_format(log_name, log_pid),
-                                self.use_color)
+        msg = ansi.format(
+            self._get_format(log_name, log_pid),
+            self.use_color)
         log_env = os.environ.get('DATALAD_LOG_TRACEBACK', '')
         collide = log_env == 'collide'
         limit = 100 if collide else int(log_env) if log_env.isdigit() else 100
@@ -188,11 +192,10 @@ class ColorFormatter(logging.Formatter):
 
         levelname = record.levelname
 
-        if self.use_color and levelname in colors.LOG_LEVEL_COLORS:
-            record.levelname = colors.color_word(
+        if self.use_color and levelname in LOG_LEVEL_COLORS:
+            record.levelname = ansi.colorize(
                 "{:7}".format(levelname),
-                colors.LOG_LEVEL_COLORS[levelname],
-                force=True)
+                LOG_LEVEL_COLORS[levelname])
         record.msg = record.msg.replace("\n", "\n| ")
         if self._tb:
             if not getattr(record, 'notraceback', False):
@@ -365,7 +368,7 @@ def with_result_progress(fn, label="Total", unit=" Files", log_filter=None):
         if count:
             msg = "{:d} {}".format(count, verb)
             if omg:
-                msg = colors.color_word(msg, colors.RED)
+                msg = ansi.colorize(msg, ansi.color.RED)
             return msg
 
 

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -40,7 +40,7 @@ from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import CapturedException
 from datalad.support.param import Parameter
-import datalad.support.ansi_colors as ac
+from datalad.support.ansi_colors import formatter as ansi
 from datalad.support.json_py import (
     load as jsonload,
     load_xzstream,
@@ -1016,9 +1016,11 @@ class Metadata(Interface):
                        res['refds']) if res.get('refds', None) else res['path']
         meta = res.get('metadata', {})
         ui.message('{path}{type}:{spacer}{meta}{tags}'.format(
-            path=ac.color_word(path, ac.BOLD),
+            path=ansi.colorize(path, ansi.color.BOLD),
             type=' ({})'.format(
-                ac.color_word(res['type'], ac.MAGENTA)) if 'type' in res else '',
+                ansi.colorize(
+                    res['type'],
+                    ansi.color.MAGENTA)) if 'type' in res else '',
             spacer=' ' if len([m for m in meta if m != 'tag']) else '',
             meta=','.join(k for k in sorted(meta.keys())
                           if k not in ('tag', '@context', '@id'))

--- a/datalad/support/ansi_colors.py
+++ b/datalad/support/ansi_colors.py
@@ -134,11 +134,19 @@ FIELD = BOLD
 
 
 def color_enabled():
+    warnings.warn('color_enabled() is deprecated, use AnsiFormatter',
+                  DeprecationWarning)
     return AnsiFormatter().is_enabled
 
 
 def format_msg(fmt, use_color=False):
-    """Replace $RESET and $BOLD with corresponding ANSI entries"""
+    """Replace $RESET and $BOLD with corresponding ANSI entries
+
+    .. deprecated:: 0.17
+       Use AnsiFormatter.format() instead.
+    """
+    warnings.warn('format_msg() is deprecated, use AnsiFormatter.format()',
+                  DeprecationWarning)
     return AnsiFormatter().format(fmt, use_color=use_color)
 
 
@@ -157,7 +165,12 @@ def color_word(s, color, force=False):
     Returns
     -------
     str
+
+    .. deprecated:: 0.17
+       Use AnsiFormatter.colorize() instead.
     """
+    warnings.warn('color_word() is deprecated, use AnsiFormatter.colorize()',
+                  DeprecationWarning)
     if not color:
         return s
 
@@ -170,4 +183,11 @@ def color_word(s, color, force=False):
 
 
 def color_status(status):
-    return color_word(status, RESULT_STATUS_COLORS.get(status))
+    """
+    .. deprecated:: 0.17
+       Use AnsiFormatter.color_status() instead.
+    """
+    warnings.warn(
+        'color_status() is deprecated, use AnsiFormatter.color_status()',
+        DeprecationWarning)
+    return formatter.color_status(status)

--- a/datalad/support/parallel.py
+++ b/datalad/support/parallel.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 from queue import Queue, Empty
 from threading import Thread
 
-from . import ansi_colors as colors
+from datalad.support.ansi_colors import formatter as ansi
 from ..log import log_progress
 from ..utils import path_is_subpath
 from datalad.support.exceptions import CapturedException
@@ -35,7 +35,7 @@ def _count_str(count, verb, omg=False):
     if count:
         msg = "{:d} {}".format(count, verb)
         if omg:
-            msg = colors.color_word(msg, colors.RED)
+            msg = ansi.colorize(msg, ansi.color.RED)
         return msg
 
 

--- a/datalad/support/tests/test_ansi_colors.py
+++ b/datalad/support/tests/test_ansi_colors.py
@@ -9,6 +9,7 @@
 """Test ANSI color tools """
 
 import os
+import pytest
 from unittest.mock import patch
 
 from datalad.support import ansi_colors as colors
@@ -19,6 +20,7 @@ from datalad.tests.utils_pytest import (
 import datalad.utils as du
 
 
+@pytest.mark.filterwarnings(r"ignore::DeprecationWarning")
 def test_color_enabled():
     # In the absence of NO_COLOR, follow ui.color, or ui.is_interactive if 'auto'
     with patch.dict(os.environ), \
@@ -50,7 +52,7 @@ def test_color_enabled():
 # In all other tests, just patch color_enabled
 #
 
-
+@pytest.mark.filterwarnings(r"ignore::DeprecationWarning")
 def test_format_msg():
     fmt = r'a$BOLDb$RESETc$BOLDd$RESETe'
     for enabled in (True, False):
@@ -67,6 +69,7 @@ def test_format_msg():
         assert_equal(colors.format_msg(fmt, use_color=True), 'a\033[1mb\033[0mc\033[1md\033[0me')
 
 
+@pytest.mark.filterwarnings(r"ignore::DeprecationWarning")
 def test_color_word():
     s = 'word'
     green_s = '\033[1;32mword\033[0m'
@@ -83,6 +86,7 @@ def test_color_word():
         assert_equal(colors.color_word(s, colors.GREEN, force=False), s)
 
 
+@pytest.mark.filterwarnings(r"ignore::DeprecationWarning")
 def test_color_status():
     # status -> (plain, colored)
     statuses = {

--- a/datalad/ui/utils.py
+++ b/datalad/ui/utils.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Various utils oriented to UI"""
 
-from datalad.support import ansi_colors
+from datalad.support.ansi_colors import formatter as ansi
 from datalad.utils import on_windows
 import struct
 
@@ -71,6 +71,6 @@ def get_console_width(default_min=20):
 def show_hint(msg):
     from datalad.ui import ui
     ui.message("{}".format(
-            ansi_colors.color_word(
-                msg,
-                ansi_colors.YELLOW)))
+        ansi.colorize(
+            msg,
+            ansi.color.YELLOW)))


### PR DESCRIPTION
With this PR, the previous decision making for color loggin outlined in https://github.com/datalad/datalad/issues/6714 is simplified to:

`LoggerHelper.get_initialized_logger()` calls `datalad.utils.is_interactive()` to check whether to enable color logging. The result of this evaluation (`use_color`) go into `ColorFormatter.__init__(use_color=...)`.

`ColorFormatter.__init__`'s use_color goes into `datalad.support.ansi_colors.formatter.format()`, which is an instance method of `AnsiFormatter`. This instance will check for `datalad.utils.is_interactive()` 
 and env var `NO_COLOR` once in a datalad process.

**Bottom line:** Color logging will be performed if requested by the logging code, and deemed possible by `AnsiFormatter`.

Importantly, the latter no longer requires an initialized UI to function. Therefore, one can now see the UI-related debug messages that are emitted when the UI is actually needed for messaging, e.g.:

```
[DEBUG  ] UI set to DialogUI(out=<TextIOWrapper>) 
```

- Closes #6714 
- Closes #6718 
- Closes #6713 