### PR TITLE
MNT: Remove ``eval_file_type()`` from code base

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -337,8 +337,6 @@ def _datasets_since_(dataset, since, paths, recursive, recursion_limit):
             annex=None,
             recursive=recursive,
             recursion_limit=recursion_limit,
-            # make it as fast as possible
-            eval_file_type=False,
             # TODO?: expose order as an option for diff and push
             # since in some cases breadth-first would be sufficient
             # and result in "taking action faster"

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -154,7 +154,6 @@ def diff_dataset(
         untracked='normal',
         recursive=False,
         recursion_limit=None,
-        eval_file_type=True,
         reporting_order='depth-first',
         datasets_only=False,
 ):
@@ -185,10 +184,6 @@ def diff_dataset(
       Flag to enable recursive operation (see main diff() command).
     recursion_limit : int, optional
       Recursion limit (see main diff() command).
-    eval_file_type : bool, optional
-      Whether to perform file type discrimination between real symlinks
-      and symlinks representing annex'ed files. This can be expensive
-      in datasets with many files.
     reporting_order : {'depth-first', 'breadth-first', 'bottom-up'}, optional
       By default, subdataset content records are reported after the record
       on the subdataset's submodule in a superdataset (depth-first).
@@ -291,7 +286,6 @@ def diff_dataset(
             origpaths=None if not path else OrderedDict(path),
             untracked=untracked,
             annexinfo=annex,
-            eval_file_type=eval_file_type,
             cache=content_info_cache,
             order=reporting_order,
             datasets_only=datasets_only,
@@ -305,7 +299,7 @@ def diff_dataset(
 
 
 def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
-             annexinfo, eval_file_type, cache, order='depth-first', datasets_only=False):
+             annexinfo, cache, order='depth-first', datasets_only=False):
     if not ds.is_installed():
         # asked to query a subdataset that is not available
         lgr.debug("Skip diff of unavailable subdataset: %s", ds)
@@ -344,7 +338,6 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
             to,
             paths=paths_arg,
             untracked=untracked,
-            # deprecated unused !!! eval_file_type=eval_file_type,
             eval_submodule_state='full' if to is None else 'commit',
             _cache=cache)
     except InvalidGitReferenceError as e:
@@ -434,7 +427,6 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
                     origpaths=origpaths,
                     untracked=untracked,
                     annexinfo=annexinfo,
-                    eval_file_type=eval_file_type,
                     cache=cache,
                     order=order,
                     datasets_only=datasets_only,

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -695,8 +695,6 @@ class CreateSibling(Interface):
                     annex=None,
                     untracked='no',
                     recursive=True,
-                    # save cycles, we are only looking for datasets
-                    eval_file_type=False,
                     datasets_only=True,
                 )
                 # not installed subdatasets would be 'clean' so we would skip them

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -85,9 +85,6 @@ class _CachedRepo(object):
             paths=[rpath],
             # a simple `exists()` will not be enough (pointer files, etc...)
             eval_availability=True,
-            # if it truly is a symlink, not just an annex pointer, we would not
-            # want to resolve it
-            # deprecated! unused;  eval_file_type=True,
         )
         finfo = finfo.popitem()[1] if finfo else {}
         return finfo

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2652,8 +2652,7 @@ class GitRepo(CoreGitRepo):
                         attrline += ' {}={}'.format(a, val)
                 f.write('{}\n'.format(attrline))
 
-    def get_content_info(self, paths=None, ref=None, untracked='all',
-                         eval_file_type=None):
+    def get_content_info(self, paths=None, ref=None, untracked='all'):
         """Get identifier and type information from repository content.
 
         This is simplified front-end for `git ls-files/tree`.
@@ -2681,9 +2680,6 @@ class GitRepo(CoreGitRepo):
           'no': no untracked files are reported; 'normal': untracked files
           and entire untracked directories are reported as such; 'all': report
           individual files even in fully untracked directories.
-        eval_file_type :
-          THIS FUNCTIONALITY IS NO LONGER SUPPORTED.
-          Setting this flag has no effect.
 
         Returns
         -------
@@ -2708,10 +2704,6 @@ class GitRepo(CoreGitRepo):
           repository)
         """
         lgr.debug('%s.get_content_info(...)', self)
-        if eval_file_type is not None:
-            warnings.warn(
-                "GitRepo.get_content_info(eval_file_type=) no longer supported",
-                DeprecationWarning)
         # TODO limit by file type to replace code in subdatasets command
         info = OrderedDict()
 
@@ -2928,22 +2920,14 @@ class GitRepo(CoreGitRepo):
             if v.get('state', None) != 'clean'}
 
     def diffstatus(self, fr, to, paths=None, untracked='all',
-                   eval_submodule_state='full', eval_file_type=None,
-                   _cache=None):
+                   eval_submodule_state='full', _cache=None):
         """Like diff(), but reports the status of 'clean' content too.
 
         It supports an additional submodule evaluation state 'global'.
         If given, it will return a single 'modified'
         (vs. 'clean') state label for the entire repository, as soon as
         it can.
-
-        The eval_file_type parameter is ignored.
         """
-        if eval_file_type is not None:
-            warnings.warn(
-                "GitRepo.diffstatus(eval_file_type=) no longer supported",
-                DeprecationWarning)
-
         def _get_cache_key(label, paths, ref, untracked=None):
             return self.path, label, tuple(paths) if paths else None, \
                 ref, untracked


### PR DESCRIPTION
This is a maintenance change to fix #6652. It removes all remaining uses of the deprecated and unused ``eval_file_type()`` parameter, and the parameter itself. As far as I was able to grep around, only ``datalad-ukbiobank`` needs an adjustment for this change, but let's see if any unit tests break.


