### PR TITLE
Clarify confusing INFO log message from get() on dataset installation

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -622,7 +622,7 @@ def _install_targetpath(
             yield res
         return
     lgr.info(
-        "Installing %s%s recursively",
+        "Ensuring presence of %s%s",
         ds,
         (" to get %s" % target_path
          if ds.path != target_path


### PR DESCRIPTION
The confusion arises from a message that announces the installation
of a (sub)dataset, even when the dataset is already present.

This change rewords the message to be more valid in this case.

Fixes datalad/datalad#6862