### PR TITLE
Protect again failing to load a command interface from an extension

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -57,6 +57,11 @@ def _generate_extension_api():
         for intfspec in interfaces:
             # turn the interface spec into an instance
             intf = load_interface(intfspec[:2])
+            if intf is None:
+                lgr.error(
+                    "Skipping unusable command interface '%s.%s' from extension %r",
+                    intfspec[0], intfspec[1], ename)
+                continue
             api_name = get_api_name(intfspec)
             if api_name in globals():
                 lgr.debug(


### PR DESCRIPTION
Previously DataLad could crash if an extension entrypoint was
importable, but a declared command suit item would not.

This change now skips each individual command interface with an
error message like this:

```
% python -c 'import datalad.api as dl'
[ERROR  ] Internal error, cannot import interface 'datalad_dataverse.create_sibling_dataverse': ModuleNotFoundError(No module named 'datalad_next')
[ERROR  ] Skipping unusable command interface 'datalad_dataverse.create_sibling_dataverse.CreateSiblingDataverse' from extension 'dataverse'
```

(I have an extension installed, where one command depends on an
unavailable package).

Closes datalad/datalad#6874