### PR TITLE
In addition to default (system) ssh version, report configured ssh; fix ssh version parsing on Windows

### DIFF
--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -97,12 +97,18 @@ def _get_bundled_git_version():
         return out.split()[2]
 
 
-def _get_ssh_version(exe="ssh"):
-    """Return version of ssh available system-wide
+def _get_ssh_version(exe=None):
+    """Return version of ssh
 
-    Annex prior 20170302 was using bundled version, but now would use system one
-    if installed
+    Annex prior 20170302 was using bundled version, then across all systems
+    we used system one if installed, and then switched to the one defined in
+    configuration, with system-wide (not default in PATH e.g. from conda)
+    "forced" on Windows.  If no specific executable provided in `exe`, we will
+    use the one in configuration
     """
+    if exe is None:
+        from datalad import cfg
+        exe = cfg.obtain("datalad.ssh.executable")
     out = _runner.run(
         [exe, '-V'],
         protocol=StdOutErrCapture)
@@ -116,12 +122,10 @@ def _get_ssh_version(exe="ssh"):
     return stdout.split(',', 1)[0].split(' ')[0].rstrip('.').split('_')[-1]
 
 
-_get_system_ssh_version = _get_ssh_version
-
-
-def _get_configured_ssh_version():
-    from datalad import cfg
-    return _get_ssh_version(cfg.obtain("datalad.ssh.executable"))
+def _get_system_ssh_version():
+    """Return version of the default on the system (in the PATH) ssh
+    """
+    return _get_ssh_version("ssh")
 
 
 def _get_system_7z_version():
@@ -161,7 +165,7 @@ class ExternalVersions(object):
         'cmd:git': _get_git_version,
         'cmd:bundled-git': _get_bundled_git_version,
         'cmd:system-git': _get_system_git_version,
-        'cmd:configured-ssh': _get_configured_ssh_version,
+        'cmd:ssh': _get_ssh_version,
         'cmd:system-ssh': _get_system_ssh_version,
         'cmd:7z': _get_system_7z_version,
     }

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -111,7 +111,9 @@ def _get_system_ssh_version():
     if out['stderr'].startswith('OpenSSH'):
         stdout = out['stderr']
     assert stdout.startswith('OpenSSH')  # that is the only one we care about atm
-    return stdout.split(' ', 1)[0].rstrip(',.').split('_')[1]
+    # The last item in _-separated list in the first word which could be separated
+    # from the rest by , or yet have another word after space
+    return stdout.split(',', 1)[0].split(' ')[0].rstrip('.').split('_')[-1]
 
 
 def _get_system_7z_version():

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -97,14 +97,14 @@ def _get_bundled_git_version():
         return out.split()[2]
 
 
-def _get_system_ssh_version():
+def _get_ssh_version(exe="ssh"):
     """Return version of ssh available system-wide
 
     Annex prior 20170302 was using bundled version, but now would use system one
     if installed
     """
     out = _runner.run(
-        'ssh -V'.split(),
+        [exe, '-V'],
         protocol=StdOutErrCapture)
     # apparently spits out to err but I wouldn't trust it blindly
     stdout = out['stdout']
@@ -114,6 +114,14 @@ def _get_system_ssh_version():
     # The last item in _-separated list in the first word which could be separated
     # from the rest by , or yet have another word after space
     return stdout.split(',', 1)[0].split(' ')[0].rstrip('.').split('_')[-1]
+
+
+_get_system_ssh_version = _get_ssh_version
+
+
+def _get_configured_ssh_version():
+    from datalad import cfg
+    return _get_ssh_version(cfg.obtain("datalad.ssh.executable"))
 
 
 def _get_system_7z_version():
@@ -153,6 +161,7 @@ class ExternalVersions(object):
         'cmd:git': _get_git_version,
         'cmd:bundled-git': _get_bundled_git_version,
         'cmd:system-git': _get_system_git_version,
+        'cmd:configured-ssh': _get_configured_ssh_version,
         'cmd:system-ssh': _get_system_ssh_version,
         'cmd:7z': _get_system_7z_version,
     }

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -236,6 +236,8 @@ def test_system_ssh_version():
 
     for s, v in [
         ('OpenSSH_7.4p1 Debian-6, OpenSSL 1.0.2k  26 Jan 2017', '7.4p1'),
+        ('OpenSSH_8.1p1, LibreSSL 2.7.3', '8.1p1'),
+        ('OpenSSH_for_Windows_8.1p1, LibreSSL 3.0.2', '8.1p1'),
     ]:
         ev = ExternalVersions()
         # TODO: figure out leaner way


### PR DESCRIPTION
Closes #6728 in the first commit fixing the parsing of a more elaborate version "identifier".

Then two subsequent commits pretty much provide two alternative ways to present 2nd version of `ssh` -- the one we actually use, which might be not the "system" one, i.e. not the one "first" in the PATH but the one we configure to use since https://github.com/datalad/datalad/pull/6553 which is on Windows is the "system" one, i.e. installed system wide and not in conda. (but not necessarily reported as `cmd:system-ssh`).

So here is how it looks for me on windows ATM:

```
(datalad) C:\Users\DataLad\PycharmProjects\datalad>datalad wtf -S dependencies
# WTF
## dependencies
  - annexremote: 1.2.1
  - boto: 2.49.0
  - cmd:7z: 9.20
  - cmd:annex: 8.20201008-g3be4731
  - cmd:bundled-git: UNKNOWN
  - cmd:git: 2.34.1.windows.1
  - cmd:ssh: 8.1p1
  - cmd:system-git: 2.34.1.windows.1
  - cmd:system-ssh: 8.8p1
  - exifread: 2.1.2
  - humanize: 3.1.0
  - iso8601: 0.1.13
  - keyring: 21.4.0
  - keyrings.alt: 3.1
  - msgpack: 1.0.0
  - mutagen: 1.41.1
  - platformdirs: 2.5.1
  - requests: 2.24.0
 ```

and on `maint` it is
```
(datalad) C:\Users\DataLad\PycharmProjects\datalad>datalad wtf -S dependencies | grep ssh
  - cmd:system-ssh: 8.8p1
```
since 

```
(datalad) C:\Users\DataLad\PycharmProjects\datalad>ssh -V
OpenSSH_8.8p1, OpenSSL 1.1.1l  24 Aug 2021

(datalad) C:\Users\DataLad\PycharmProjects\datalad>C:\WINDOWS\System32\OpenSSH\ssh.exe -V
OpenSSH_for_Windows_8.1p1, LibreSSL 3.0.2
```
and if I move  the "default" ssh aside I get that `for` for the version @adswa observed in https://github.com/datalad/datalad/issues/6617#issuecomment-1140876564 :

```
(datalad) C:\Users\DataLad\PycharmProjects\datalad>mv C:\Users\DataLad\miniconda3\envs\datalad\Library\usr\bin\ssh.exe  C:\Users\DataLad\miniconda3\envs\datalad\Library\usr\bin\ssh.exe_aside

(datalad) C:\Users\DataLad\PycharmProjects\datalad>ssh -V
OpenSSH_for_Windows_8.1p1, LibreSSL 3.0.2

(datalad) C:\Users\DataLad\PycharmProjects\datalad>datalad wtf -S dependencies | grep ssh
  - cmd:system-ssh: for
```
