### PR TITLE
RM(TST): remove testing of datalad.test which was removed from 0.17.0

### DIFF
--- a/datalad/tests/test_misc.py
+++ b/datalad/tests/test_misc.py
@@ -30,16 +30,3 @@ def test_get_response_stamp():
     eq_(r['size'], 101)
     eq_(r['mtime'], 1367377320)
     eq_(r['url'], "http://www.example.com/1.dat")
-
-
-def test_test():
-    try:
-        import numpy
-        assert Version(numpy.__version__) >= Version('1.2')
-    except:
-        raise SkipTest("Need numpy 1.2")
-
-    # we need to avoid running global teardown
-    with patch.dict('os.environ', {'DATALAD_TESTS_NOTEARDOWN': '1'}):
-        # we can't swallow outputs due to all the nosetests dances etc
-        datalad.test('datalad.support.tests.test_status', verbose=0)


### PR DESCRIPTION
This test was always skipped since conditioned on having numpy installed
and we no longer keep it as a dependency of any kind so on all CIs it was
skipped.  But I ran into it while testing for debian build where for
some reason numpy was installed

Actually detected while looking at fails for conda: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=533304&view=logs&j=517fe804-fa30-5dc2-1413-330699242c05&t=c10fa5f2-fdf6-5338-3bdb-c4bea7c23412