### PR TITLE
BF: use --python-match minor option in new datalad-installer release to match outside version of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ matrix:
     env:
       - NOSE_SELECTION=
       - NOSE_SELECTION_OP=not
+      # current "default" version of git-annex 8.20201007  is not co-installable
+      # with python 3.10, so let's just allow for any git-annex version
+      - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex -m conda"
   - if: type = cron
     python: 3.7
     # Single run for Python 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
     - DATALAD_DATASETS_TOPURL=https://datasets-tests.datalad.org
     # How/which git-annex we install.  conda's build would be the fastest, but it must not
     # get ahead in PATH to not shadow travis' python
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20201007 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20201007 -m conda"
 
 matrix:
   include:
@@ -73,12 +73,12 @@ matrix:
     env:
     - NOSE_SELECTION_OP=not
     - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20210310 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20210310 -m conda"
   - python: 3.7
     env:
     - NOSE_SELECTION_OP=""
     - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20210310 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20210310 -m conda"
     # To test https://github.com/datalad/datalad/pull/4342 fix in case of no "not" for NOSE.
     # From our testing in that PR seems to have no effect, but kept around since should not hurt.
     - LANG=bg_BG.UTF-8
@@ -143,7 +143,7 @@ matrix:
   - if: type = cron
     python: 3.7
     env:
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --batch git-annex=8.20200309 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20200309 -m conda"
   # Run with git's master branch rather the default one on the system.
   - if: type = cron
     python: 3.7


### PR DESCRIPTION
@bpoldrack spotted that we are not actually testing against the python version
we set in our matrix runs of travis CI setup.  with datalad-installer 0.9.0 we
can now match to minor (or try even more detailed match) portion of the version
of system wide python. Again -- it would not be system wide python intallation,
but conda installation of python matching in minor portion of the version, which
is what we care in our matrix