### PR TITLE
BF: Make create's check for procedures work with several again

### DIFF
--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -349,7 +349,7 @@ class Create(Interface):
             discovered_procs = tbds.run_procedure(
                 discover=True,
                 result_renderer='disabled',
-                return_type='generator',
+                return_type='list',
             )
             for cfg_proc_ in cfg_proc:
                 for discovered_proc in discovered_procs:


### PR DESCRIPTION
A comment in code review accidentally changed the return type of
an internal ``run_procdure --discover`` call within ``create`` from ``list``
to ``generator``: https://github.com/datalad/datalad/pull/6457#discussion_r809040262
When several procedures were given to ``create`` at once (described in
#6840), the loop over the generator was repeated for each procedure,
and due to chance, procedure discovery sometimes failed when the
generator was depleted at the second for loop iteration.
This change reverts this and changes the return type back to 'list'.

Fixes #6840.


### Changelog
#### 🐛 Bug Fixes
- Create's internal procedure discovery sometimes failed to find available procedures when several were executes at once. An internal return type change fixed this again.  Fixes #6840
