### PR TITLE
ENH(TST): test against supported git annex repo version 10 + make it a full sweep over tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,21 @@ matrix:
     env:
     - PYTEST_SELECTION=
     - PYTEST_SELECTION_OP=not
+  # Two matrix runs for "recent python and git-annex with the recent supported by git annex
+  # new version of repo"
   - python: '3.10'
     dist: focal
     env:
       - PYTEST_SELECTION=
       - PYTEST_SELECTION_OP=not
-      # current "default" version of git-annex 8.20201007  is not co-installable
-      # with python 3.10, so let's just allow for any git-annex version
+      - DATALAD_REPO_VERSION=10
+      - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex -m conda"
+  - python: '3.10'
+    dist: focal
+    env:
+      - PYTEST_SELECTION=
+      - PYTEST_SELECTION_OP=
+      - DATALAD_REPO_VERSION=10
       - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex -m conda"
   - if: type = cron
     python: 3.7


### PR DESCRIPTION
10 is the most recent supported git annex repo version.  It should bring improvement
in some operation performance (see e.g.
https://github.com/dandi/dandisets/issues/229#issuecomment-1192971292 ). But it is not the
default version git annex would use (it uses 8), so AFAIK there is no "real life" testing
for operation of v10 annex repos.  Also we did not do full sweep of testing against python
3.10, so I made second matrix run for it, to which I also added testing against v10.  This
way we do not do full combinatorics of python version/git-annex/git-annex repo version but
at least gain 1 environment with 2 matrix runs for full tests sweep in a "most modern
environment" setting
