### PR TITLE
Align `status/diff` reporting behavior with `git-diff-files`

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3182,8 +3182,13 @@ class GitRepo(CoreGitRepo):
         if state in ('clean', 'added', 'modified', None):
             # assign present gitsha to any record
             # state==None can only happen for subdatasets that
-            # already existed, so also assign a sha for them
-            props['gitshasum'] = to_sha
+            # already existed, so also assign a sha for them.
+            # However, for any worktree modification we do not want to report
+            # the gitsha that we have on record as "current", just like
+            # `git diff-files` would not
+            # https://github.com/datalad/datalad/issues/6875
+            if modified_in_worktree is False:
+                props['gitshasum'] = to_sha
             if 'bytesize' in to_state:
                 # if we got this cheap, report it
                 props['bytesize'] = to_state['bytesize']


### PR DESCRIPTION
Git does not report the previously recorded gitsha for content that
is modified in the worktree. This change removes the `gitshasum`
report from such a result record, in order to match this behavior.

With a worktree modification for a path, reporting the old `gitshasum`
will often just be wrong (except for type changes).

Fixes datalad/datalad#6875

Filed against `master` (not `maint`), because of the implied behavior change.

### Changelog
#### 🐛 Bug Fixes
- Align `status/diff` reporting behavior with `git-diff-files`, by not reporting a `gitshasum` property for paths that are modified in the working tree. Fixes #6875 
