### PR TITLE
Avoid import of nose-based tests.utils, make  skip_if_no_module() and skip_if_no_network() allowed at module level

### DIFF
--- a/datalad/runner/tests/test_threadsafety.py
+++ b/datalad/runner/tests/test_threadsafety.py
@@ -8,11 +8,12 @@ from typing import (
     Tuple,
 )
 
+from datalad.tests.utils_pytest import assert_raises
+
 from ..coreprotocols import StdOutCapture
 from ..nonasyncrunner import ThreadedRunner
 from ..protocol import GeneratorMixIn
 from .utils import py2cmd
-from datalad.tests.utils import assert_raises
 
 
 class MinimalGeneratorProtocol(GeneratorMixIn, StdOutCapture):

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -209,7 +209,7 @@ def skip_if_no_module(module):
     try:
         imp = __import__(module)
     except Exception as exc:
-        pytest.skip("Module %s fails to load" % module)
+        pytest.skip("Module %s fails to load" % module, allow_module_level=True)
 
 
 def skip_if_scrapy_without_selector():
@@ -252,7 +252,7 @@ def skip_if_no_network(func=None):
 
     def check_and_raise():
         if dl_cfg.get('datalad.tests.nonetwork'):
-            pytest.skip("Skipping since no network settings")
+            pytest.skip("Skipping since no network settings", allow_module_level=True)
 
     if func:
         @wraps(func)


### PR DESCRIPTION
This PR addresses the test failures seen in the conda-forge feedstock:

* A remaining import of nose-based `datalad.test.utils` is updated so that nose is no longer needed during tests.
* Calling `skip_if_no_module()` and `skip_if_no_network()` at module level (as is done in `datalad/downloaders/tests/test_s3.py`) is now allowed.

I suggest releasing this in 0.17.1 soon so that a passing release can be made on conda-forge.

### Changelog
#### 🛡 Tests
- Fix failing tests on conda-forge