### PR TITLE
BF: push to github - remove datalad-push-default-first config only in non-dry run to ensure we push default branch separately in next step

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1983,7 +1983,8 @@ class GitRepo(CoreGitRepo):
                 )
             )
         # note: above push_ should raise exception if errors out
-        if cfg.get_from_source('local', cfg_push_var) is not None:
+        if '--dry-run' not in git_options \
+            and cfg.get_from_source('local', cfg_push_var) is not None:
             lgr.debug("Removing %s variable from local git config after successful push", cfg_push_var)
             cfg.unset(cfg_push_var, 'local')
         return push_res


### PR DESCRIPTION
Fixes #6749. Ref: original fix in #5010  which was incomplete

- I am not 100% confident and did not carry full archeological expedition on
  how it could have worked ever since due to that --dry-run it was "always"
  there
- 2nd call to that push comes with refspec since it is that initial --dry-run
  which provides them. And that is when we should separate them out
- Unfortunately since there is no dedicated dry_run option to push,
  I had to rely on matching it in git-options
- We stopped using VCR for playing out the integration tests with github,
  and mocking out interactions would provide no point since we want to ensure
  correct operation against github.  So I do not see an easy way to
  develop a unittest, so I will leave it at this
