### PR TITLE
Improved support for saving typechanges

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3323,6 +3323,17 @@ class GitRepo(CoreGitRepo):
             if state == 'clean':
                 # we don't care about clean
                 continue
+            if state == 'modified' and props.get('gitshasum') \
+                    and props.get('gitshasum') == props.get('prev_gitshasum'):
+                # reported as modified, but with identical shasums -> typechange
+                # a subdataset maybe? do increasingly expensive tests for
+                # speed reasons
+                if props.get('type') != 'dataset' and f.is_dir() \
+                        and GitRepo.is_valid_repo(f):
+                    # it was not a dataset, but now there is one.
+                    # we declare it untracked to engage the discovery tooling.
+                    state = 'untracked'
+                    props = dict(type='dataset', state='untracked')
             status_state[state][f] = props
             # The hybrid one to retain the same order as in original status
             if state in ('modified', 'untracked'):

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -7,12 +7,14 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test saveds function"""
 
+import shutil
 
 from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils_pytest import (
     assert_in,
+    assert_in_results,
     assert_not_in,
     assert_repo_status,
     create_tree,
@@ -22,6 +24,10 @@ from datalad.tests.utils_pytest import (
     known_failure_windows,
     slow,
     with_tempfile,
+)
+from datalad.utils import (
+    on_windows,
+    rmtree,
 )
 
 
@@ -75,6 +81,51 @@ def test_gitrepo_save_all(path=None):
 @with_tempfile
 def test_annexrepo_save_all(path=None):
     _test_save_all(path, AnnexRepo)
+
+
+@with_tempfile
+def test_save_typechange(path=None):
+    ckwa = dict(result_renderer='disabled')
+    ds = Dataset(path).create(**ckwa)
+    foo = ds.pathobj / 'foo'
+    # save a file
+    foo.write_text('some')
+    ds.save(**ckwa)
+    # now delete the file and replace with a directory and a file in it
+    foo.unlink()
+    foo.mkdir()
+    bar = foo / 'bar'
+    bar.write_text('foobar')
+    res = ds.save(**ckwa)
+    assert_in_results(res, path=str(bar), action='add', status='ok')
+    assert_repo_status(ds.repo)
+    if not on_windows:
+        # now replace file with subdataset
+        # (this is https://github.com/datalad/datalad/issues/5418)
+        bar.unlink()
+        Dataset(ds.pathobj / 'tmp').create(**ckwa)
+        shutil.move(ds.pathobj / 'tmp', bar)
+        res = ds.save(**ckwa)
+        assert_repo_status(ds.repo)
+        assert len(ds.subdatasets(**ckwa)) == 1
+    # now replace directory with subdataset
+    rmtree(foo)
+    Dataset(ds.pathobj / 'tmp').create(**ckwa)
+    shutil.move(ds.pathobj / 'tmp', foo)
+    # right now a first save() will save the subdataset removal only
+    ds.save(**ckwa)
+    # subdataset is gone
+    assert len(ds.subdatasets(**ckwa)) == 0
+    # but it takes a second save() run to get a valid status report
+    # to understand that there is a new subdataset on a higher level
+    ds.save(**ckwa)
+    assert_repo_status(ds.repo)
+    assert len(ds.subdatasets(**ckwa)) == 1
+    # now replace subdataset with a file
+    rmtree(foo)
+    foo.write_text('some')
+    ds.save(**ckwa)
+    assert_repo_status(ds.repo)
 
 
 @with_tempfile


### PR DESCRIPTION
This changeset brings a tests for verifying that `save()` can handle the
following type changes in a dataset:

- replace a file with a directory (that has content)
- replace a file with a (sub)dataset
- replace a directory with a (sub)dataset
- replace a subdataset with a file

`GitRepo.save_()` was fixed to detect and handle replacing a file
with a (sub)dataset.

At the moment the (rather complex case of) replacing a directory that
contains a registered subdataset with a new subdataset requires two
calls to `save()`, instead of being able bring the dataset to a clean
state in one go. This first call automatically unregisters the vanished
subdataset, and the second call registers the new one.

Fixes datalad/datalad#5418

### Changelog
#### 🐛 Bug Fixes
- `save` can now handle various type changes in a dataset, such as a file replaced by a directory or a subdataset, a directory replaced by a subdataset, or a subdataset replaced by a file. Fixes #5418
