### PR TITLE
Prevent reentry of a runner instance

### DIFF
--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -453,8 +453,7 @@ class ThreadedRunner:
             self.generator = _ResultGenerator(self, self.protocol.result_queue)
             return self.generator
 
-        result = self.process_loop()
-        return result
+        return self.process_loop()
 
     def process_loop(self) -> Any:
         # Process internal messages until no more active file descriptors

--- a/datalad/runner/tests/test_threadsafety.py
+++ b/datalad/runner/tests/test_threadsafety.py
@@ -1,5 +1,4 @@
 import random
-import sys
 import threading
 import time
 
@@ -7,7 +6,10 @@ from ..coreprotocols import StdOutCapture
 from ..nonasyncrunner import ThreadedRunner
 from ..protocol import GeneratorMixIn
 from .utils import py2cmd
-from datalad.tests.utils import assert_raises
+from datalad.tests.utils import (
+    assert_in,
+    assert_raises,
+)
 
 
 class MinimalGeneratorProtocol(GeneratorMixIn, StdOutCapture):
@@ -23,7 +25,6 @@ class MinimalStdOutGeneratorProtocol(GeneratorMixIn, StdOutCapture):
 
     def pipe_data_received(self, fd, data):
         for line in data.decode().splitlines():
-            print(fd, line, file=sys.stderr)
             self.send_result((fd, line))
 
 
@@ -40,7 +41,7 @@ def test_thread_reentry_detection():
     exceptions = []
 
     shared_runner = ThreadedRunner(
-        cmd=py2cmd("for i in range(10): print(i)"),
+        cmd=py2cmd("for i in range(5): print(i)"),
         protocol_class=MinimalGeneratorProtocol,
         stdin=None)
 
@@ -53,7 +54,7 @@ def test_thread_reentry_detection():
     thread_1.join()
     thread_2.join()
 
-    assert exceptions == [RuntimeError]
+    assert_in(RuntimeError, exceptions)
 
 
 def test_thread_serialization():
@@ -70,7 +71,7 @@ def test_thread_serialization():
     exceptions = []
 
     shared_runner = ThreadedRunner(
-        cmd=py2cmd("for i in range(10): print(i)"),
+        cmd=py2cmd("for i in range(5): print(i)"),
         protocol_class=StdOutCapture,
         stdin=None)
 
@@ -88,7 +89,7 @@ def test_thread_serialization():
 def test_reentry_detection():
 
     runner = ThreadedRunner(
-        cmd=py2cmd("for i in range(10): print(i)"),
+        cmd=py2cmd("for i in range(5): print(i)"),
         protocol_class=MinimalGeneratorProtocol,
         stdin=None)
 
@@ -99,7 +100,7 @@ def test_reentry_detection():
 def test_leave_handling():
 
     runner = ThreadedRunner(
-        cmd=py2cmd("for i in range(10): print(i)"),
+        cmd=py2cmd("for i in range(5): print(i)"),
         protocol_class=MinimalStdOutGeneratorProtocol,
         stdin=None)
 
@@ -128,7 +129,7 @@ def test_thread_leave_handling():
     exceptions = []
 
     shared_runner = ThreadedRunner(
-        cmd=py2cmd("for i in range(10): print(i)"),
+        cmd=py2cmd("for i in range(5): print(i)"),
         protocol_class=MinimalStdOutGeneratorProtocol,
         stdin=None)
 

--- a/datalad/runner/tests/test_threadsafety.py
+++ b/datalad/runner/tests/test_threadsafety.py
@@ -1,0 +1,124 @@
+import random
+import sys
+import threading
+import time
+
+import pytest
+
+from datalad.runner.coreprotocols import StdOutCapture
+from datalad.runner.nonasyncrunner import ThreadedRunner
+from datalad.runner.protocol import GeneratorMixIn
+from datalad.runner.tests.utils import py2cmd
+
+
+class MinimalGeneratorProtocol(GeneratorMixIn, StdOutCapture):
+    def __init__(self):
+        StdOutCapture.__init__(self)
+        GeneratorMixIn.__init__(self)
+
+
+class MinimalStdOutGeneratorProtocol(GeneratorMixIn, StdOutCapture):
+    def __init__(self):
+        StdOutCapture.__init__(self)
+        GeneratorMixIn.__init__(self)
+
+    def pipe_data_received(self, fd, data):
+        self.send_result((fd, data.decode()))
+
+
+def test_thread_reentry_detection():
+    def run_on(runner: ThreadedRunner):
+        for _ in runner.run():
+            time.sleep(random.random())
+
+    # make exceptions visible to test thread
+    def new_hook(*args):
+        exceptions.append(args[0].exc_type)
+
+    threading.excepthook = new_hook
+
+    exceptions = []
+
+    shared_runner = ThreadedRunner(
+        cmd=py2cmd("for i in range(10): print(i)"),
+        protocol_class=MinimalGeneratorProtocol,
+        stdin=None)
+
+    thread_1 = threading.Thread(
+        name="thread_1",
+        target=run_on,
+        args=(shared_runner,))
+
+    thread_2 = threading.Thread(
+        name="thread_2",
+        target=run_on,
+        args=(shared_runner,))
+
+    thread_1.start()
+    thread_2.start()
+
+    thread_1.join()
+    thread_2.join()
+
+    assert exceptions == [RuntimeError]
+
+
+def test_reentry_detection():
+
+    runner = ThreadedRunner(
+        cmd=py2cmd("for i in range(10): print(i)"),
+        protocol_class=MinimalGeneratorProtocol,
+        stdin=None)
+
+    runner.run()
+    with pytest.raises(RuntimeError):
+        runner.run()
+
+
+def test_leave_handling():
+
+    runner = ThreadedRunner(
+        cmd=py2cmd("for i in range(10): print(i)"),
+        protocol_class=MinimalStdOutGeneratorProtocol,
+        stdin=None)
+
+    iteration_1_result = tuple(runner.run())
+    iteration_2_result = tuple(runner.run())
+    assert iteration_1_result == iteration_2_result
+
+
+def test_thread_leave_handling():
+    def run_on(runner: ThreadedRunner):
+        for _ in runner.run():
+            time.sleep(random.random())
+
+    # make exceptions visible to test thread
+    def new_hook(*args):
+        exceptions.append(args[0].exc_type)
+
+    threading.excepthook = new_hook
+
+    exceptions = []
+
+    shared_runner = ThreadedRunner(
+        cmd=py2cmd("for i in range(10): print(i)"),
+        protocol_class=MinimalStdOutGeneratorProtocol,
+        stdin=None)
+
+    thread_1 = threading.Thread(
+        name="thread_1",
+        target=run_on,
+        args=(shared_runner,))
+
+    thread_2 = threading.Thread(
+        name="thread_2",
+        target=run_on,
+        args=(shared_runner,))
+
+    thread_1.start()
+    thread_1.join()
+
+    thread_2.start()
+    thread_2.join()
+
+    assert exceptions == []

--- a/datalad/runner/tests/test_threadsafety.py
+++ b/datalad/runner/tests/test_threadsafety.py
@@ -1,9 +1,11 @@
 import random
 import threading
 import time
+from threading import Thread
 from typing import (
     Any,
     List,
+    Tuple,
 )
 
 from ..coreprotocols import StdOutCapture
@@ -36,7 +38,10 @@ def _runner_with_protocol(protocol) -> ThreadedRunner:
         stdin=None)
 
 
-def _run_on(runner: ThreadedRunner, iterate: bool, exceptions: List):
+def _run_on(runner: ThreadedRunner,
+            iterate: bool,
+            exceptions: List
+            ):
     try:
         gen = runner.run()
         if iterate:
@@ -46,22 +51,31 @@ def _run_on(runner: ThreadedRunner, iterate: bool, exceptions: List):
         exceptions.append(e.__class__)
 
 
+def _get_run_on_threads(protocol: Any,
+                        iterate: bool
+                        ) -> Tuple[Thread, Thread, List]:
+
+    runner = _runner_with_protocol(protocol)
+
+    args = (runner, iterate, [])
+    thread_1 = threading.Thread(target=_run_on, args=args)
+    thread_2 = threading.Thread(target=_run_on, args=args)
+
+    return thread_1, thread_2, args[2]
+
+
 def _reentry_detection_run(protocol: Any,
                            iterate: bool
                            ) -> List:
 
-    runner = _runner_with_protocol(protocol)
-
-    exceptions = []
-    thread_1 = threading.Thread(target=_run_on, args=(runner, iterate, exceptions))
-    thread_2 = threading.Thread(target=_run_on, args=(runner, iterate, exceptions))
+    thread_1, thread_2, exception = _get_run_on_threads(protocol, iterate)
 
     thread_1.start()
     thread_2.start()
 
     thread_1.join()
     thread_2.join()
-    return exceptions
+    return exception
 
 
 def test_thread_reentry_detection():
@@ -74,7 +88,7 @@ def test_thread_reentry_detection():
 
 def test_thread_serialization():
     # expect that two run calls on the same runner with a non-generator-protocol
-    # do not create a runtime error
+    # do not create a runtime error (executions are serialized though)
 
     exceptions = _reentry_detection_run(StdOutCapture, True)
     assert exceptions == []
@@ -100,10 +114,10 @@ def test_thread_leave_handling():
     # expect no exception on repeated call to run of a runner with
     # generator-protocol, if the generator was exhausted before the second call
 
-    shared_runner = _runner_with_protocol(MinimalStdOutGeneratorProtocol)
-    exceptions = []
-    thread_1 = threading.Thread(target=_run_on, args=(shared_runner, True, exceptions))
-    thread_2 = threading.Thread(target=_run_on, args=(shared_runner, True, exceptions))
+    thread_1, thread_2, exception = _get_run_on_threads(
+        MinimalStdOutGeneratorProtocol,
+        True
+    )
 
     thread_1.start()
     thread_1.join()
@@ -111,4 +125,4 @@ def test_thread_leave_handling():
     thread_2.start()
     thread_2.join()
 
-    assert exceptions == []
+    assert exception == []

--- a/datalad/runner/tests/test_threadsafety.py
+++ b/datalad/runner/tests/test_threadsafety.py
@@ -3,12 +3,11 @@ import sys
 import threading
 import time
 
-import pytest
-
 from ..coreprotocols import StdOutCapture
 from ..nonasyncrunner import ThreadedRunner
 from ..protocol import GeneratorMixIn
 from .utils import py2cmd
+from datalad.tests.utils import assert_raises
 
 
 class MinimalGeneratorProtocol(GeneratorMixIn, StdOutCapture):
@@ -94,8 +93,7 @@ def test_reentry_detection():
         stdin=None)
 
     runner.run()
-    with pytest.raises(RuntimeError):
-        runner.run()
+    assert_raises(RuntimeError, runner.run)
 
 
 def test_leave_handling():


### PR DESCRIPTION
This PR addresses issue #6595 

Fixes #6595 

The commits in this PR add a re-entry detection for the methode `ThreadedRunner.run()`, which is not re-entrant. It should also not be called if the protocol that was used is a subclass of `GeneratorMixIn` and the generator returned by `ThreadedRunner.run()` has not yet raised `StopIteration`.

Both cases are detected and handled by this PR. In the non-generator case, the invocations will be serialized. That means the second caller will only be allowed to enter the method if the current caller has left it. In the generator-case, a `RuntimeError` is raised. This might lead to different, new errors, but will provide deterministic detection of the re-entrance issue, that is, of issue #6595

### Changelog
#### 🐛 Bug Fixes
- Prevent reentry of a runner instance. Fixes #6595 
