### PR TITLE
More selective `unlock` progress reporting in noninteractive cases

### DIFF
--- a/datalad/local/unlock.py
+++ b/datalad/local/unlock.py
@@ -186,7 +186,8 @@ class Unlock(Interface):
             ):
                 log_progress(
                     lgr.info, pbar_id,
-                    "Files to unlock %i", nfiles, update=1, increment=True,
+                    "Files to unlock %i", nfiles,
+                    update=1, increment=True,
                     noninteractive_level=logging.DEBUG)
                 nfiles -= 1
                 yield get_status_dict(

--- a/datalad/local/unlock.py
+++ b/datalad/local/unlock.py
@@ -177,6 +177,7 @@ class Unlock(Interface):
                 unit=' Files',
                 label='Unlocking',
                 total=nfiles,
+                noninteractive_level=logging.INFO,
             )
             ds = Dataset(ds_path)
             for r in ds.repo._call_annex_records_items_(
@@ -184,7 +185,9 @@ class Unlock(Interface):
                     files=files,
             ):
                 log_progress(
-                    lgr.info, pbar_id, "Files to unlock %i", nfiles, update=1, increment=True)
+                    lgr.info, pbar_id,
+                    "Files to unlock %i", nfiles, update=1, increment=True,
+                    noninteractive_level=logging.DEBUG)
                 nfiles -= 1
                 yield get_status_dict(
                     path=op.join(ds.path, r['file']),
@@ -195,7 +198,12 @@ class Unlock(Interface):
                     # git-annex will spend considerable time after the last
                     # file record to finish things up, let this be known
                     log_progress(
-                        lgr.info, pbar_id, "Recording unlocked state in git", update=0, increment=True)
+                        lgr.info, pbar_id,
+                        "Recording unlocked state in git",
+                        update=0, increment=True,
+                        noninteractive_level=logging.INFO)
 
             log_progress(
-                lgr.info, pbar_id, "Completed unlocking files")
+                lgr.info, pbar_id,
+                "Completed unlocking files",
+                noninteractive_level=logging.INFO)


### PR DESCRIPTION
Logs start, end, and "recording state in git' phase at INFO level,
but the messages for each and every file only at DEBUG.

This will make default logging more sensible volume-wise.


### Changelog
No needed.