### PR TITLE
RF: Replace distutils LooseVersion with looseversion

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -11,7 +11,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from distutils.version import LooseVersion
 import logging
 import os
 from os.path import (
@@ -20,6 +19,8 @@ from os.path import (
     normpath,
     relpath,
 )
+
+from looseversion import LooseVersion
 
 from datalad import ssh_manager
 

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -12,8 +12,8 @@ import sys
 import os.path as op
 from os import linesep
 
-from distutils.version import LooseVersion
 from itertools import chain
+from looseversion import LooseVersion
 
 from datalad.log import lgr
 # import version helper from config to have only one implementation

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requires = {
         'patool>=1.7',
         'tqdm',
         'annexremote',
+        'looseversion',
     ],
     'downloaders': [
         'boto',


### PR DESCRIPTION
Fixes #6307

Followed the convention of stdlib -> dependency -> currentpackage imports, but since there weren't dependency imports in these two files, I'm not positive that you follow this convention. LMK if I should change anything.

### Changelog
#### 🏠 Internal
- Use `looseversion.LooseVersion` as drop-in replacement for `distutils.version.LooseVersion`