### PR TITLE
Report `prev_type` rather than `type` for `diff/status` of deletions

### DIFF
--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -81,3 +81,14 @@ RESERVED_NAMES_WIN = {'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3',
                       'LPT9'}
 # Characters that can't be a part of a file name on Windows
 ILLEGAL_CHARS_WIN = "[<>:/\\|?*\"]|[\0-\31]"
+
+# mode identifiers used by Git (ls-files, ls-tree), mapped to
+# type identifiers as used in command results
+GIT_MODE_TYPE_MAP = {
+    '100644': 'file',
+    # we do not distinguish executables
+    '100755': 'file',
+    '040000': 'directory',
+    '120000': 'symlink',
+    '160000': 'dataset',
+}

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -439,7 +439,7 @@ class Status(Interface):
             or refds == os.getcwd() else None
         path = res['path'] if refds is None \
             else str(ut.Path(res['path']).relative_to(refds))
-        type_ = res.get('type', res.get('type_src', ''))
+        type_ = res.get('type', res.get('prev_type', ''))
         max_len = len('untracked')
         state = res.get('state', 'unknown')
         ui.message(u'{fill}{state}: {path}{type_}'.format(

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -97,6 +97,7 @@ def test_repo_diff(path=None, norepo=None):
         {ut.Path(ds.repo.pathobj / 'new'): {
             'state': 'modified',
             'type': 'file',
+            'prev_type': 'file',
             # the beast is modified, but no change in shasum -> not staged
             'gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6',
             'prev_gitshasum': '7b4d68d70fcae134d5348f5e118f5e9c9d3f05f6'}})

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3414,6 +3414,12 @@ class GitRepo(CoreGitRepo):
                     if not props.get('gitshasum')
                     # we already did the submodules
                     and props.get('type') != 'dataset'
+                    # update-index only works for files.
+                    # a directory could end up here, when a previously
+                    # committed file was replaced by a directory and
+                    # a new file in it was added. this would automatically
+                    # stage a deletion for the previous file object
+                    and not f.is_dir()
                 ]
             )
             # now yield all deletions

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3222,7 +3222,7 @@ class GitRepo(CoreGitRepo):
 
         if state == 'deleted':
             # report the type that was deleted
-            props['type'] = from_state['type']
+            props['prev_type'] = from_state['type']
 
         if state:
             # only report a state if we could determine any

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -49,6 +49,7 @@ from datalad.config import (
     write_config_section,
 )
 from datalad.consts import (
+    GIT_MODE_TYPE_MAP,
     ILLEGAL_CHARS_WIN,
     RESERVED_NAMES_WIN,
 )
@@ -2788,12 +2789,6 @@ class GitRepo(CoreGitRepo):
 
     def _get_content_info_line_helper(self, ref, info, lines, props_re):
         """Internal helper of get_content_info() to parse Git output"""
-        mode_type_map = {
-            '100644': 'file',
-            '100755': 'file',
-            '120000': 'symlink',
-            '160000': 'dataset',
-        }
         for line in lines:
             if not line:
                 continue
@@ -2818,7 +2813,7 @@ class GitRepo(CoreGitRepo):
             # revisit the file props after this path has not been rejected
             if props:
                 inf['gitshasum'] = props.group('sha')
-                inf['type'] = mode_type_map.get(
+                inf['type'] = GIT_MODE_TYPE_MAP.get(
                     props.group('type'), props.group('type'))
 
                 if ref and inf['type'] == 'file':


### PR DESCRIPTION
This PR sits on top of https://github.com/datalad/datalad/pull/6797 to enable a simple and clear fix. Only the last commit is relevant here.

This change aligns the behavior with that of `git diff-files`.
    
The default result renderer is adjusted to maintain the same (visual) behavior. This is also fixing the querying of an outdated result property.
    
Closes datalad/datalad#6877

PR against `master`, because of the implied behavior change.

### Changelog
#### 🐛 Bug Fixes
- Align status/diff reporting behavior with git-diff-files, by not reporting a `type` property for paths that are deleted. Instead `prev_type` is reported. Fixes #6877