### PR TITLE
Fix test errors caused by updated chardet v5 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from _datalad_build_support.setup import (
 requires = {
     'core': [
         'platformdirs',
-        'chardet>=3.0.4',      # rarely used but small/omnipresent
+        'chardet>=3.0.4, <5.0.0',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
         'importlib-metadata >=3.6; python_version < "3.10"',


### PR DESCRIPTION
Fixes #6776 

This PR limits the allowed `chardet` version to <5.0.0, because `requests` does only support `chardet` up to version 4, and version 5.0.0. was released on pypi on 25th of June 2022

### Changelog
#### 🏠 Internal
- limit chardet version to version 4 in order to fulfill `requests`-dependencies
