### PR TITLE
Prevent duplicated result rendering when searching in default datasets

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -301,7 +301,7 @@ def _search_from_virgin_install(dataset, query):
             "Performing search using DataLad superdataset %r",
             default_ds.path
         )
-        for res in default_ds.search(query):
+        for res in default_ds.search(query, result_renderer="disabled"):
             yield res
         return
     else:


### PR DESCRIPTION
This PR Fixes #6763 

This commit disables the result renderer in a recursive call to `Dataset.search()`. This recursive call is used when no dataset to search through is found and the default super-dataset, i.e. `///` is used.

When the result renderer in the recursive call was not disabled, each result was reported twice.


### Changelog
#### 🐛 Bug Fixes
- prevent duplicated result rendering when searching on default datasets. Fixes #6763
