### PR TITLE
Fix doc string typo

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3430,7 +3430,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         """
         .. deprecated:: 0.16
             Use get_content_annexinfo() or the test helper
-            datalad/utils/get_annexstatus() instead.
+            datalad/tests/utils/get_annexstatus() instead.
         """
         info = self.get_content_annexinfo(
             paths=paths,


### PR DESCRIPTION
This PR corrects the location-description of `datalad.tests.utils.get_annexstatus()` in the doc string of `datalad.support.annexrepo.annexstatus()`, where `get_annexstatus` is described as replacement
for `annexstatus()`.

Thanks for contributing!

### Changelog
#### 🏠 Internal
- fixes the location description of `datalad.tests.utils.get_annexstatus()` in the doc-string of `datalad.support.annexrepo.annexstatus()`.
