### PR TITLE
Fix "common data source" test to use a valid URL (maint-based & extended edition)

### DIFF
--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -581,10 +581,11 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url, remotep
     # and the other one
     assert_status('ok', testbed.get('testfile2'))
 
-    # Let's get explicitly from 'fresh' remote which would not work if URL
-    # above is wrong etc
-    assert_status('ok', testbed.drop('testfile'))
-    assert_status('ok', testbed.get('testfile', source="fresh-sr"))
+    # Let's get explicitly from both remotes which would not work if URL
+    # above is wrong or one of the remotes not autoenabled
+    for remote in 'mike2', 'fresh-sr':
+        assert_status('ok', testbed.drop('testfile'))
+        assert_status('ok', testbed.get('testfile', source=remote))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -551,7 +551,11 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
     res = ds_fromurl.siblings(
         'add',
         name='fresh',
-        url=url,
+        # we must amend the URL given by serve_path_via_http, because
+        # we are serving the root of a non-bare repository, but git-annex
+        # needs to talk to its .git (git-clone would also not eat
+        # `url` unmodified).
+        url=url + '.git',
         as_common_datasrc='fresh-sr',
         result_renderer='disabled',
     )

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -43,7 +43,6 @@ from datalad.tests.utils import (
     serve_path_via_http,
     DEFAULT_BRANCH,
     DEFAULT_REMOTE,
-    HTTPPath,
 )
 
 from datalad.utils import (
@@ -514,7 +513,9 @@ def test_bf3733(path):
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @serve_path_via_http
-def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url, remotepath2, url2):
     ds = Dataset(remotepath).create()
     (ds.pathobj / 'testfile').write_text('likemagic')
     (ds.pathobj / 'testfile2').write_text('likemagic2')
@@ -522,6 +523,11 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
 
     # make clonable via HTTP
     ds.repo.call_git(['update-server-info'])
+
+    # populate location of the 2nd url, so we have two remotes with different UUIDs
+    ds2 = clone(source=remotepath, path=remotepath2)
+    ds2.get('testfile')
+    ds2.repo.call_git(['update-server-info'])
 
     # this does not work for remotes that have path URLs
     ds_frompath = clone(source=remotepath, path=viapath)
@@ -552,34 +558,33 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
     # same thing should be possible by adding a fresh remote
     # We need to do it on a different URL since some versions of git-annex
     # such as 10.20220322-1~ndall+1 might refuse operate with multiple remotes
-    # with identical URLs
-    with HTTPPath(remotepath) as url2:
-        res = ds_fromurl.siblings(
-            'add',
-            name='fresh',
-            # we must amend the URL given by serve_path_via_http, because
-            # we are serving the root of a non-bare repository, but git-annex
-            # needs to talk to its .git (git-clone would also not eat
-            # `url` unmodified).
-            url=url2 + '.git',
-            as_common_datasrc='fresh-sr',
-            result_renderer='disabled',
-        )
-        assert_status('ok', res)
+    # with identical URLs, and otherwise just reuse the same UUID/remote
+    res = ds_fromurl.siblings(
+        'add',
+        name='fresh',
+        # we must amend the URL given by serve_path_via_http, because
+        # we are serving the root of a non-bare repository, but git-annex
+        # needs to talk to its .git (git-clone would also not eat
+        # `url` unmodified).
+        url=url2 + '.git',
+        as_common_datasrc='fresh-sr',
+        result_renderer='disabled',
+    )
+    assert_status('ok', res)
 
-        # now try if it works. we will clone the clone, and get a repo that does
-        # not know its ultimate origin. still, we should be able to pull data
-        # from it via the special remote
-        testbed = clone(source=ds_fromurl, path=testbed)
-        assert_status('ok', testbed.get('testfile'))
-        eq_('likemagic', (testbed.pathobj / 'testfile').read_text())
-        # and the other one
-        assert_status('ok', testbed.get('testfile2'))
+    # now try if it works. we will clone the clone, and get a repo that does
+    # not know its ultimate origin. still, we should be able to pull data
+    # from it via the special remote
+    testbed = clone(source=ds_fromurl, path=testbed)
+    assert_status('ok', testbed.get('testfile'))
+    eq_('likemagic', (testbed.pathobj / 'testfile').read_text())
+    # and the other one
+    assert_status('ok', testbed.get('testfile2'))
 
-        # Let's get explicitly from 'fresh' remote which would not work if URL
-        # above is wrong etc
-        assert_status('ok', testbed.drop('testfile'))
-        assert_status('ok', testbed.get('testfile', source="fresh-sr"))
+    # Let's get explicitly from 'fresh' remote which would not work if URL
+    # above is wrong etc
+    assert_status('ok', testbed.drop('testfile'))
+    assert_status('ok', testbed.get('testfile', source="fresh-sr"))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -570,6 +570,11 @@ def test_as_common_datasource(testbed, viapath, viaurl, remotepath, url):
     # and the other one
     assert_status('ok', testbed.get('testfile2'))
 
+    # Let's get explicitly from 'fresh' remote which would not work if URL
+    # above is wrong etc
+    assert_status('ok', testbed.drop('testfile'))
+    assert_status('ok', testbed.get('testfile', source="fresh-sr"))
+
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
Rebased #6785 against `maint` and then extended the test to actually test that we can get data from that remote for which we specified the now fixed URL.  While at it, as described in https://github.com/datalad/datalad/pull/6785#issuecomment-1172659104 I have ran into another peculiarity of git-annex which would have made #6785 fail on some versions of git-annex ~~, and thus made that remote be served from another URL.  Now seems all to work with both bleeding edge and not so versions.~~ . It is "fun" -- most recent version works it out fine - just replaces one URL with another since UUID is the same (thus makes sense):

```
$> git show git-annex:remote.log
d7d23c22-a9d6-4f88-987d-8b671db81d4e autoenable=true location=http://127.0.0.1:43859/.git name=mike2 type=git timestamp=165670508

$> git show git-annex:remote.log
d7d23c22-a9d6-4f88-987d-8b671db81d4e autoenable=true location=http://127.0.0.1:40665/.git name=fresh-sr type=git timestamp=1656705139.816543473s
```

With that, again, we would not be testing those both cases ('configured' vs 'added' with url), so evolved test to do have two different repos (UUIDs) with two urls and test explicitly that we can get from any of them (so they are autoenabled etc)