### PR TITLE
Introduce typechange detection for status reporting and saving

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -81,3 +81,14 @@ RESERVED_NAMES_WIN = {'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3',
                       'LPT9'}
 # Characters that can't be a part of a file name on Windows
 ILLEGAL_CHARS_WIN = "[<>:/\\|?*\"]|[\0-\31]"
+
+# mode identifiers used by Git (ls-files, ls-tree), mapped to
+# type identifiers as used in command results
+GIT_MODE_TYPE_MAP = {
+    '100644': 'file',
+    # we do not distinguish executables
+    '100755': 'file',
+    '040000': 'directory',
+    '120000': 'symlink',
+    '160000': 'dataset',
+}

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -97,6 +97,7 @@ def test_repo_diff(path=None, norepo=None):
         {ut.Path(ds.repo.pathobj / 'new'): {
             'state': 'modified',
             'type': 'file',
+            'prev_type': 'file',
             # the beast is modified, but no change in shasum -> not staged
             'gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6',
             'prev_gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6'}})

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3414,6 +3414,12 @@ class GitRepo(CoreGitRepo):
                     if not props.get('gitshasum')
                     # we already did the submodules
                     and props.get('type') != 'dataset'
+                    # update-index only works for files.
+                    # a directory could end up here, when a previously
+                    # committed file was replaced by a directory and
+                    # a new file in it was added. this would automatically
+                    # stage a deletion for the previous file object
+                    and not f.is_dir()
                 ]
             )
             # now yield all deletions

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -49,6 +49,7 @@ from datalad.config import (
     write_config_section,
 )
 from datalad.consts import (
+    GIT_MODE_TYPE_MAP,
     ILLEGAL_CHARS_WIN,
     RESERVED_NAMES_WIN,
 )
@@ -2788,12 +2789,6 @@ class GitRepo(CoreGitRepo):
 
     def _get_content_info_line_helper(self, ref, info, lines, props_re):
         """Internal helper of get_content_info() to parse Git output"""
-        mode_type_map = {
-            '100644': 'file',
-            '100755': 'file',
-            '120000': 'symlink',
-            '160000': 'dataset',
-        }
         for line in lines:
             if not line:
                 continue
@@ -2818,7 +2813,7 @@ class GitRepo(CoreGitRepo):
             # revisit the file props after this path has not been rejected
             if props:
                 inf['gitshasum'] = props.group('sha')
-                inf['type'] = mode_type_map.get(
+                inf['type'] = GIT_MODE_TYPE_MAP.get(
                     props.group('type'), props.group('type'))
 
                 if ref and inf['type'] == 'file':


### PR DESCRIPTION
The proposed changes improve the accuracy of `status/diff` reporting, and consequently the reliability with which `save` can act on datasets modified in more complex ways (files replaced by subdatasets, etc.)

I cannot anticipate to which degree this change is appreciated in datalad-core, given that the added accuracy comes with a runtime cost. I nevertheless wanted to develop and proposed it here.

Should this change be rejected, it may still make sense to ingest the included test, to document which dataset modification scenarios are not supported.

And https://github.com/datalad/datalad/pull/6797/commits/990bc16d42295ebbef496e8135d45ac95949d80a should likely be adopted nevertheless.

I will now detach here and extract this essence of this PR in a patch for inclusion in `datalad-next`. Further work on `diff --patch` and diff drivers will continue outside `-core`.

TODO:

- [x] check whether changes possibly already merged from #6793 require an update or could now be done cheaper/simpler
- [x] add test for typechange reporting from `diffstatus()` as suitable test to add this to sits in #6793
- [x] expand type annotation of diff results, record previous and new type
- [x] the current implementation leaves the working tree modified after a safe on adjusted branches. This is an unintentional change and needs to be investigated