### PR TITLE
Fix broken annex symlink after git-mv before saving

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -938,6 +938,19 @@ def test_save_diff_ignore_submodules_config(path):
     assert_repo_status(ds.path)
 
 
+@with_tree({"subdir": {"foo": "foocontent"}})
+def test_save_git_mv_fixup(path=None):
+    ds = Dataset(path).create(force=True)
+    ds.save()
+    assert_repo_status(ds.path)
+    ds.repo.call_git(["mv", op.join("subdir", "foo"), "foo"])
+    ds.save()
+    # Was link adjusted properly?  (gh-3686)
+    assert (ds.pathobj / 'foo').read_text() == "foocontent"
+    # all clean
+    assert_repo_status(ds.path)
+
+
 @with_tree(tree={'somefile': 'file content',
                  'subds': {'file_in_sub': 'other'}})
 def test_save_amend(dspath):


### PR DESCRIPTION
This is a single forgotten to be CPed commit from one of the PRs by @mih sent to `master`.  I think I might have already did some misdemeanor and pushed some cherry-picks directly to `maint` without a PR.

With this PR we would be at 0.16.6-26-gedfcfabdb and worth release'ing a quick bug fix release (would also help to bring datalad/git-annex testing into a bit more green land on 'release')