### PR TITLE
XFAIL test_runner_parametrized_protocol on python3.8 when getting duplicate output

### DIFF
--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -199,7 +199,13 @@ def test_runner_parametrized_protocol():
         # value passed to protocol constructor
         value=b'5',
     )
-    eq_(res['stdout'], '5')
+    try:
+        eq_(res['stdout'], '5')
+    except AssertionError:
+        # TODO: remove when dropping support for python3.8
+        if res['stdout'] == '55' and sys.version_info[:2] == (3, 8):
+            pytest.xfail("got 55 and not 5, see https://github.com/datalad/datalad/issues/4921")
+        raise
 
 
 @integration  # ~3 sec


### PR DESCRIPTION
This should close (unresolved) but not fix https://github.com/datalad/datalad/issues/4921
which seems to happen so far rarely on conda on 3.8 python only. If some brave soul
manages to figure it out -- great. But I would not break our knuckles to see it fixed
since seems to be very particular.  I made xfail also very particular (not over entire
test, only for 3.8 and only for the 55 output) so we do not miss any other problem