### PR TITLE
BF(workaround to #6759): if saving credential failed, just log error and continue

### DIFF
--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -140,7 +140,10 @@ class Credential(object):
 
     def _ask_and_set(self, f, instructions=None):
         v = self._ask_field_value(f, instructions=instructions)
-        self.set(**{f: v})
+        try:
+            self.set(**{f: v})
+        except Exception as e:
+            lgr.error("Failed to record credential field %r: %s", f, CapturedException(e))
         return v
 
     def enter_new(self, instructions=None, **kwargs):


### PR DESCRIPTION
This way user can still continue and achieve the goal without the entire
datalad process crashing and have no clear way forward.  User would just
need to keep entering credential every time I guess.

Ref (not really a fix IMHO): #6759
