### PR TITLE
Unsucesfull attempt to provide fixture creating a plain text keyring

### DIFF
--- a/datalad/local/tests/test_gitcredential.py
+++ b/datalad/local/tests/test_gitcredential.py
@@ -70,10 +70,9 @@ def test_gitcredential_interface(path=None):
     assert_false(cred['password'])
 
 
-@with_tempfile
-def test_datalad_credential_helper(path=None):
+def test_datalad_credential_helper(tmp_path, passwordless_keyring):
 
-    ds = Dataset(path).create()
+    ds = Dataset(tmp_path).create()
 
     # tell git to use git-credential-datalad
     ds.config.add('credential.helper', 'datalad', scope='local')


### PR DESCRIPTION
does not work for some reason on debian... easiest is to just set

PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring

for the entire process and then nothing is asked...

Ref: https://github.com/datalad/datalad/issues/6623
