### PR TITLE
Preserve final trailing slash in ``call_git()`` output

### DIFF
--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -366,7 +366,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         Internal helper to the call_git*() methods.
         Unlike call_git, _call_git returns both stdout and stderr.
         The parameters, return value, and raised exceptions match those
-        documented for `call_git`, with the exception of env, which is TODO?.
+        documented for `call_git`, with the exception of env, which allows to
+        specify the custom environment (variables) to be used.
         """
         runner = self._git_runner
         stderr_log_level = {True: 5, False: 11}[expect_stderr]

--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -429,12 +429,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ------
         CommandError if the call exits with a non-zero status.
         """
-        return "\n".join(
-            self.call_git_items_(args,
-                                 files,
-                                 expect_stderr=expect_stderr,
-                                 expect_fail=expect_fail,
-                                 read_only=read_only))
+
+        return self._call_git(args,
+                 files,
+                 expect_stderr=expect_stderr,
+                 expect_fail=expect_fail,
+                 read_only=read_only)[0]
 
     def call_git_items_(self,
                         args,

--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -364,9 +364,9 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         """Allows for calling arbitrary commands.
 
         Internal helper to the call_git*() methods.
-
+        Unlike call_git, _call_git returns both stdout and stderr.
         The parameters, return value, and raised exceptions match those
-        documented for `call_git`.
+        documented for `call_git`, with the exception of env, which is TODO?.
         """
         runner = self._git_runner
         stderr_log_level = {True: 5, False: 11}[expect_stderr]

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -641,7 +641,7 @@ def test_global_config():
 def test_bare(src, path):
     # create a proper datalad dataset with all bells and whistles
     ds = Dataset(src).create()
-    dlconfig_sha = ds.repo.call_git(['rev-parse', 'HEAD:.datalad/config'])
+    dlconfig_sha = ds.repo.call_git(['rev-parse', 'HEAD:.datalad/config']).strip()
     # can we handle a bare repo version of it?
     gr = AnnexRepo.clone(
         src, path, clone_options=['--bare', '-b', DEFAULT_BRANCH])


### PR DESCRIPTION
A failure in ``datalad-ukbiobank`` (datalad/datalad-ukbiobank#82 and a misguided fix in datalad/datalad-ukbiobank#85 has revealed that a change introduced in https://github.com/datalad/datalad/pull/6278 caused final trailing newlines to be removed from the final stdout of our ``call_git`` calls. In datalad-ukb, unit tests started to fail as the contents of files that were written with `git cat-file -p <sourcebranch>:<sourcefile>` lacked the trailing newlines that the source files had.

I'm poking in the dark and PRing a WIP PR in hopes of improvements and feedback to fix this by switching back to ``_call_git()`` from ``call_git_items()``. The PR also contains half of a docstring fix @yarikoptic idenitified - input on the description of the `env` parameter (see commit) would be appreciated.