### PR TITLE
DOC: minor fix - consistent DataLad (not Datalad) in docs and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1383,7 +1383,7 @@
 - The credential helper no longer asks the user to repeat tokens or
   AWS keys.  ([#5219][])
 
-- The new option `datalad.locations.sockets` controls where Datalad
+- The new option `datalad.locations.sockets` controls where DataLad
   stores SSH sockets, allowing users to more easily work around file
   system and path length restrictions.  ([#5238][])
 
@@ -2842,7 +2842,7 @@ Primarily bugfixes with some optimizations and refactorings.
 - [addurls][] now suggests close matches when the URL or file format
   contains an unknown field.  ([#3594][])
 
-- Shared logic used in the setup.py files of Datalad and its
+- Shared logic used in the setup.py files of DataLad and its
   extensions has been moved to modules in the _datalad_build_support/
   directory.  ([#3600][])
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2751,7 +2751,7 @@ Enhancements and new features
 -  The credential helper no longer asks the user to repeat tokens or AWS
    keys. (`#5219 <https://github.com/datalad/datalad/issues/5219>`__)
 
--  The new option ``datalad.locations.sockets`` controls where Datalad
+-  The new option ``datalad.locations.sockets`` controls where DataLad
    stores SSH sockets, allowing users to more easily work around file
    system and path length restrictions.
    (`#5238 <https://github.com/datalad/datalad/issues/5238>`__)
@@ -4824,7 +4824,7 @@ Enhancements and new features
    unknown field.
    (`#3594 <https://github.com/datalad/datalad/issues/3594>`__)
 
--  Shared logic used in the setup.py files of Datalad and its extensions
+-  Shared logic used in the setup.py files of DataLad and its extensions
    has been moved to modules in the \_datalad_build_support/ directory.
    (`#3600 <https://github.com/datalad/datalad/issues/3600>`__)
 

--- a/docs/source/credentials.rst
+++ b/docs/source/credentials.rst
@@ -9,7 +9,7 @@ Both directions are independent of each other and none is necessarily required.
 Either direction can be configured based on URL matching patterns.
 In addition, Git can be configured to always query DataLad for credentials without any URL matching.
 
-Let Git query Datalad
+Let Git query DataLad
 =====================
 
 In order to allow Git to query credentials from DataLad, Git needs to be configured to use the git credential helper delivered with DataLad (an executable called `git-credential-datalad`).

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -10,13 +10,13 @@ Customization and extension of functionality
 DataLad provides numerous commands that cover many use cases. However, there
 will always be a demand for further customization or extensions of built-in
 functionality at a particular site, or for an individual user. DataLad
-addresses this need with a mechanism for extending particular Datalad
+addresses this need with a mechanism for extending particular DataLad
 functionality, such as metadata extractor, or providing entire command suites
 for a specialized purpose.
 
 As the name suggests, a :term:`DataLad extension` package is a proper Python package.
 Consequently, there is a significant amount of boilerplate code involved in the
-creation of a new Datalad extension. However, this overhead enables a number of
+creation of a new DataLad extension. However, this overhead enables a number of
 useful features for extension developers:
 
 - extensions can provide any number of additional commands that can be grouped into
@@ -25,7 +25,7 @@ useful features for extension developers:
 - extensions can define `entry_points` for any number of additional metadata extractors
   that become automatically available to DataLad
 - extensions can define `entry_points` for their test suites, such that the standard `datalad create`
-  command will automatically run these tests in addition to the tests shipped with Datalad core
+  command will automatically run these tests in addition to the tests shipped with DataLad core
 - extensions can ship additional dataset procedures by installing them into a
   directory ``resources/procedures`` underneath the extension module directory
 

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -12,7 +12,7 @@ extractors that have to be enabled in a dataset's configuration. Extractors
 yield metadata in a JSON-LD_-like structure that can be arbitrarily complex and
 deeply nested. Metadata from each extractor is kept unmodified, unmangled, and
 separate from metadata of other extractors. This design enables tailored
-applications using particular metadata that can use Datalad as a
+applications using particular metadata that can use DataLad as a
 content-agnostic aggregation and transport layer without being limited or
 impacted by other metadata sources and schemas.
 
@@ -186,10 +186,10 @@ identified at the moment.
 
 .. _metadata-datalad_core:
 
-Datalad's internal metadata storage (``datalad_core``)
+DataLad's internal metadata storage (``datalad_core``)
 ------------------------------------------------------
 
-This extractor can express Datalad's internal metadata representation, such
+This extractor can express DataLad's internal metadata representation, such
 as the relationship of a super- and a subdataset. It uses DataLad's own
 constrained vocabulary.
 


### PR DESCRIPTION
For yet another attempt to cut a release (see #6829)