### PR TITLE
Remove superfluous `AnnexRepo.remove()` implementation

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2683,24 +2683,6 @@ class AnnexRepo(GitRepo, RepoInterface):
             self._batched.close()
         super(AnnexRepo, self).precommit()
 
-
-    @normalize_paths(match_return_type=False)
-    def remove(self, files, force=False, **kwargs):
-        """Remove files from git/annex
-
-        Parameters
-        ----------
-        files
-        force: bool, optional
-        """
-
-        # TODO: parameter 'force' unnecessary => kwargs / to_options
-        self.precommit()  # since might interfere
-
-        return super(AnnexRepo, self).remove(files, force=force,
-                                             normalize_paths=False,
-                                             **kwargs)
-
     def get_contentlocation(self, key, batch=False):
         """Get location of the key content
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1305,6 +1305,12 @@ class GitRepo(CoreGitRepo):
         if recursive:
             kwargs['r'] = True
 
+        # the name is chosen badly, but the purpose is to make sure that
+        # any pending operations actually manifest themselves in the Git repo
+        # on disk (in case of an AnnexRepo, it could be pending batch
+        # processes that need closing)
+        self.precommit()
+
         # output per removed file is expected to be "rm 'PATH'":
         return [
             line.strip()[4:-1]


### PR DESCRIPTION
By moving the `Repo.precommit()` call into the actual
implementation in `GitRepo`. No change in API or functionality.

This scores a point in datalad/datalad#4595

### Changelog
#### 🏠 Internal
- Consolidate `GitRepo.remove()` and `AnnexRepo.remove()` into a single implementation.
