### PR TITLE
Addressing problem testing against python 3.10 on Travis (skip more annex versions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,6 +204,8 @@ before_install:
       PYTEST_OPTS=( "${PYTEST_OPTS[@]}" --doctest-modules --durations=0 --durations-min=5 --fail-slow 30 );
       export DATALAD_TESTS_SETUP_TESTREPOS=1;
     fi
+  # Show git describe output to ensure that we did fetch all the tags etc
+  - git describe
   # Just in case we need to check if nfs is there etc
   - sudo lsmod
   # The ultimate one-liner setup for NeuroDebian repository

--- a/datalad/local/tests/test_add_archive_content.py
+++ b/datalad/local/tests/test_add_archive_content.py
@@ -518,7 +518,7 @@ class TestAddArchiveOptions():
     # git-annex regression
     # https://git-annex.branchable.com/bugs/regression__58___annex_add_of_moved_file_errors_out/
     @skip_if(
-        '10.20220624' <= external_versions['cmd:annex'] < '10.20220706',  # approx when was fixed
+        '10.20220525' <= external_versions['cmd:annex'] < '10.20220706',  # approx when was fixed
         msg="buggy git-annex release"
     )
     def test_add_archive_leading_dir(self):


### PR DESCRIPTION
prompted by https://github.com/datalad/datalad/pull/6841#issuecomment-1185529529 . Still don't know why it got `0+unknown` version, let's see if repeats here