### PR TITLE
ENH(UX): report known values for progress bar backend/config

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -632,7 +632,7 @@ _definitions = {
             'title': 'UI progress bars',
             'text': 'Default backend for progress reporting'}),
         'default': None,
-        'type': EnsureChoice('tqdm', 'tqdm-ipython', 'log', 'none'),
+        'type': EnsureChoice('tqdm', 'log', 'none'),
     },
     'datalad.ui.color': {
         'ui': ('question', {

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -108,18 +108,25 @@ class ConsoleLog(object):
         else:
             progressbars = ConsoleLog.progressbars
 
+        backend_src = 'backend option'
         if backend is None:
             # Resort to the configuration
             from .. import cfg
             backend = cfg.get('datalad.ui.progressbar', None)
+            backend_src = 'datalad.ui.progressbar config'
 
         if backend is None:
             try:
                 pbar = progressbars['tqdm']
             except KeyError:
                 pbar = progressbars.values()[0]  # any
-        else:
+        elif backend in progressbars:
             pbar = progressbars[backend]
+        else:
+            raise ValueError(
+                f"Got unknown value of {backend_src} {backend!r}. "
+                f"Known are: {', '.join(map(repr, progressbars))}"
+            )
         return pbar(*args, out=self.out, **kwargs)
 
     @property

--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -125,6 +125,11 @@ class LogProgressBar(ProgressBarBase):
             if x > 2 \
             else LogProgressBar._naturalfloat(x) + ' sec'
 
+    def start(self, initial=0):
+        super().start(initial=initial)
+        msg = " with initial specified to be {initial}" if initial else ''
+        lgr.info("Start %s%s", self.label, msg)
+
     def finish(self, partial=False):
         msg, args = ' %s ', [self.label]
 

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -149,6 +149,20 @@ def _test_progress_bar(backend, len, increment):
 
 
 def test_progress_bar():
+    # ensure that we crash with informative message
+    with assert_raises(ValueError) as cme:
+        _test_progress_bar("unknown-backend", 0, True)
+    assert_in(', '.join(map(repr, progressbars)), str(cme.exception))
+
+    # we cannot really centralize "cheaply" setup of known backends but
+    # we can at least verify that they are consistent between those in
+    # common_cfg and progressbars
+
+    from datalad.interface.common_cfg import definitions
+    eq_(sorted(progressbars),
+        # some are internal or deprecated and should not be listed
+        sorted(definitions.get('datalad.ui.progressbar')['type']._allowed + ('annex-remote', 'silent')) )
+
     # More of smoke testing given various lengths of fill_text
     for backend in progressbars:
         for l in 0, 4, 10, 1000:


### PR DESCRIPTION
Compare

    $> rm -rf datalad && DATALAD_UI_PROGRESSBAR=mumba datalad clone https://github.com/datalad/datalad.git
    [ERROR  ] Got unknown value of datalad.ui.progressbar config 'mumba'. Known are: 'silent', 'none', 'log', 'tqdm', 'annex-remote' (ValueError)

to

    $> rm -rf datalad && DATALAD_UI_PROGRESSBAR=mumba datalad clone https://github.com/datalad/datalad.git
    [ERROR  ] 'mumba' (KeyError)

Inspired by https://github.com/datalad/datalad/issues/4325
