### PR TITLE
WiP: dump of a provider config/auth to support downloads from brainlife

### DIFF
--- a/datalad/downloaders/__init__.py
+++ b/datalad/downloaders/__init__.py
@@ -12,6 +12,7 @@
 
 from datalad.downloaders.credentials import (
     AWS_S3,
+    BrainLife_Token,
     LORIS_Token,
     NDA_S3,
     Token,
@@ -32,5 +33,6 @@ CREDENTIAL_TYPES = {
     'nda-s3': NDA_S3,
     'token': Token,
     'loris-token': LORIS_Token,
+    'brainlife-token': BrainLife_Token,
     'git': GitCredential,
 }

--- a/datalad/downloaders/configs/brainlife.cfg
+++ b/datalad/downloaders/configs/brainlife.cfg
@@ -1,0 +1,13 @@
+[provider:brainlife]
+# There are 5 used buckets ATM with
+# Example: https://brainlife.io/api/warehouse/dataset/download/605b91bbbc89fe21415e1958
+url_re = https://brainlife.io/api/.*
+credential = brainlife
+authentication_type = bearer_token
+
+[credential:brainlife]
+# url where to request credentials
+#url = https://brainlife.io/auth/#!/signup
+# Actually used by the code
+url = https://brainlife.io/api/auth/local/auth
+type = brainlife-token

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -447,6 +447,23 @@ class LORIS_Token(CompositeCredential):
         super(CompositeCredential, self).__init__(name, url, keyring)
 
 
+def _brainlife_adapter(composite, user=None, password=None, **kwargs):
+    from datalad.support.third.loris_token_generator import LORISTokenGenerator
+
+    gen = LORISTokenGenerator(
+        url=composite.url, method="POST", data_how="urlencode", field="jwt")
+
+    return dict(token=gen.generate_token(user, password))
+
+
+class BrainLife_Token(CompositeCredential):
+    _CREDENTIAL_CLASSES = (UserPassword, Token)
+    _CREDENTIAL_ADAPTERS = (_brainlife_adapter,)
+
+    def __init__(self, name, url=None, keyring=None):
+        super(CompositeCredential, self).__init__(name, url, keyring)
+
+
 class GitCredential(Credential):
     """Credential to access git-credential
     """


### PR DESCRIPTION
Attn @soichih :

```shell
datalad --dbg download-url https://brainlife.io/api/warehouse/dataset/download/605b91bbbc89fe21415e1958
```
worked for me and I got 

```shell
$> tar -tvf 605b91bbbc89fe21415e1958.tar 
-rw-r--r-- brlife/brlife   766 2021-03-24 15:23 microperimetry.tsv
```