### PR TITLE
DX: Demote loglevel of message on url parameters to debug

### DIFF
--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -631,7 +631,7 @@ class URL(RI):
         This function converts ParseResult into dict"""
 
         if pr.params:
-            lgr.warning("ParseResults contains params %r, which will be ignored"
+            lgr.debug("ParseResults contains params %r, which will be ignored"
                         % (pr.params,))
 
         hostname_port = pr.netloc.split('@')[-1]

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -211,7 +211,7 @@ def test_url_base():
 
     assert_raises(ValueError, url._set_from_fields, unknown='1')
 
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         # we don't "care" about params ATM so there is a warning if there are any
         purl = URL("http://example.com/;param")
         eq_(str(purl), 'http://example.com/;param')  # but we do maintain original string


### PR DESCRIPTION
Our own obscure paths generate filepaths that RFC 1808 on URLs
schemes mistakes to have URL parameter specifications because
they contain a semicolon (see  #6872).
Internally, when urlparse detects parameters in a URL, we warn
that those parameters will not be honored or considered at all.
In general, I find this is a nice thing to do, but annoying when
its actually not a URL with parameters. My initial thought on
how to keep the information but make it less annoying is to
demote the log level of the message from warning to debug.
Alternatively, we could do more parsing and guessing on whether
or not something a URL where parameters make sense, but that
could probably easily introduce more problems or wrong assessments. So this change here could maybe fix #6872 


### Changelog
#### 🏠 Internal
- In order to reduce inconsequential warnings over obscure paths resembling URLs with parameters in tests, a warning about ignoring URL parameters has been demoted to debug log level
