### PR TITLE
Fix "common data source" test to use a valid URL

### DIFF
--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -548,7 +548,11 @@ def test_as_common_datasource(testbed=None, viapath=None, viaurl=None, remotepat
     res = ds_fromurl.siblings(
         'add',
         name='fresh',
-        url=url,
+        # we must amend the URL given by serve_path_via_http, because
+        # we are serving the root of a non-bare repository, but git-annex
+        # needs to talk to its .git (git-clone would also not eat
+        # `url` unmodified).
+        url=url + '.git',
         as_common_datasrc='fresh-sr',
         result_renderer='disabled',
     )


### PR DESCRIPTION
Previously the test relied on git-annex to be more tolerant to
invalid repository URLs than Git itself.

Fixes datalad/datalad#6779

### Changelog
#### 🛡 Tests
- Fix "common data source" test to use a valid URL to avoid failure with git-annex later than 10.20220525-64-g14584e7a3. Fixes #6779
