### PR TITLE
Properly include "data packages" in project

### DIFF
--- a/_datalad_build_support/setup.py
+++ b/_datalad_build_support/setup.py
@@ -25,7 +25,7 @@ from packaging.version import Version
 from setuptools import (
     Command,
     DistutilsOptionError,
-    find_packages,
+    find_namespace_packages,
     findall,
     setup,
 )
@@ -438,7 +438,9 @@ def datalad_setup(name, **kwargs):
     # packages = find_packages('.', include=['datalad*'])
     # so we will filter manually for maximal compatibility
     if kwargs.get('packages') is None:
-        kwargs['packages'] = [pkg for pkg in find_packages('.') if pkg.startswith(name)]
+        # Use find_namespace_packages() in order to include folders that
+        # contain data files but no Python code
+        kwargs['packages'] = [pkg for pkg in find_namespace_packages('.') if pkg.startswith(name)]
     if kwargs.get('long_description') is None:
         kwargs.update(get_long_description_from_README())
 


### PR DESCRIPTION
There are several folders in `datalad/` that contain data files but no Python source code, and we want these to be included when datalad is installed.  Currently, these folders are automatically included by the combination of `graft datalad` in `MANIFEST.in` and `include_package_data=True` in `setup.py`, but because we set `packages` in `setup()` to `find_packages()` instead of `find_namespace_packages()`, the folders themselves are not recognized by setuptools as packages.  [This combination of settings is deprecated](https://github.com/pypa/setuptools/issues/3340), and the setuptools developers recommend using `find_namespace_packages()` instead of `find_packages()` for such situations.