### PR TITLE
Fix a race condition in ssh copy test

### DIFF
--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -204,8 +204,8 @@ def test_ssh_manager_close_no_throw(bogus_socket=None):
 @skip_if_on_windows
 @skip_ssh
 @with_tempfile(mkdir=True)
-@with_tempfile(content="one")
-@with_tempfile(content="two")
+@with_tempfile(content='one')
+@with_tempfile(content='two')
 def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
     port = get_ssh_port('datalad-test')
     remote_url = 'ssh://datalad-test:{}'.format(port)
@@ -216,7 +216,7 @@ def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
     obscure_file = get_most_obscure_supported_name()
     obscure_path = opj(sourcedir, obscure_file)
     with open(obscure_path, 'w') as f:
-        f.write("three")
+        f.write('three')
 
     # copy first two temp files to remote_url:sourcedir
     sourcefiles = [sourcefile1, sourcefile2]
@@ -225,7 +225,10 @@ def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
     # we copy to a different name because the test setup maps local dir and
     # remote dir to the same directory on the test machine. That means the file
     # is copied onto itself. With ssh version 9 this leads to an empty file.
-    ssh.put(obscure_path, opj(remote_url, sourcedir, obscure_file + ".c opy"))
+    # We perform copy instead of just writing the content to the destination
+    # file,  because ww want to ensure that the source file is picked up by
+    # 'ssh.put()'.
+    ssh.put(obscure_path, opj(remote_url, sourcedir, obscure_file + '.c opy'))
 
     # docs promise that connection is auto-opened in case of multiplex
     if _ssh_manager_is_multiplex:
@@ -244,8 +247,8 @@ def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
 
     # check if targetfiles(and its content) exist in remote_url:targetdir,
     # this implies file(s) and recursive directory copying pass
-    for targetfile, content in zip(sourcefiles + [obscure_file + ".c opy"],
-                                   ["one", "two", "three"]):
+    for targetfile, content in zip(sourcefiles + [obscure_file + '.c opy'],
+                                   ['one', 'two', 'three']):
         targetpath = opj(targetdir, targetfile)
         ok_(exists(targetpath))
         with open(targetpath, 'r') as fp:

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -228,7 +228,7 @@ def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
     # We perform copy instead of just writing the content to the destination
     # file,  because ww want to ensure that the source file is picked up by
     # 'ssh.put()'.
-    ssh.put(obscure_path, opj(remote_url, sourcedir, obscure_file + '.c opy'))
+    ssh.put([obscure_path], opj(remote_url, sourcedir, obscure_file + '.c opy'))
 
     # docs promise that connection is auto-opened in case of multiplex
     if _ssh_manager_is_multiplex:

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -222,6 +222,9 @@ def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
     sourcefiles = [sourcefile1, sourcefile2]
     ssh.put(sourcefiles, opj(remote_url, sourcedir))
     # copy obscure file to remote_url:sourcedir/'<obscure_file_name>.c opy'
+    # we copy to a different name because the test setup maps local dir and
+    # remote dir to the same directory on the test machine. That means the file
+    # is copied onto itself. With ssh version 9 this leads to an empty file.
     ssh.put(obscure_path, opj(remote_url, sourcedir, obscure_file + ".c opy"))
 
     # docs promise that connection is auto-opened in case of multiplex

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -212,14 +212,18 @@ def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
     manager = SSHManager()
     ssh = manager.get_connection(remote_url)
 
-    # write to obscurely named file in sourcedir
-    obscure_file = opj(sourcedir, get_most_obscure_supported_name())
-    with open(obscure_file, 'w') as f:
+    # copy content of sourcefile3 to an obscurely named file in sourcedir
+    obscure_file = get_most_obscure_supported_name()
+    obscure_path = opj(sourcedir, obscure_file)
+    with open(obscure_path, 'w') as f:
         f.write("three")
 
-    # copy tempfile list to remote_url:sourcedir
-    sourcefiles = [sourcefile1, sourcefile2, obscure_file]
+    # copy first two temp files to remote_url:sourcedir
+    sourcefiles = [sourcefile1, sourcefile2]
     ssh.put(sourcefiles, opj(remote_url, sourcedir))
+    # copy obscure file to remote_url:sourcedir/'<obscure_file_name>.c opy'
+    ssh.put(obscure_path, opj(remote_url, sourcedir, obscure_file + ".c opy"))
+
     # docs promise that connection is auto-opened in case of multiplex
     if _ssh_manager_is_multiplex:
         ok_(ssh.is_open())
@@ -237,7 +241,8 @@ def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
 
     # check if targetfiles(and its content) exist in remote_url:targetdir,
     # this implies file(s) and recursive directory copying pass
-    for targetfile, content in zip(sourcefiles, ["one", "two", "three"]):
+    for targetfile, content in zip(sourcefiles + [obscure_file + ".c opy"],
+                                   ["one", "two", "three"]):
         targetpath = opj(targetdir, targetfile)
         ok_(exists(targetpath))
         with open(targetpath, 'r') as fp:


### PR DESCRIPTION
Fixes issue #6798 

This PR modifies the test `datalad.support.tests.test_sshconnector::test_ssh_copy` so that it does not longer populate a source directory by copying existing files onto themselves, thereby remove a race condition that left a source file empty.

### Changelog
#### 🛡 Tests
- remove a race condition in ssh copy test
