### PR TITLE
Let push honor multiple publication dependencies declared via siblings 

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -13,6 +13,7 @@
 __docformat__ = 'restructuredtext'
 
 from collections import OrderedDict
+from itertools import chain
 import logging
 import re
 
@@ -498,7 +499,13 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
     depvar = 'remote.{}.datalad-publish-depends'.format(target)
     # list of remotes that are publication dependencies for the
     # target remote
-    publish_depends = ensure_list(ds.config.get(depvar, []))
+    # multiple dependencies could come from multiple declarations
+    # of such a config items, but each declaration could also
+    # contain a white-space separated list of remote names
+    # see https://github.com/datalad/datalad/issues/6867
+    publish_depends = list(chain.from_iterable(
+        d.split() for d in ensure_list(
+            ds.config.get(depvar, [], get_all=True))))
     if publish_depends:
         lgr.debug("Discovered publication dependencies for '%s': %s'",
                   target, publish_depends)

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -499,13 +499,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
     depvar = 'remote.{}.datalad-publish-depends'.format(target)
     # list of remotes that are publication dependencies for the
     # target remote
-    # multiple dependencies could come from multiple declarations
-    # of such a config items, but each declaration could also
-    # contain a white-space separated list of remote names
-    # see https://github.com/datalad/datalad/issues/6867
-    publish_depends = list(chain.from_iterable(
-        d.split() for d in ensure_list(
-            ds.config.get(depvar, [], get_all=True))))
+    publish_depends = ensure_list(ds.config.get(depvar, [], get_all=True))
     if publish_depends:
         lgr.debug("Discovered publication dependencies for '%s': %s'",
                   target, publish_depends)


### PR DESCRIPTION
The documentation for declaring publication dependencies allows for two different ways to declare multiple dependencies:

1. Declaring a single config item with a list of dependencies (space-separated)
2. Declaring a config item multiple times with a single dependency each.

Previously `push()` only supported (1), while `siblings()` produced (2).

This change lets `push()` handle both scenarios.

Fixes #6867

Thanks to @LoannPeurey for the report!