### PR TITLE
Make sure a subdataset is saved with a complete .gitmodules record

### DIFF
--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -279,14 +279,16 @@ class Save(Interface):
                     sub_status = superds_status.get(subds_path, {})
                     if not (sub_status.get("state") == "clean" and
                             sub_status.get("type") == "dataset"):
-                        # TODO actually start from an entry that may already
-                        # exist in the status record
-                        superds_status[subds_path] = dict(
+                        # start from an entry that may already exist in the
+                        # status record
+                        superds_status[subds_path] = superds_status.get(
+                            subds_path,
+                            # if we got nothing yet:
                             # shot from the hip, some status config
                             # to trigger this specific super/sub
                             # relation to be saved
-                            state='untracked',
-                            type='dataset')
+                            dict(state='untracked', type='dataset')
+                        )
                 paths_by_ds[superds] = superds_status
 
         def save_ds(args, version_tag=None):

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -1092,3 +1092,17 @@ def test_save_amend(dspath=None):
         )
     assert_not_in(last_sha, ds.repo.get_branch_commits_(branch))
     eq_(ds.repo.format_commit("%B", branch).strip(), "new initial commit")
+
+
+@with_tempfile
+def test_save_sub_trailing_sep_bf6547(path=None):
+    ds = Dataset(path).create()
+    # create not-yet-subdataset inside
+    subds = Dataset(ds.pathobj / 'sub').create()
+    ds.save(path='sub' + os.path.sep)
+    assert_in_results(
+        ds.subdatasets(result_renderer='disabled'),
+        path=subds.path,
+    )
+    # make sure it has the .gitmodules record
+    assert 'sub' in (ds.pathobj / '.gitmodules').read_text()

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3650,7 +3650,8 @@ class GitRepo(CoreGitRepo):
                 # a subdataset
                 # TODO: we could update the URL, and branch info at this point,
                 # even for previously registered subdatasets
-                if i['type'] != 'dataset':
+                if i['type'] != 'dataset' or (
+                        i['type'] == 'dataset' and i['state'] == 'untracked'):
                     gmprops = dict(path=i['rpath'], url=i['url'])
                     if i['id']:
                         gmprops['datalad-id'] = i['id']


### PR DESCRIPTION
Previously, the test for adding a gitmodules record was incomplete
and relied on the assumption that for a new subdataset the type
`dataset` was not determined by the initial `status()` inspection.
However, this is not the case, when an explicit subdataset path
with a trailing path-separator is given to `save()`.

This change amends the test condition to also test for the state
being `untracked`. In principle this alone should be a sufficient
condition. However, due to the complexity of the decision making
in the present implementation, the previous condition as also
kept as an alternative, in order to prevent unexpected side-effect.

Fixes datalad/datalad#6547

### Changelog
#### 🐛 Bug Fixes
- Ensure saving a new subdataset to a superdataset yields a valid `.gitmodules` record regardless of whether and how a path constraint is given to the `save()` call. Fixes #6547