### PR TITLE
Do not quote paths for ssh >= 9

### DIFF
--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Module to help maintain a registry of versions for external modules etc
 """
+import re
 import sys
 import os.path as op
 from os import linesep
@@ -116,10 +117,16 @@ def _get_ssh_version(exe=None):
     stdout = out['stdout']
     if out['stderr'].startswith('OpenSSH'):
         stdout = out['stderr']
-    assert stdout.startswith('OpenSSH')  # that is the only one we care about atm
-    # The last item in _-separated list in the first word which could be separated
-    # from the rest by , or yet have another word after space
-    return stdout.split(',', 1)[0].split(' ')[0].rstrip('.').split('_')[-1]
+    match = re.match(
+        "OpenSSH_([0-9][0-9]*)\\.([0-9][0-9]*)(p([0-9][0-9]*))?",
+        stdout)
+    if match:
+        return "OPEN_SSH{}.{}.{}".format(
+            match.groups()[0],
+            match.groups()[1],
+            match.groups()[3])
+    else:
+        return "UNKNOWN0.0.0"
 
 
 def _get_system_ssh_version():

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -118,15 +118,14 @@ def _get_ssh_version(exe=None):
     if out['stderr'].startswith('OpenSSH'):
         stdout = out['stderr']
     match = re.match(
-        "OpenSSH_([0-9][0-9]*)\\.([0-9][0-9]*)(p([0-9][0-9]*))?",
+        "OpenSSH.*_([0-9][0-9]*)\\.([0-9][0-9]*)(p([0-9][0-9]*))?",
         stdout)
     if match:
-        return "OPEN_SSH{}.{}.{}".format(
+        return "{}.{}p{}".format(
             match.groups()[0],
             match.groups()[1],
             match.groups()[3])
-    else:
-        return "UNKNOWN0.0.0"
+    raise AssertionError(f"no OpenSSH client found: {stdout}")
 
 
 def _get_system_ssh_version():

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -16,6 +16,7 @@ git calls to a ssh remote without the need to reauthenticate.
 import fasteners
 import os
 import logging
+import re
 from socket import gethostname
 from hashlib import md5
 from subprocess import Popen
@@ -215,13 +216,39 @@ class BaseSSHConnection(object):
 
     @property
     def ssh_version(self):
+        """
+        Determine name and version of the ssh-client.
+
+        Returns
+        -------
+        Tuple[str, int, int, int]
+          - first element of the result is the name of the client or '?' if the
+            client is unknown
+          - second element of the result is the version number or 0 if the
+            client is unknown
+          - third element of the result is the sub-version number or 0 if the
+            client is unknown
+          - fourth element of the result is the patch number or 0 if the
+            client is unknown
+        """
         if self._ssh_version is None:
             result = self.runner.run(
                 [self.ssh_executable, "-V"],
-                protocol=StdErrCapture
-            )
-            version_string = result["stderr"].split(".")[0].split("_")[1]
-            self._ssh_version = int(version_string)
+                protocol=StdErrCapture)
+
+            version_string = result["stderr"].strip()
+            # Check for OpenSSH version
+            match = re.match(
+                "OpenSSH_([0-9][0-9]*)\\.([0-9][0-9]*)(p([0-9][0-9]*))?",
+                version_string)
+            if match:
+                self._ssh_version = (
+                    "OpenSSH",
+                    int(match.groups()[0] or "0"),
+                    int(match.groups()[1] or "0"),
+                    int(match.groups()[3] or "0"))
+            else:
+                self._ssh_version = ("?", 0, 0, 0)
         return self._ssh_version
 
     def _adjust_cmd_for_bundle_execution(self, cmd):
@@ -269,9 +296,10 @@ class BaseSSHConnection(object):
         return ["scp"] + scp_options
 
     def _quote_filename(self, filename):
-        if self.ssh_version < 9:
-            return _quote_filename_for_scp(filename)
-        return filename
+        if self.ssh_version[0] == "OpenSSH" and self.ssh_version[1] >= 9:
+            # no filename quoting for OpenSSH version 9 and above
+            return filename
+        return _quote_filename_for_scp(filename)
 
     def put(self, source, destination, recursive=False, preserve_attrs=False):
         """Copies source file/folder to destination on the remote.

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -83,7 +83,11 @@ def get_connection_hash(hostname, port='', username='', identity_file='',
     # References:
     #  https://github.com/ansible/ansible/issues/11536#issuecomment-153030743
     #  https://github.com/datalad/datalad/pull/1377
-    return md5(
+
+    # The "# nosec" below skips insecure hash checks by 'codeclimate'. The hash
+    # is not security critical, since it is only used as an "abbreviation" of
+    # the unique connection property string.
+    return md5(         # nosec
         '{lhost}{rhost}{port}{identity_file}{username}{force_ip}'.format(
             lhost=gethostname(),
             rhost=hostname,

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -266,7 +266,7 @@ class BaseSSHConnection(object):
         return ["scp"] + scp_options
 
     def _quote_filename(self, filename):
-        if self.ssh_version[0] >= 9:
+        if self.ssh_version[0] == "OPEN_SSH" and self.ssh_version[1] >= 9:
             # no filename quoting for OpenSSH version 9 and above
             return filename
         return _quote_filename_for_scp(filename)

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -266,7 +266,7 @@ class BaseSSHConnection(object):
         return ["scp"] + scp_options
 
     def _quote_filename(self, filename):
-        if self.ssh_version[0] == "OPEN_SSH" and self.ssh_version[1] >= 9:
+        if self.ssh_version[0] >= 9:
             # no filename quoting for OpenSSH version 9 and above
             return filename
         return _quote_filename_for_scp(filename)

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -218,7 +218,8 @@ class BaseSSHConnection(object):
     @property
     def ssh_version(self):
         if self._ssh_version is None:
-            self._ssh_version = external_versions["cmd:ssh"].version
+            ssh_version = external_versions["cmd:ssh"]
+            self._ssh_version = ssh_version.version if ssh_version else None
         return self._ssh_version
 
     def _adjust_cmd_for_bundle_execution(self, cmd):
@@ -266,10 +267,11 @@ class BaseSSHConnection(object):
         return ["scp"] + scp_options
 
     def _quote_filename(self, filename):
-        if self.ssh_version[0] >= 9:
-            # no filename quoting for OpenSSH version 9 and above
-            return filename
-        return _quote_filename_for_scp(filename)
+        if self.ssh_version and self.ssh_version[0] < 9:
+            return _quote_filename_for_scp(filename)
+
+        # no filename quoting for OpenSSH version 9 and above
+        return filename
 
     def put(self, source, destination, recursive=False, preserve_attrs=False):
         """Copies source file/folder to destination on the remote.

--- a/datalad/support/tests/test_sshconnector.py
+++ b/datalad/support/tests/test_sshconnector.py
@@ -256,8 +256,7 @@ def test_ssh_copy(sourcedir=None, sourcefile1=None, sourcefile2=None):
 
     # and now a quick smoke test for get
     # but simplify the most obscure filename slightly to not trip `scp` itself
-    togetfile = Path(targetdir) / (
-        get_most_obscure_supported_name().replace('`', '') + '2')
+    togetfile = Path(targetdir) / (obscure_file.replace('`', '') + '2')
     togetfile.write_text(str('something'))
     ssh.get(opj(remote_url, str(togetfile)), sourcedir)
     ok_((Path(sourcedir) / togetfile.name).exists())

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1603,7 +1603,7 @@ with_parametric_batch = pytest.mark.parametrize("batch", [False, True])
 # filesystems across different OSs.  Start with the most obscure
 OBSCURE_PREFIX = os.getenv('DATALAD_TESTS_OBSCURE_PREFIX', '')
 # Those will be tried to be added to the base name if filesystem allows
-OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5', '{}', "'", '"']
+OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5', '{}', "'", '"', '<', '>']
 UNICODE_FILENAME = u"ΔЙקم๗あ"
 
 # OSX is exciting -- some I guess FS might be encoding differently from decoding


### PR DESCRIPTION
This is the work by @christian-monch in #6812 with 2 little final tune ups to get it working and robustify against case where version is None for some reason (avoid quoting). And also submitted against `maint`.

I would appreciate quite review/merge since that test kept failing all our CI runs, bringing fatigue.