### PR TITLE
MNT: Modernize export-archive

### DIFF
--- a/datalad/local/export_archive.py
+++ b/datalad/local/export_archive.py
@@ -116,7 +116,7 @@ class ExportArchive(Interface):
             filename = Path(default_filename)  # in current directory
         elif filename.exists() and filename.is_dir():
             filename = filename / default_filename # under given directory
-        if not filename.suffix == file_extension:
+        if filename.suffix != file_extension:
             filename = filename.with_suffix(file_extension)
 
         root = dataset.path

--- a/datalad/local/export_archive.py
+++ b/datalad/local/export_archive.py
@@ -81,6 +81,7 @@ class ExportArchive(Interface):
         from unittest.mock import patch
 
         from datalad.distribution.dataset import require_dataset
+        from datalad.utils import file_basename
         from datalad.support.annexrepo import AnnexRepo
 
         import logging
@@ -123,7 +124,7 @@ class ExportArchive(Interface):
         # use dir inside matching the output filename without suffix(es)
         # TODO: could be an option to the export plugin allowing empty value
         # for no leading dir
-        leading_dir = filename.name[: -len(''.join(filename.suffixes))]
+        leading_dir = file_basename(filename)
 
         # workaround for inability to pass down the time stamp
         with patch('time.time', return_value=committed_date), \

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1468,7 +1468,7 @@ class GitRepo(CoreGitRepo):
             env=env,
         )
 
-    # TODO usage is primarily in the tests, consider making a test helper and
+    # TODO usage is only in the tests, consider making a test helper and
     # remove from GitRepo API
     def get_indexed_files(self):
         """Get a list of files in git's index


### PR DESCRIPTION
This change contains maintenance work on export-archive. This includes
a complete switch from os.path to Pathlib, as well as abandoning old
almost never used and @normalize_path-polluted repo methods
get_indexed_files() and is_under_annex(), and replacing them with
get_content_{annex,}info(). This allows us to simplify the logic in
the for loop over all files further.

Coincidentally, because the switch from normlize_path functions
to get_content_{annex,}info() prevents faulty path handling when
export-archive is called from subdirectories inside of datasets,
this change fixes #6741


### Changelog
#### 🐛 Bug Fixes
- `export-archive` doesn't rely on `normalize_path()` methods anymore and became more robust when called from subdirectories (fixes #6741)
