### PR TITLE
Fix broken annex symlink after git-mv before saving

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -949,6 +949,19 @@ def test_save_diff_ignore_submodules_config(path=None):
     assert_repo_status(ds.path)
 
 
+@with_tree({"subdir": {"foo": "foocontent"}})
+def test_save_git_mv_fixup(path=None):
+    ds = Dataset(path).create(force=True)
+    ds.save()
+    assert_repo_status(ds.path)
+    ds.repo.call_git(["mv", op.join("subdir", "foo"), "foo"])
+    ds.save()
+    # Was link adjusted properly?  (gh-3686)
+    assert (ds.pathobj / 'foo').read_text() == "foocontent"
+    # all clean
+    assert_repo_status(ds.path)
+
+
 @with_tree(tree={'somefile': 'file content',
                  'subds': {'file_in_sub': 'other'}})
 def test_save_amend(dspath=None):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3336,7 +3336,22 @@ class GitRepo(CoreGitRepo):
         # - commit (with all paths that have been touched, to bypass
         #   potential pre-staged bits)
 
-        need_partial_commit = True if self.get_staged_paths() else False
+        staged_paths = self.get_staged_paths()
+        need_partial_commit = bool(staged_paths)
+        if need_partial_commit and hasattr(self, "call_annex"):
+            # so we have some staged content. let's check which ones
+            # are symlinks -- those could be annex key links that
+            # are broken after a `git-mv` operation
+            # https://github.com/datalad/datalad/issues/4967
+            # call `git-annex pre-commit` on them to rectify this before
+            # saving the wrong symlinks
+            added = status_state['added']
+            tofix = [
+                sp for sp in staged_paths
+                if added.get(self.pathobj / sp, {}).get("type") == "symlink"
+            ]
+            if tofix:
+                self.call_annex(['pre-commit'], files=tofix)
 
         # remove first, because removal of a subds would cause a
         # modification of .gitmodules to be added to the todo list


### PR DESCRIPTION
This change is picking up on the discussion in datalad/datalad#4967
and the stale PR datalad/datalad#5016.

Previously, annex'ed files moved with `git-mv` were repaired by
git-annex only after `datalad save` performed change detection. This
led to `save()` leaving the dataset in a non-clean state, and require
a second `save()` call.

This change prevents this outcome by specifically calling `git annex
pre-commit` on any already staged symlinks, before processing by
`save()`.

Fixes datalad/datalad#4967
### Changelog
#### 🐛 Bug Fixes
- `save` now repairs annex symlinks broken by a `git-mv` operation prior recording a new dataset state. Fixes #4967
