### PR TITLE
ENH: Allow siblings to set annex.ignore of siblings

### DIFF
--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -32,6 +32,7 @@ from datalad.interface.common_opts import (
     annex_groupwanted_opt,
     annex_required_opt,
     annex_wanted_opt,
+    annex_ignore_opt,
     as_common_datasrc,
     inherit_opt,
     location_description,
@@ -191,6 +192,7 @@ class Siblings(Interface):
         annex_required=annex_required_opt,
         annex_group=annex_group_opt,
         annex_groupwanted=annex_groupwanted_opt,
+        annex_ignore=annex_ignore_opt,
         inherit=inherit_opt,
         get_annex_info=Parameter(
             args=("--no-annex-info",),
@@ -221,6 +223,7 @@ class Siblings(Interface):
             annex_required=None,
             annex_group=None,
             annex_groupwanted=None,
+            annex_ignore=None,
             inherit=False,
             get_annex_info=True,
             recursive=False,
@@ -277,6 +280,7 @@ class Siblings(Interface):
             annex_required=annex_required,
             annex_group=annex_group,
             annex_groupwanted=annex_groupwanted,
+            annex_ignore=annex_ignore,
             inherit=inherit,
             get_annex_info=get_annex_info,
             res_kwargs=res_kwargs,
@@ -428,7 +432,7 @@ def _configure_remote(
         ds, repo, name, known_remotes, url, pushurl, fetch, description,
         as_common_datasrc, publish_depends, publish_by_default,
         annex_wanted, annex_required, annex_group, annex_groupwanted,
-        inherit, res_kwargs, **unused_kwargs):
+        annex_ignore, inherit, res_kwargs, **unused_kwargs):
     result_props = dict(
         action='configure-sibling',
         path=ds.path,
@@ -553,6 +557,10 @@ def _configure_remote(
 
         assert isinstance(repo, GitRepo)  # just against silly code
         if isinstance(repo, AnnexRepo):
+            # before we try to enable special remotes, honour user-provided
+            # annex ignore configurations
+            if annex_ignore is not None:
+                repo.set_remote_ignore(name, annex_ignore)
             # we need to check if added sibling an annex, and try to enable it
             # another part of the fix for #463 and #432
             try:

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -160,6 +160,20 @@ def test_siblings(origin=None, repo_path=None, local_clone_path=None):
     eq_(httpurl1 + "/elsewhere",
         source.repo.get_remote_url("test-remote"))
 
+    # smoke test for setting annex ignore: reconfigure remote with annex ignore
+    with chpwd(source.path):
+        res = siblings('configure', name="dl-test-remote", annex_ignore='true',
+                       **ca)
+        assert_result_count(
+            res, 1,
+            name="dl-test-remote", type='sibling')
+        assert res[0]['annex-ignore'] == True
+        res = siblings('configure', name="dl-test-remote", annex_ignore='false',
+                       **ca)
+        assert_result_count(
+            res, 1,
+            name="dl-test-remote", type='sibling')
+        assert res[0]['annex-ignore'] == 'false'
     # no longer a use case, I would need additional convincing that
     # this is anyhow useful other then triple checking other peoples
     # errors. for an actual check use 'query'

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -269,6 +269,11 @@ annex_groupwanted_opt = Parameter(
     See https://git-annex.branchable.com/git-annex-groupwanted/ for more information""",
     constraints=EnsureStr() | EnsureNone())
 
+annex_ignore_opt = Parameter(
+    args=("--annex-ignore",),
+    metavar='BOOL',
+    doc="Whether or not a remote shall be ignored or not",
+    constraints=EnsureChoice(None, True, False, 'true', 'false'))
 
 inherit_opt = Parameter(
     args=("--inherit",),

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -699,6 +699,16 @@ class AnnexRepo(GitRepo, RepoInterface):
             default=False
         )
 
+    def set_remote_ignore(self, remote, ignored=False):
+        """Add or set an annex-ignore section for a given remote"""
+        # check if there is a section already
+        if self.config.has_section('remote.{}.annex-ignore'.format(remote)):
+            # overwrite (set) config
+            self.config.set('remote.{}.annex-ignore'.format(remote), ignored, scope='local')
+        else:
+            # add it
+            self.config.add('remote.{}.annex-ignore'.format(remote), ignored, scope='local')
+
     def is_special_annex_remote(self, remote, check_if_known=True):
         """Return whether remote is a special annex remote
 


### PR DESCRIPTION
This PR tries to implement #4028. It adds a ``--annex-ignore`` parameter to ``siblings`` that can add or set an `annex.ignore` config in the datasets ``.git/config``. For this, it also adds an internal helper ``set_remote_ignore`` in ``Annexrepo``. When the parameter is set, it will be added to a remote configuration before annex has a chance to emit the ``Could not enable annex remote %s. This is expected if %s is a pure Git remote, or happens if it is not accessible.``-warning

I'm not sure though if this is sufficient to address the use case in  #4028 so I would like to as @bpoldrack for clarification. Was something simple like this what you had envisioned? Or does it need to go deeper?
I'm also not sure about the parameter specification (suggestions for what to change ``metavar`` and the value defaults into are welcome - I think there are too many defaults, and I'm not sure if its a valid metavar name)



### Changelog
TBD
