### PR TITLE
BF: provide /dev/null as --git-dir instead of no value

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -373,7 +373,7 @@ class ConfigManager(object):
             # The caller didn't specify a repository. Unset the git directory
             # when calling 'git config' to prevent a repository in the current
             # working directory from leaking configuration into the output.
-            self._config_cmd = ['git', '--git-dir=', 'config']
+            self._config_cmd = ['git', '--git-dir=/dev/null', 'config']
 
         self._src_mode = source
         run_kwargs = dict()

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -289,6 +289,24 @@ def test_something(path=None, new_home=None):
 
 
 @with_tree(tree={
+    '.gitconfig': """\
+[includeIf "gitdir:**/devbgc/**"]
+    path = ~/.gitconfig_bgc
+
+[custom "datalad"]
+  variable = value
+"""})
+def test_includeif_breaking(new_home=None):
+    patched_env = os.environ.copy()
+    patched_env.pop('GIT_CONFIG_GLOBAL', None)
+    patched_env.update(get_home_envvars(new_home))
+    with patch.dict('os.environ', patched_env, clear=True):
+        cfg = ConfigManager()
+        # just want to make sure we read it and didn't crash
+        assert cfg.get('custom.datalad.variable') == "value"
+
+
+@with_tree(tree={
     'ds': {
         '.datalad': {
             'config': """\


### PR DESCRIPTION
As it was reported in https://github.com/datalad/datalad/issues/6815
and inquired from git folks for a better solution (no reply yet) at
https://lore.kernel.org/git/YscCKuoDPBbs4iPX@lena.dartmouth.edu/T/#u
whenever we provide an empty value for --git-dir, iff there is includeIf
statement in config, then git starts to demand a non-empty value for that
setting.  Unfortunately RTFM does not give any clear answer either that is
a legit or not. So I have decided to replace one questionable use with
another which does not cause an error.

Anther alternative I found we could have used two separate invocations of
--system and --global, but we cannot use them at the same time.

I would be intrigued to see how it works or not on Windows ;) (didn't run a full sweep of tests locally either)

Closes #6815

edit: only later mentioned that sent it from a `maint` branch, oops