### PR TITLE
Polish trace back-logging and other logging aspects

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -460,7 +460,15 @@ _definitions = {
     },
     'datalad.log.traceback': {
         'ui': ('question', {
-               'title': 'Runs TraceBack function with collide set to True, if this flag is set to "collide". This replaces any common prefix between current traceback log and previous invocation with "..."'}),
+               'title': 'Includes a compact traceback in a log message, with '
+                        'generic components removed. '
+                        'This setting is only in effect when given as an '
+                        'environment variable DATALAD_LOG_TRACEBACK. '
+                        'An integer value specifies the maximum traceback '
+                        'depth to be considered. '
+                        'If set to "collide", a common traceback prefix '
+                        'between a current traceback and a previously logged '
+                        'traceback is replaced with "…" (maximum depth 100).'}),
     },
     'datalad.ssh.identityfile': {
         'ui': ('question', {

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -66,11 +66,29 @@ class TraceBack(object):
         else:
             self.__prefix_re = None
 
+
+    def _extract_stack(self, limit=None):
+        """Call traceback.extract_stack() with limit parameter
+
+        Parameters
+        ----------
+        limit: int, optional
+          Limit stack trace entries (starting from the invocation point)
+          if limit is positive, or to the last `abs(limit)` entries.
+          If limit is omitted or None, all entries are printed.
+
+        Returns
+        -------
+        traceback.StackSummary
+        """
         import traceback
-        self._extract_stack = traceback.extract_stack
+        return traceback.extract_stack(limit=limit)
 
     def __call__(self):
-        ftb = self._extract_stack(limit=self.limit+10)[:-2]
+        # get the stack description. All but the last three items, which
+        # represent the entry into this utility rather than the traceback
+        # relevant for the caller
+        ftb = self._extract_stack(limit=self.limit + 10)[:-3]
         entries = [[mbasename(x[0]), str(x[1])]
                    for x in ftb if mbasename(x[0]) != 'logging.__init__']
         entries = [e for e in entries if e[0] != 'unittest']

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -340,6 +340,30 @@ class OnlyProgressLog(logging.Filter):
 
 
 def filter_noninteractive_progress(logger, record):
+    """Companion of log_progress() to suppress undesired progress logging
+
+    This filter is to be used with a log handler's addFilter() method
+    for the case of a non-interactive session (e.g., pipe to log file).
+
+    It inspects the log record for `dlm_progress_noninteractive_level`
+    keys that can be injected via log_progress(noninteractive_level=).
+
+    If a log-level was declared in this fashion, it will be evaluated
+    against the logger's effective level, and records are discarded
+    if their level is too low. If no log-level was declared, a log record
+    passes this filter unconditionally.
+
+    Parameters
+    ----------
+    logger: logging.Logger
+      The logger instance whose effective level to check against.
+    record:
+      The log record to inspect.
+
+    Returns
+    -------
+    bool
+    """
     level = getattr(record, "dlm_progress_noninteractive_level", None)
     return level is None or level >= logger.level
 

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -44,17 +44,16 @@ def mbasename(s):
 
 
 class TraceBack(object):
-    """Customized traceback to be included in debug messages
+    """Customizable traceback for inclusion debug log messages
     """
 
     def __init__(self, limit=100, collide=False):
-        """Initialize TraceBack metric
-
+        """
         Parameters
         ----------
         collide : bool
-          if True then prefix common with previous invocation gets
-          replaced with ...
+          if True, deduplicate a subsequent message by replacing a common
+          prefix string with an ellipsis.
         """
         self.__prev = ""
         self.limit = limit
@@ -77,7 +76,7 @@ class TraceBack(object):
         entries = [e for e in entries if e[0] != 'unittest']
 
         if len(entries) > self.limit:
-            sftb = '...>'
+            sftb = '…>'
             entries = entries[-self.limit:]
         else:
             sftb = ''
@@ -104,7 +103,7 @@ class TraceBack(object):
             common_prefix2 = self.__prefix_re.sub('', common_prefix)
 
             if common_prefix2 != "":
-                sftb = '...' + sftb[len(common_prefix2):]
+                sftb = '…' + sftb[len(common_prefix2):]
             self.__prev = prev_next
 
         return sftb

--- a/datalad/tests/test_log.py
+++ b/datalad/tests/test_log.py
@@ -161,7 +161,7 @@ def test_traceback():
 
     # we limit to the last 100
     tb1 = rec(TraceBack(collide=True), 110)
-    ok_endswith(tb1, "...>test_log:%s" % (",".join([str(tb_line)]*100)))
+    ok_endswith(tb1, "…>test_log:%s" % (",".join([str(tb_line)]*100)))
 
 
 @known_failure_githubci_win


### PR DESCRIPTION
### Changelog
#### 💫 Enhancements and new features
- Documentation and behavior of traceback reporting for log messages via `DATALAD_LOG_TRACEBACK` was improved to yield a more compact report. The documentation for this feature has been clarified. Closes #6744 
#### Documentation
- API documentation for log helpers, like `log_progress()` is now included in the renderer documentation. Fixes #6731 