### PR TITLE
Merge commit '0.16.6-17-g9e147092b' into merge-maint

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -38,7 +38,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements-devel.txt
+        # we are using pytest here but extensions still tested with nose
         pip install nose
     - name: Install ${{ matrix.extension }} extension
       run: |
@@ -65,3 +66,9 @@ jobs:
         python -m nose -s -v --with-cov --cover-package datalad $(echo ${{ matrix.extension }} | tr '-' '_')
         # TODO: later whenever some extensions would migrate to pytest -- use pytest
         # python -m pytest -c ../tox.ini -s -v --cov=datalad --pyargs $(echo ${{ matrix.extension }} | tr '-' '_')
+        python -m coverage xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        directory: __testhome__
+        fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.16.6 (Tue Jun 14 2022)
+
+#### 🐛 Bug Fix
+
+- Prevent duplicated result rendering when searching in default datasets [#6765](https://github.com/datalad/datalad/pull/6765) ([@christian-monch](https://github.com/christian-monch))
+- BF(workaround): skip test_ria_postclonecfg on OSX for now ([@yarikoptic](https://github.com/yarikoptic))
+- BF(workaround to #6759): if saving credential failed, just log error and continue [#6762](https://github.com/datalad/datalad/pull/6762) ([@yarikoptic](https://github.com/yarikoptic))
+- Prevent reentry of a runner instance [#6737](https://github.com/datalad/datalad/pull/6737) ([@christian-monch](https://github.com/christian-monch))
+
+#### Authors: 2
+
+- Christian Mönch ([@christian-monch](https://github.com/christian-monch))
+- Yaroslav Halchenko ([@yarikoptic](https://github.com/yarikoptic))
+
+---
+
 # 0.16.5 (Wed Jun 08 2022)
 
 #### 🐛 Bug Fix

--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -282,7 +282,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ----------
         sep : str, optional
           Use `sep` as line separator. Does not create an empty last line if
-          the input ends on sep.
+          the input ends on sep. The lines contain the separator, if it exists.
 
         All other parameters match those described for `call_git`.
 
@@ -338,14 +338,14 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 env=env)
 
         line_splitter = {
-            STDOUT_FILENO: LineSplitter(sep),
-            STDERR_FILENO: LineSplitter(sep)
+            STDOUT_FILENO: LineSplitter(sep, keep_ends=True),
+            STDERR_FILENO: LineSplitter(sep, keep_ends=True)
         }
 
         for file_no, content in generator:
             if file_no in (STDOUT_FILENO, STDERR_FILENO):
                 for line in line_splitter[file_no].process(content):
-                    yield file_no, line + "\n"
+                    yield file_no, line
             else:
                 raise ValueError(f"unknown file number: {file_no}")
 
@@ -364,9 +364,10 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         """Allows for calling arbitrary commands.
 
         Internal helper to the call_git*() methods.
-
+        Unlike call_git, _call_git returns both stdout and stderr.
         The parameters, return value, and raised exceptions match those
-        documented for `call_git`.
+        documented for `call_git`, with the exception of env, which allows to
+        specify the custom environment (variables) to be used.
         """
         runner = self._git_runner
         stderr_log_level = {True: 5, False: 11}[expect_stderr]
@@ -429,12 +430,13 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         ------
         CommandError if the call exits with a non-zero status.
         """
-        return "\n".join(
+        return "".join(
             self.call_git_items_(args,
                                  files,
                                  expect_stderr=expect_stderr,
                                  expect_fail=expect_fail,
-                                 read_only=read_only))
+                                 read_only=read_only,
+                                 keep_ends=True))
 
     def call_git_items_(self,
                         args,
@@ -443,7 +445,8 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                         expect_fail=False,
                         env=None,
                         read_only=False,
-                        sep=None):
+                        sep=None,
+                        keep_ends=False):
         """
         Call git, yield output lines when available. Output lines are split
         at line ends or `sep` if `sep` is not None.
@@ -458,7 +461,20 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
 
         Returns
         -------
-        Generator that yields stdout items.
+        Generator that yields stdout items, i.e. lines with the line ending or
+        separator removed.
+
+        Please note, this method is meant to be used to process output that is
+        meant for 'interactive' interpretation. It is not intended to return
+        stdout from a command like "git cat-file". The reason is that
+        it strips of the line endings (or separator) from the result lines,
+        unless 'keep_ends' is True. If 'keep_ends' is False, you will not know
+        which line ending was stripped (if 'separator' is None) or whether a
+        line ending (or separator) was stripped at all, because the last line
+        may not have a line ending (or separator).
+
+        If you want to reliably recreate the output set 'keep_ends' to True and
+        "".join() the result, or use 'GitRepo.call_git()' instead.
 
         Raises
         ------
@@ -481,7 +497,13 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                                                     env=env,
                                                     sep=sep):
                 if file_no == STDOUT_FILENO:
-                    yield line.rstrip("\n")
+                    if keep_ends is True:
+                        yield line
+                    else:
+                        if sep:
+                            yield line.rstrip(sep)
+                        else:
+                            yield line.rstrip()
                 else:
                     stderr_lines.append(line)
 

--- a/datalad/dataset/tests/test_gitrepo.py
+++ b/datalad/dataset/tests/test_gitrepo.py
@@ -320,3 +320,59 @@ def test_get_dot_git(emptycase=None, gitdircase=None, barecase=None, gitfilecase
 
         eq_(_get_dot_git(gitfilecase, resolved=r),
             (gitfilecase.resolve() if r else gitfilecase) / 'subdir')
+
+
+file1_content = "file1 content\n"
+file2_content = "file2 content\0"
+example_tree = {
+    "file1": file1_content,
+    "file2": file2_content
+}
+
+
+def _create_test_gitrepo(temp_dir):
+    repo = GitRepo(temp_dir)
+    repo.init()
+    repo.call_git(["add", "."])
+    repo.call_git(["commit", "-m", "test commit"])
+
+    hash_keys = tuple(
+        repo.call_git(["hash-object", file_name]).strip()
+        for file_name in ("file1", "file2")
+    )
+    return repo, hash_keys
+
+
+@with_tree(tree=example_tree)
+def test_call_git_items(temp_dir=None):
+    # check proper handling of separator in call_git_items_
+    repo, (hash1, hash2) = _create_test_gitrepo(temp_dir)
+
+    expected_tree_lines = (
+        f'100644 blob {hash1}\tfile1',
+        f'100644 blob {hash2}\tfile2'
+    )
+
+    assert_equal(
+        expected_tree_lines,
+        tuple(repo.call_git_items_(["ls-tree", "HEAD"]))
+    )
+
+    assert_equal(
+        expected_tree_lines,
+        tuple(repo.call_git_items_(["ls-tree", "-z", "HEAD"], sep="\0"))
+    )
+
+
+@with_tree(tree=example_tree)
+def test_call_git_call_git_items_identity(temp_dir=None):
+    # Ensure that git_call() and "".join(call_git_items_(..., keep_ends=True))
+    # yield the same result and that the result is identical to the file content
+
+    repo, hash_keys = _create_test_gitrepo(temp_dir)
+    args = ["cat-file", "-p"]
+    for hash_key, content in zip(hash_keys, (file1_content, file2_content)):
+        r_item = "".join(repo.call_git_items_(args + [hash_key], keep_ends=True))
+        r_no_item = repo.call_git(args, [hash_key])
+        assert_equal(r_item, r_no_item)
+        assert_equal(r_item, content)

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -140,7 +140,10 @@ class Credential(object):
 
     def _ask_and_set(self, f, instructions=None):
         v = self._ask_field_value(f, instructions=instructions)
-        self.set(**{f: v})
+        try:
+            self.set(**{f: v})
+        except Exception as e:
+            lgr.error("Failed to record credential field %r: %s", f, CapturedException(e))
         return v
 
     def enter_new(self, instructions=None, **kwargs):

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -301,7 +301,7 @@ def _search_from_virgin_install(dataset, query):
             "Performing search using DataLad superdataset %r",
             default_ds.path
         )
-        for res in default_ds.search(query):
+        for res in default_ds.search(query, result_renderer="disabled"):
             yield res
         return
     else:

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -13,6 +13,7 @@ Thread based subprocess execution with stdout and stderr passed to protocol obje
 import enum
 import logging
 import subprocess
+import threading
 import time
 from collections import deque
 from collections.abc import Generator
@@ -115,6 +116,7 @@ class _ResultGenerator(Generator):
             # state: GeneratorState.process_exited.
             if len(self.result_queue) > 0:
                 return self.result_queue.popleft()
+            self.runner.generator = None
             raise StopIteration(self.return_code)
 
     def throw(self, exception_type, value=None, trace_back=None):
@@ -237,10 +239,13 @@ class ThreadedRunner:
         self.result = None
         self.process_removed = False
         self.return_code = None
+        self.generator = None
 
         self.last_touched = dict()
         self.active_file_numbers = set()
         self.stall_check_interval = 10
+
+        self.initialization_lock = threading.Lock()
 
     def _check_result(self):
         if self.exception_on_error is True:
@@ -261,6 +266,13 @@ class ThreadedRunner:
     def run(self) -> Union[Any, Generator]:
         """
         Run the command as specified in __init__.
+
+        This method is not re-entrant. Furthermore, if the protocol is a
+        subclass of `GeneratorMixIn`, and the generator has not been
+        exhausted, i.e. it has not raised `StopIteration`, this method should
+        not be called again. If it is called again before the generator is
+        exhausted, a `RuntimeError` is raised. In the non-generator case, a
+        second caller will be suspended until the first caller has returned.
 
         Returns
         -------
@@ -291,6 +303,13 @@ class ThreadedRunner:
                # get the return code of the process
                result = gen.return_code
         """
+        with self.initialization_lock:
+            return self._locked_run()
+
+    def _locked_run(self) -> Union[Any, Generator]:
+        if self.generator is not None:
+            raise RuntimeError("ThreadedRunner.run() was re-entered")
+
         if isinstance(self.stdin, (int, IO, type(None))):
             # We will not write anything to stdin. If the caller passed a
             # file-like he can write to it from a different thread.
@@ -346,6 +365,7 @@ class ThreadedRunner:
                     "information."
                 )
             raise
+
         self.process_running = True
         self.active_file_numbers.add(None)
 
@@ -430,7 +450,8 @@ class ThreadedRunner:
         self.process_waiting_thread.start()
 
         if issubclass(self.protocol_class, GeneratorMixIn):
-            return _ResultGenerator(self, self.protocol.result_queue)
+            self.generator = _ResultGenerator(self, self.protocol.result_queue)
+            return self.generator
 
         return self.process_loop()
 

--- a/datalad/runner/tests/test_threadsafety.py
+++ b/datalad/runner/tests/test_threadsafety.py
@@ -1,0 +1,128 @@
+import random
+import threading
+import time
+from threading import Thread
+from typing import (
+    Any,
+    List,
+    Tuple,
+)
+
+from ..coreprotocols import StdOutCapture
+from ..nonasyncrunner import ThreadedRunner
+from ..protocol import GeneratorMixIn
+from .utils import py2cmd
+from datalad.tests.utils import assert_raises
+
+
+class MinimalGeneratorProtocol(GeneratorMixIn, StdOutCapture):
+    def __init__(self):
+        StdOutCapture.__init__(self)
+        GeneratorMixIn.__init__(self)
+
+
+class MinimalStdOutGeneratorProtocol(GeneratorMixIn, StdOutCapture):
+    def __init__(self):
+        StdOutCapture.__init__(self)
+        GeneratorMixIn.__init__(self)
+
+    def pipe_data_received(self, fd, data):
+        for line in data.decode().splitlines():
+            self.send_result((fd, line))
+
+
+def _runner_with_protocol(protocol) -> ThreadedRunner:
+    return ThreadedRunner(
+        cmd=py2cmd("for i in range(5): print(i)"),
+        protocol_class=protocol,
+        stdin=None)
+
+
+def _run_on(runner: ThreadedRunner,
+            iterate: bool,
+            exceptions: List
+            ):
+    try:
+        gen = runner.run()
+        if iterate:
+            for _ in gen:
+                time.sleep(random.random())
+    except Exception as e:
+        exceptions.append(e.__class__)
+
+
+def _get_run_on_threads(protocol: Any,
+                        iterate: bool
+                        ) -> Tuple[Thread, Thread, List]:
+
+    runner = _runner_with_protocol(protocol)
+
+    args = (runner, iterate, [])
+    thread_1 = threading.Thread(target=_run_on, args=args)
+    thread_2 = threading.Thread(target=_run_on, args=args)
+
+    return thread_1, thread_2, args[2]
+
+
+def _reentry_detection_run(protocol: Any,
+                           iterate: bool
+                           ) -> List:
+
+    thread_1, thread_2, exception = _get_run_on_threads(protocol, iterate)
+
+    thread_1.start()
+    thread_2.start()
+
+    thread_1.join()
+    thread_2.join()
+    return exception
+
+
+def test_thread_reentry_detection():
+    # expect that two run calls on the same runner with a generator-protocol
+    # and an active generator create a runtime error
+
+    exceptions = _reentry_detection_run(MinimalGeneratorProtocol, False)
+    assert exceptions == [RuntimeError]
+
+
+def test_thread_serialization():
+    # expect that two run calls on the same runner with a non-generator-protocol
+    # do not create a runtime error (executions are serialized though)
+
+    exceptions = _reentry_detection_run(StdOutCapture, True)
+    assert exceptions == []
+
+
+def test_reentry_detection():
+    runner = _runner_with_protocol(MinimalGeneratorProtocol)
+    runner.run()
+    assert_raises(RuntimeError, runner.run)
+
+
+def test_leave_handling():
+    runner = _runner_with_protocol(MinimalStdOutGeneratorProtocol)
+    all_results = [
+        "".join(e[1] for e in runner.run())
+        for _ in (0, 1)
+    ]
+
+    assert all_results[0] == all_results[1]
+
+
+def test_thread_leave_handling():
+    # expect no exception on repeated call to run of a runner with
+    # generator-protocol, if the generator was exhausted before the second call
+
+    thread_1, thread_2, exception = _get_run_on_threads(
+        MinimalStdOutGeneratorProtocol,
+        True
+    )
+
+    thread_1.start()
+    thread_1.join()
+
+    thread_2.start()
+    thread_2.join()
+
+    assert exception == []

--- a/datalad/runner/tests/test_utils.py
+++ b/datalad/runner/tests/test_utils.py
@@ -19,76 +19,83 @@ from ..utils import (
 )
 
 
+test_lines = [
+    "first line",
+    "second line",
+    "third line",
+    ""
+]
+
+
+def _check_splitting_endings_separator(endings: List[str],
+                                       separator: Optional[str] = None,
+                                       keep_ends: bool = False,
+                                       check_continuation: bool = False
+                                       ):
+    for line_ending in endings:
+        line_splitter = LineSplitter(separator=separator, keep_ends=keep_ends)
+        full_end = line_ending + separator if separator else line_ending
+        if separator:
+            expected_end = full_end if keep_ends else line_ending
+        else:
+            expected_end = line_ending if keep_ends else ""
+
+        lines = line_splitter.process(
+            full_end.join(test_lines)
+            + full_end
+            + ("fourth " if check_continuation else "")
+        )
+        assert_equal(
+            lines,
+            [line + expected_end for line in test_lines]
+        )
+
+        if check_continuation:
+            assert_equal(line_splitter.remaining_data, "fourth ")
+            lines = line_splitter.process("line" + full_end)
+            assert_equal(
+                lines,
+                ["fourth line" + expected_end])
+            assert_is_none(line_splitter.finish_processing())
+        else:
+            assert_is_none(line_splitter.finish_processing())
+
+
 def test_line_splitter_basic():
-    line_splitter = LineSplitter()
-    lines = line_splitter.process(
-        "first line\n"
-        "second line\r\n"
-        "third line\n"
-        "\n"
-    )
-
-    assert_equal(
-        lines,
-        [
-            "first line",
-            "second line",
-            "third line",
-            ""
-        ])
-
-    assert_is_none(line_splitter.finish_processing())
+    # expect lines without endings, split at standard line-endings
+    _check_splitting_endings_separator(["\n", "\r\n"])
+    _check_splitting_endings_separator(["\n", "\r\n"], check_continuation=True)
 
 
-def test_line_splitter_unterminated():
-    # Expect two lines split at "x", after the second process-call
-    line_splitter = LineSplitter("x")
-    lines = line_splitter.process("first line")
-    assert_equal(lines, [])
-    lines = line_splitter.process("xsecond linex")
-    assert_equal(lines, ["first line", "second line"])
-    assert_is_none(line_splitter.finish_processing())
+def test_line_splitter_basic_keep():
+    # expect lines without endings, split at standard line-endings
+    _check_splitting_endings_separator(["\n", "\r\n"], keep_ends=True)
+    _check_splitting_endings_separator(
+        ["\n", "\r\n"],
+        keep_ends=True,
+        check_continuation=True)
 
 
-def test_line_splitter_separator():
-    line_splitter = LineSplitter("X")
-    lines = line_splitter.process(
-        "first line\nX"
-        "second line\r\nX"
-        "third line\nX"
-        "\nX"
-    )
-
-    assert_equal(lines, [
-        "first line\n",
-        "second line\r\n",
-        "third line\n",
-        "\n"
-    ])
-
-    assert_is_none(line_splitter.finish_processing())
+def test_line_splitter_zero():
+    # expect lines without endings, split at standard line-endings
+    _check_splitting_endings_separator(["\n", "\r\n"], separator="\x00")
+    _check_splitting_endings_separator(
+        ["\n", "\r\n"],
+        separator="\x00",
+        check_continuation=True)
 
 
-def test_line_splitter_continue():
-    line_splitter = LineSplitter()
-    lines = line_splitter.process(
-        "first line\n"
-        "second line\r\n"
-        "third line\n"
-        "fourth "
-    )
-
-    assert_equal(lines, [
-        "first line",
-        "second line",
-        "third line"
-    ])
-
-    assert_equal(line_splitter.remaining_data, "fourth ")
-
-    lines = line_splitter.process("line\n")
-    assert_equal(lines, ["fourth line"])
-    assert_is_none(line_splitter.finish_processing())
+def test_line_splitter_zero_keep():
+    # expect lines without endings, split at standard line-endings
+    _check_splitting_endings_separator(
+        ["\n", "\r\n"],
+        separator="\x00",
+        keep_ends=True)
+    _check_splitting_endings_separator(
+        ["\n", "\r\n"],
+        separator="\x00",
+        keep_ends=True,
+        check_continuation=True)
 
 
 def test_line_splitter_corner_cases():

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -412,7 +412,6 @@ def test_url_dicts():
     eq_(URL("http://host").query_dict, {})
 
 
-@skip_if_on_windows
 def test_get_url_path_on_fileurls():
     eq_(URL('file:///a').path, '/a')
     eq_(URL('file:///a/b').path, '/a/b')

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -643,7 +643,7 @@ def test_global_config():
 def test_bare(src=None, path=None):
     # create a proper datalad dataset with all bells and whistles
     ds = Dataset(src).create()
-    dlconfig_sha = ds.repo.call_git(['rev-parse', 'HEAD:.datalad/config'])
+    dlconfig_sha = ds.repo.call_git(['rev-parse', 'HEAD:.datalad/config']).strip()
     # can we handle a bare repo version of it?
     gr = AnnexRepo.clone(
         src, path, clone_options=['--bare', '-b', DEFAULT_BRANCH])

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,8 +2,37 @@
 
 Change log
 **********
+0.16.6 (Tue Jun 14 2022)
+========================
+
+Bug Fix
+-------
+
+-  Prevent duplicated result rendering when searching in default
+   datasets `#6765 <https://github.com/datalad/datalad/pull/6765>`__
+   (`@christian-monch <https://github.com/christian-monch>`__)
+-  BF(workaround): skip test_ria_postclonecfg on OSX for now
+   (`@yarikoptic <https://github.com/yarikoptic>`__)
+-  BF(workaround to #6759): if saving credential failed, just log error
+   and continue `#6762 <https://github.com/datalad/datalad/pull/6762>`__
+   (`@yarikoptic <https://github.com/yarikoptic>`__)
+-  Prevent reentry of a runner instance
+   `#6737 <https://github.com/datalad/datalad/pull/6737>`__
+   (`@christian-monch <https://github.com/christian-monch>`__)
+
+Authors: 2
+----------
+
+-  Christian Mnch
+   (`@christian-monch <https://github.com/christian-monch>`__)
+-  Yaroslav Halchenko (`@yarikoptic <https://github.com/yarikoptic>`__)
+
+--------------
+
 0.16.5 (Wed Jun 08 2022)
 ========================
+
+.. _bug-fix-1:
 
 Bug Fix
 -------
@@ -27,7 +56,7 @@ Authors: 1
 0.16.4 (Thu Jun 02 2022)
 ========================
 
-.. _bug-fix-1:
+.. _bug-fix-2:
 
 Bug Fix
 -------
@@ -68,7 +97,7 @@ Authors: 3
 0.16.3 (Thu May 12 2022)
 ========================
 
-.. _bug-fix-2:
+.. _bug-fix-3:
 
 Bug Fix
 -------
@@ -119,7 +148,7 @@ Authors: 4
 0.16.2 (Thu Apr 21 2022)
 ========================
 
-.. _bug-fix-3:
+.. _bug-fix-4:
 
 Bug Fix
 -------
@@ -848,7 +877,7 @@ Authors: 11
 0.15.6 (Sun Feb 27 2022)
 ========================
 
-.. _bug-fix-4:
+.. _bug-fix-5:
 
 Bug Fix
 -------
@@ -885,7 +914,7 @@ Enhancement
    `#6364 <https://github.com/datalad/datalad/pull/6364>`__
    (`@adswa <https://github.com/adswa>`__)
 
-.. _bug-fix-5:
+.. _bug-fix-6:
 
 Bug Fix
 -------
@@ -936,7 +965,7 @@ Authors: 5
 0.15.4 (Thu Dec 16 2021)
 ========================
 
-.. _bug-fix-6:
+.. _bug-fix-7:
 
 Bug Fix
 -------
@@ -1021,7 +1050,7 @@ Authors: 6
 0.15.3 (Sat Oct 30 2021)
 ========================
 
-.. _bug-fix-7:
+.. _bug-fix-8:
 
 Bug Fix
 -------
@@ -1125,7 +1154,7 @@ Authors: 7
 0.15.2 (Wed Oct 06 2021)
 ========================
 
-.. _bug-fix-8:
+.. _bug-fix-9:
 
 Bug Fix
 -------
@@ -1192,7 +1221,7 @@ Authors: 5
 0.15.1 (Fri Sep 24 2021)
 ========================
 
-.. _bug-fix-9:
+.. _bug-fix-10:
 
 Bug Fix
 -------
@@ -1607,7 +1636,7 @@ Tests
 0.14.8 (Sun Sep 12 2021)
 ========================
 
-.. _bug-fix-10:
+.. _bug-fix-11:
 
 Bug Fix
 -------
@@ -1715,7 +1744,7 @@ Authors: 4
 0.14.7 (Tue Aug 03 2021)
 ========================
 
-.. _bug-fix-11:
+.. _bug-fix-12:
 
 Bug Fix
 -------
@@ -1804,6 +1833,8 @@ Internal
    (`@yarikoptic <https://github.com/yarikoptic>`__
    `@jwodder <https://github.com/jwodder>`__)
 
+.. _authors-2-1:
+
 Authors: 2
 ----------
 
@@ -1815,7 +1846,7 @@ Authors: 2
 0.14.5 (Mon Jun 21 2021)
 ========================
 
-.. _bug-fix-12:
+.. _bug-fix-13:
 
 Bug Fix
 -------

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from _datalad_build_support.setup import (
 requires = {
     'core': [
         'platformdirs',
-        'chardet>=3.0.4',      # rarely used but small/omnipresent
+        'chardet>=3.0.4, <5.0.0',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
         'importlib-metadata >=3.6; python_version < "3.10"',


### PR DESCRIPTION
    Merge commit '0.16.6-17-g9e147092b' into merge-maint
    
    * commit '0.16.6-17-g9e147092b': (27 commits)
      Upload coverage from extension tests
      limit chardet version to <5.0.0
      limit chardet version to <5.0.0
      implement call_git with call_git_items_
      refactor runner.utils tests
      keep line endings intact as long as possible
      add a test for call_git_items_ results
      do not skip file-URL tests on windows
      adapt tests to modified GitRepo.call_git-semantic
      Update RST changelog
      Update CHANGELOG.md
      BF(workaround): skip test_ria_postclonecfg on OSX for now
      prevent result rendering in recursive search-call
      DOC: Finalize adjustment of the docstring for _call_git to be factually correct
      refactor thread safety tests
      refactor thread-safety tests
      remove unnecessary assignment
      fix exception recording
      remove debug print, use test's member check
      use assert_raises from datalad test utils
      ...
    
     Conflicts:
            .github/workflows/test_extensions.yml - we added custom installation of nose in master and that conflicted with changes in maint
            datalad/core/distributed/tests/test_clone.py - just a comment conflicted, not clear why git was not smart enough
            datalad/dataset/tests/test_gitrepo.py - also removed unused subprocess import

