### PR TITLE
Clean up line end handling in GitRepo

### DIFF
--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -282,7 +282,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ----------
         sep : str, optional
           Use `sep` as line separator. Does not create an empty last line if
-          the input ends on sep.
+          the input ends on sep. The lines contain the separator, if it exists.
 
         All other parameters match those described for `call_git`.
 
@@ -338,14 +338,14 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 env=env)
 
         line_splitter = {
-            STDOUT_FILENO: LineSplitter(sep),
-            STDERR_FILENO: LineSplitter(sep)
+            STDOUT_FILENO: LineSplitter(sep, keep_ends=True),
+            STDERR_FILENO: LineSplitter(sep, keep_ends=True)
         }
 
         for file_no, content in generator:
             if file_no in (STDOUT_FILENO, STDERR_FILENO):
                 for line in line_splitter[file_no].process(content):
-                    yield file_no, line + "\n"
+                    yield file_no, line
             else:
                 raise ValueError(f"unknown file number: {file_no}")
 
@@ -430,12 +430,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ------
         CommandError if the call exits with a non-zero status.
         """
-
-        return self._call_git(args,
-                 files,
-                 expect_stderr=expect_stderr,
-                 expect_fail=expect_fail,
-                 read_only=read_only)[0]
+        return self._call_git(
+            args,
+            files,
+            expect_stderr=expect_stderr,
+            expect_fail=expect_fail,
+            read_only=read_only)[0]
 
     def call_git_items_(self,
                         args,
@@ -444,7 +444,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                         expect_fail=False,
                         env=None,
                         read_only=False,
-                        sep=None):
+                        sep=None,
+                        keep_ends=False):
         """
         Call git, yield output lines when available. Output lines are split
         at line ends or `sep` if `sep` is not None.
@@ -459,7 +460,20 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         Returns
         -------
-        Generator that yields stdout items.
+        Generator that yields stdout items, i.e. lines with the line ending or
+        separator removed.
+
+        Please note, this method is meant to be used to process output that is
+        meant for 'interactive' interpretation. It is not intended to return
+        stdout from a command like "git cat-file". The reason is that
+        it strips of the line endings (or separator) from the result lines,
+        unless 'keep_ends' is True. If 'keep_ends' is False, you will not know
+        which line ending was stripped (if 'separator' is None) or whether a
+        line ending (or separator) was stripped at all, because the last line
+        may not have a line ending (or separator).
+
+        If you want to reliably recreate the output set 'keep_ends' to True and
+        "".join() the result, or use 'GitRepo.call_git()' instead.
 
         Raises
         ------
@@ -482,7 +496,13 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                                                     env=env,
                                                     sep=sep):
                 if file_no == STDOUT_FILENO:
-                    yield line.rstrip("\n")
+                    if keep_ends is True:
+                        yield line
+                    else:
+                        if sep:
+                            yield line.rstrip(sep)
+                        else:
+                            yield line.rstrip()
                 else:
                     stderr_lines.append(line)
 

--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -430,12 +430,13 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ------
         CommandError if the call exits with a non-zero status.
         """
-        return self._call_git(
-            args,
-            files,
-            expect_stderr=expect_stderr,
-            expect_fail=expect_fail,
-            read_only=read_only)[0]
+        return "".join(
+            self.call_git_items_(args,
+                                 files,
+                                 expect_stderr=expect_stderr,
+                                 expect_fail=expect_fail,
+                                 read_only=read_only,
+                                 keep_ends=True))
 
     def call_git_items_(self,
                         args,

--- a/datalad/dataset/tests/test_gitrepo.py
+++ b/datalad/dataset/tests/test_gitrepo.py
@@ -325,3 +325,24 @@ def test_get_dot_git(emptycase, gitdircase, barecase, gitfilecase):
 
         eq_(_get_dot_git(gitfilecase, resolved=r),
             (gitfilecase.resolve() if r else gitfilecase) / 'subdir')
+
+
+@with_tree(tree={
+    "file1": "file1 content",
+    "file2": "file2 content"
+})
+def test_call_git_items(temp_dir):
+
+    repo = GitRepo(temp_dir)
+    repo.init()
+    repo.call_git(["add", "."])
+    repo.call_git(["commit", "-m", "test commit"])
+    print(temp_dir)
+
+    res1 = tuple(repo.call_git_items_(["ls-tree", "HEAD"]))
+    print(res1)
+
+    res2 = tuple(repo.call_git_items_(["ls-tree", "-z", "HEAD"], sep="\0"))
+    print(res2)
+
+    print(res1, res2)

--- a/datalad/runner/tests/test_utils.py
+++ b/datalad/runner/tests/test_utils.py
@@ -91,6 +91,52 @@ def test_line_splitter_continue():
     assert_is_none(line_splitter.finish_processing())
 
 
+def test_line_splitter_keep_ends():
+    line_splitter = LineSplitter(keep_ends=True)
+    lines = line_splitter.process(
+        "first line\n"
+        "second line\r\n"
+        "third line\n"
+        "fourth "
+    )
+
+    assert_equal(lines, [
+        "first line\n",
+        "second line\r\n",
+        "third line\n"
+    ])
+
+    assert_equal(line_splitter.remaining_data, "fourth ")
+
+    lines = line_splitter.process("line\n")
+    assert_equal(lines, ["fourth line\n"])
+    assert_is_none(line_splitter.finish_processing())
+
+
+def test_line_splitter_keep_ends_zero():
+    line_splitter = LineSplitter(separator="\x00", keep_ends=True)
+    lines = line_splitter.process(
+        "first line\x00"
+        "second line\x00"
+        "\r\n\x00"
+        "third line\n\x00"
+        "fourth "
+    )
+
+    assert_equal(lines, [
+        "first line\x00",
+        "second line\x00",
+        "\r\n\x00",
+        "third line\n\x00"
+    ])
+
+    assert_equal(line_splitter.remaining_data, "fourth ")
+
+    lines = line_splitter.process("line\x00")
+    assert_equal(lines, ["fourth line\x00"])
+    assert_is_none(line_splitter.finish_processing())
+
+
 def test_line_splitter_corner_cases():
     line_splitter = LineSplitter()
     lines = line_splitter.process("")

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from _datalad_build_support.setup import (
 requires = {
     'core': [
         'platformdirs',
-        'chardet>=3.0.4',      # rarely used but small/omnipresent
+        'chardet>=3.0.4, <5.0.0',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
         'importlib-metadata >=3.6; python_version < "3.10"',


### PR DESCRIPTION
Fixes #6766 

This PR cleans up the line end handling in GitRepo.call_git_items_() and related functions. It fixes a core issue that was discovered by @adswa and addressed in PR #6754. In addition to #6754 this PR will clean up line-end handling for more methods than `GitRepo.call_git()`. 

Once PR #6754 is merged, this PR should be rebased and merged as well.

In more detail. this PR equips LineSplitter with the capability to retain line endings in the returned lines. That allows for a precise reconstruction of the complete data by joining the lines returned from LineSplitter. 


### Changelog
#### 🏠 Internal
- item based output reading is now able to recreate the complete output bit-identical
