### PR TITLE
Speed up saving of removals and improve their reporting

### DIFF
--- a/datalad/local/remove.py
+++ b/datalad/local/remove.py
@@ -246,27 +246,13 @@ class Remove(Interface):
                         lgr.debug('Remove file: %s', delpath)
                         delpath.unlink()
                     continue
-                # if we get here, there is nothing on the file system
-                # anymore at this path. Either because the parent
-                # dataset vanished already, or because we dropped a
-                # dataset, and it still needs to be unregistered
-                # from its parent -> `git rm`
-                if dpath.exists():
-                    GitRepo(dpath).call_git(
-                        # no need for recursion, we know that even the root
-                        # path not longer exists
-                        ['rm', '-q'],
-                        files=[str(delpath.relative_to(dpath))]
-                    )
-                    # this path was already being removed by drop
-                    # so it must belong to a dropped dataset
-                    # save won't report about this, let's do it
-                    yield dict(
-                        action='remove',
-                        status='ok',
-                        path=str(delpath),
-                        type='dataset',
-                    )
+                else:
+                    # if we get here, there is nothing on the file system
+                    # anymore at this path. Either because the parent
+                    # dataset vanished already, or because we dropped a
+                    # dataset. `save()` will properly unregistered
+                    # from the parents at the end. nothing else to do
+                    pass
 
         if not refds.is_installed():
             # we already dropped the whole thing

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3350,7 +3350,7 @@ class GitRepo(CoreGitRepo):
                 # sense to have a duplicate implementation.
                 # we do not yield here, but only altogether below -- we are just
                 # processing gone components, should always be quick.
-                self._call_git(['rm'], files=vanished_subds)
+                self._call_git(['rm', '-q'], files=vanished_subds)
                 submodule_change = True
             # remove anything from the index that was found to be gone
             self._call_git(

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -27,7 +27,7 @@ from datalad.tests.utils_pytest import (
 
 @with_tempfile
 def test_save_basics(path=None):
-    ds = Dataset(path).create()
+    ds = Dataset(path).create(result_renderer='disabled')
     # nothing happens
     eq_(list(ds.repo.save(paths=[], _status={})),
         [])
@@ -80,7 +80,7 @@ def test_annexrepo_save_all(path=None):
 
 @with_tempfile
 def test_save_to_git(path=None):
-    ds = Dataset(path).create()
+    ds = Dataset(path).create(result_renderer='disabled')
     create_tree(
         ds.path,
         {

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -45,7 +45,8 @@ def _test_save_all(path, repocls):
     # make sure we get a 'delete' result for each deleted file
     eq_(
         set(r['path'] for r in res if r['action'] == 'delete'),
-        {k for k, v in orig_status.items() if k.name == 'file_deleted'}
+        {k for k, v in orig_status.items()
+         if k.name in ('file_deleted', 'file_staged_deleted')}
     )
     saved_status = ds.repo.status(untracked='all')
     # we still have an entry for everything that did not get deleted

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1817,6 +1817,7 @@ def assert_repo_status(path, annex=None, untracked_mode='normal', **kwargs):
 
 def get_convoluted_situation(path, repocls=AnnexRepo):
     from datalad.api import create
+    ckwa = dict(result_renderer='disabled')
 
     #if 'APPVEYOR' in os.environ:
     #    # issue only happens on appveyor, Python itself implodes
@@ -1826,7 +1827,7 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
     #        'reason unknown')
     repo = repocls(path, create=True)
     # use create(force) to get an ID and config into the empty repo
-    ds = Dataset(path).create(force=True)
+    ds = Dataset(path).create(force=True, **ckwa)
     # base content
     create_tree(
         ds.path,
@@ -1856,7 +1857,7 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
                 'file_dropped_clean': 'file_dropped_clean',
             }
         )
-    ds.save()
+    ds.save(**ckwa)
     if isinstance(ds.repo, AnnexRepo):
         # some files straight in git
         create_tree(
@@ -1870,42 +1871,42 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
                 'file_ingit_modified': 'file_ingit_clean',
             }
         )
-        ds.save(to_git=True)
+        ds.save(to_git=True, **ckwa)
         ds.drop([
             'file_dropped_clean',
             opj('subdir', 'file_dropped_clean')],
-            reckless='kill')
+            reckless='kill', **ckwa)
     # clean and proper subdatasets
-    ds.create('subds_clean')
-    ds.create(opj('subdir', 'subds_clean'))
-    ds.create('subds_unavailable_clean')
-    ds.create(opj('subdir', 'subds_unavailable_clean'))
+    ds.create('subds_clean', **ckwa)
+    ds.create(opj('subdir', 'subds_clean'), **ckwa)
+    ds.create('subds_unavailable_clean', **ckwa)
+    ds.create(opj('subdir', 'subds_unavailable_clean'), **ckwa)
     # uninstall some subdatasets (still clean)
     ds.drop([
         'subds_unavailable_clean',
         opj('subdir', 'subds_unavailable_clean')],
-        what='all', reckless='kill', recursive=True)
+        what='all', reckless='kill', recursive=True, **ckwa)
     assert_repo_status(ds.path)
     # make a dirty subdataset
-    ds.create('subds_modified')
-    ds.create(opj('subds_modified', 'someds'))
-    ds.create(opj('subds_modified', 'someds', 'dirtyds'))
+    ds.create('subds_modified', **ckwa)
+    ds.create(opj('subds_modified', 'someds'), **ckwa)
+    ds.create(opj('subds_modified', 'someds', 'dirtyds'), **ckwa)
     # make a subdataset with additional commits
-    ds.create(opj('subdir', 'subds_modified'))
+    ds.create(opj('subdir', 'subds_modified'), **ckwa)
     pdspath = opj(ds.path, 'subdir', 'subds_modified', 'progressedds')
-    ds.create(pdspath)
+    ds.create(pdspath, **ckwa)
     create_tree(
         pdspath,
         {'file_clean': 'file_ingit_clean'}
     )
-    Dataset(pdspath).save()
+    Dataset(pdspath).save(**ckwa)
     assert_repo_status(pdspath)
     # staged subds, and files
-    create(opj(ds.path, 'subds_added'))
+    create(opj(ds.path, 'subds_added'), **ckwa)
     # use internal helper to get subdataset into an 'added' state
     # that would not happen in standard datalad workflows
     list(ds.repo._save_add_submodules([ds.pathobj / 'subds_added']))
-    create(opj(ds.path, 'subdir', 'subds_added'))
+    create(opj(ds.path, 'subdir', 'subds_added'), **ckwa)
     list(ds.repo._save_add_submodules([ds.pathobj / 'subdir' / 'subds_added']))
     # some more untracked files
     create_tree(
@@ -1931,8 +1932,8 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
     )
     ds.repo.add(['file_added', opj('subdir', 'file_added')])
     # untracked subdatasets
-    create(opj(ds.path, 'subds_untracked'))
-    create(opj(ds.path, 'subdir', 'subds_untracked'))
+    create(opj(ds.path, 'subds_untracked'), **ckwa)
+    create(opj(ds.path, 'subdir', 'subds_untracked'), **ckwa)
     # deleted files
     os.remove(opj(ds.path, 'file_deleted'))
     os.remove(opj(ds.path, 'subdir', 'file_deleted'))


### PR DESCRIPTION
The previous implementation in `GitRepo._save()` used `git-rm` to
handle the staging of removed files. However, this porcelain command
also handles the actual removal of files from the working tree.
This is unnecessary here, because only items are processed that
have already found to be removed from the working tree. Therefore,
the more lightweight `update-index` is used now, and provides measurable
speed-ups. I found between 5-10% faster `datalad-save` runtimes when
removing 2k file entries from a dataset on a lightning-fast NVME drive.
Because `GitRepo` methods using the `normalize_paths` decorator are
avoided now, the speed-up should be even more substantial on slower
file systems.

This change also improves the reporting of `datalad-save` when saving
the removal of a subdataset. Previously, it was reported as

```
% datalad save -d demo
delete(ok): sub (file)
```

with the confusing `file` type property. Now it is properly reported as
a dataset:

```
% datalad save -d demo
delete(ok): sub (dataset)
```

Here is some code to help play with this:

```sh 
datalad create demo
for i in $(seq -w 2000); do echo $i > demo/${i}.txt; done
datalad save -d demo
rm demo/*.txt
multitime -n1 datalad save -d demo

# cleanup for the next run
datalad drop -d demo --reckless kill --what all -r
```

### Changelog
#### 💫 Enhancements and new features
- Saving removed dataset content was sped-up, and reporting of types of removed content now accurately states `dataset` for added and removed subdatasets, instead of `file`. Moreover, saving previously staged deletions is now also reported.
