### PR TITLE
ENH: LogProgressBar to gain "start" reporting

### DIFF
--- a/datalad/ui/progressbars.py
+++ b/datalad/ui/progressbars.py
@@ -125,6 +125,11 @@ class LogProgressBar(ProgressBarBase):
             if x > 2 \
             else LogProgressBar._naturalfloat(x) + ' sec'
 
+    def start(self, initial=0):
+        super().start(initial=initial)
+        msg = " with initial specified to be {initial}" if initial else ''
+        lgr.info("Start %s%s", self.label, msg)
+
     def finish(self, partial=False):
         msg, args = ' %s ', [self.label]
 


### PR DESCRIPTION
Spotted while comparing behavior of log_progress whenever it does
not log progress at all it logs initiation of specific actions while
we were reporting only at the end of the operation.  This way we would be reporting
also the beginning:

	$> rm -rf datalad && DATALAD_UI_PROGRESSBAR=log datalad clone https://github.com/datalad/datalad.git
	[INFO   ] Start Clone attempt
	[INFO   ] Start Enumerating
	[INFO   ]  Enumerating done in 0.000520706 sec
	[INFO   ] Start Counting
	[INFO   ]  Counting 174 Objects done in 0.0136135 sec at 12781 Objects/sec
	[INFO   ] Start Compressing
	[INFO   ]  Compressing 93 Objects done in 0.033551 sec at 2772 Objects/sec
	[INFO   ] Start Receiving
	[INFO   ]  Receiving 96987 Objects done in 6 seconds at 14219 Objects/sec
	[INFO   ] Start Resolving
	[INFO   ]  Resolving 75566 Deltas done in 0.604427 sec at 125021 Deltas/sec
	[INFO   ]  Clone attempt 2 Candidate locations done in 8 seconds at 0.246755 Candidate locations/sec
	install(ok): /tmp/datalad (dataset)

This is just an idea, and depends on either LogProgressBar not to be
completely removed (see https://github.com/datalad/datalad/issues/4325#issuecomment-1149499228)

#### 💫 Enhancements and new features
- "log" progress bar would not report about starting specific action as well
