### PR TITLE
BF: RF f-string uses in logger to %-interpolations

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -119,7 +119,7 @@ class BatchedCommandProtocol(GeneratorMixIn, StdOutErrCapture):
         if fd == STDOUT_FILENO:
             remaining_line = self.line_splitter.finish_processing()
             if remaining_line is not None:
-                lgr.debug(f"unterminated line: {remaining_line}")
+                lgr.debug("unterminated line: %s", remaining_line)
                 self.send_result((fd, remaining_line))
 
     def timeout(self, fd: Optional[int]) -> bool:
@@ -325,13 +325,13 @@ class BatchedCommand(SafeDelCloseMixin):
                     except StopIteration:
                         # The process finished executing, store the last return
                         # code and restart the process.
-                        lgr.debug(f"{self}: command exited")
+                        lgr.debug("%s: command exited", self)
                         self.return_code = self.generator.return_code
                         self.runner = None
 
         except CommandError as command_error:
             # The command exited with a non-zero return code
-            lgr.error(f"{self}: command error: {command_error}")
+            lgr.error("%s: command error: %s", self, command_error)
             self.return_code = command_error.code
             self.runner = None
 
@@ -464,19 +464,21 @@ class BatchedCommand(SafeDelCloseMixin):
                 self.return_code = self.generator.return_code
 
             except CommandError as command_error:
-                lgr.error(f"{self} subprocess failed with {command_error}")
+                lgr.error("%s subprocess failed with %s", self, command_error)
                 self.return_code = command_error.code
 
             if remaining:
-                lgr.debug(f"{self}: remaining content: {remaining}")
+                lgr.debug("%s: remaining content: %s", self, remaining)
 
             self.wait_timed_out = timeout is True
             if self.wait_timed_out:
                 lgr.debug(
-                    f"{self}: timeout while waiting for subprocess to exit")
+                    "%s: timeout while waiting for subprocess to exit", self)
                 lgr.warning(
-                    f"Batched process ({self.generator.runner.process.pid}) "
-                    f"did not finish, abandoning it without killing it")
+                    "Batched process (%s) "
+                    "did not finish, abandoning it without killing it",
+                    self.generator.runner.process.pid,
+                )
 
         result = self.get_requested_error_output(return_stderr)
         self.runner = None

--- a/datalad/runner/runnerthreads.py
+++ b/datalad/runner/runnerthreads.py
@@ -56,7 +56,7 @@ class SignalingThread(threading.Thread):
             try:
                 signal_queue.put(content, block=True, timeout=.1)
             except Full:
-                lgr.debug(f"timeout while trying to signal: {content}")
+                lgr.debug("timeout while trying to signal: %s", content)
                 error_occurred = True
         return not error_occurred
 


### PR DESCRIPTION
f-strings should not be used for logger since if any of the .format-ed
content contains some %, it would then be incorrectly or causing a crash
%-polated by the logger.  Although some of the "fixed" cases would be ok
(we know that it was an int etc) for consistency and to avoid needed
"is this particular use safe?" checks, better to avoid f-strings in
logger in general
