### PR TITLE
WIP: assemble the changelog for 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.17.0 ()
+
+#### 🐛 Bug Fix
+
+- Prevent reentry of a runner instance [#6737](https://github.com/datalad/datalad/pull/6737) (([@christian-monch](https://github.com/christian-monch)))
+- Preserve final character in ``call_git()`` output [#6754](https://github.com/datalad/datalad/pull/6754) (([@adswa](https://github.com/adswa))
+
+#### Authors: 2
+
+- Adina Wagner ([@adswa](https://github.com/adswa))
+- Christian Mönch ([@christian-monch](https://github.com/christian-monch))
+
+
+
 # 0.16.6 (Tue Jun 14 2022)
 
 #### 🐛 Bug Fix


### PR DESCRIPTION
This PR is meant to track changelog assembly for release 0.17.0

The list below will be edited to reflect the entries that made it into the release and the changelog:

### Changelog
#### 🐛 Bug Fixes

- Prevent reentry of a runner instance [#6737](https://github.com/datalad/datalad/pull/6737) (([@christian-monch](https://github.com/christian-monch)))
- Preserve final character in ``call_git()`` output [#6754](https://github.com/datalad/datalad/pull/6754) (([@adswa](https://github.com/adswa))

#### 💫 Enhancements and new features
-
#### 🪓 Deprecations and removals
-
#### 📝 Documentation
-
#### 🏠 Internal
-
#### 🛡 Tests
-
