### PR TITLE
Enable `status/diff` to detect type-changes

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -81,3 +81,14 @@ RESERVED_NAMES_WIN = {'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3',
                       'LPT9'}
 # Characters that can't be a part of a file name on Windows
 ILLEGAL_CHARS_WIN = "[<>:/\\|?*\"]|[\0-\31]"
+
+# mode identifiers used by Git (ls-files, ls-tree), mapped to
+# type identifiers as used in command results
+GIT_MODE_TYPE_MAP = {
+    '100644': 'file',
+    # we do not distinguish executables
+    '100755': 'file',
+    '040000': 'directory',
+    '120000': 'symlink',
+    '160000': 'dataset',
+}


### PR DESCRIPTION
Previously, type-changes (when a nature of a repository component
changes in the worktree, e.g., a subdataset is suddenly a file) where
not detected by `status/diff()`, because the `gitsha` report in the
does not differ between the "from" and "to" state.

This change enables this detection by combination this particular
characteristic with a "modified in working tree" indicator to
identify typechanges.

In such cases the previous `type` is not reported as the `prev_type`
property. The new type is determined by a dedicated call to `git
diff-files`, one per each typechange -- under the assumption that such
dataset modifications are rare.

For such cases, the `gitsha` property is no longer included, because
it is not provided by Git and only expensive to obtain. Previously,
the `gitsha` of the previous object of the old type was wrongly
reported.

Fixes datalad/datalad#6791

This will break tests left and right for now, because our code now longer reports wrong gitshas. If it should ever get merged, #6793 should be revisited for a potential simplification.


### Changelog
#### 🐛 Bug Fixes
- Description... Fixes #issue
#### 💫 Enhancements and new features
-