### PR TITLE
Suppress DeprecationWarning to allow for distutils to be used

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,8 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
     # comes from boto
     ignore:the imp module is deprecated
+    # workaround for https://github.com/datalad/datalad/issues/6307
+    ignore:The distutils package is deprecated
 markers =
     fail_slow
     githubci_osx


### PR DESCRIPTION
Needs to be gone for 3.12: https://github.com/datalad/datalad/issues/6307
