### PR TITLE
DX: Demote loglevel of message on url parameters to DEBUG while guessing RI

### DIFF
--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -631,7 +631,7 @@ class URL(RI):
         This function converts ParseResult into dict"""
 
         if pr.params:
-            lgr.warning("ParseResults contains params %r, which will be ignored"
+            lgr.debug("ParseResults contains params %r, which will be ignored"
                         % (pr.params,))
 
         hostname_port = pr.netloc.split('@')[-1]

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -323,7 +323,7 @@ def _guess_ri_cls(ri):
 
     # We assume that it is a URL and parse it. Depending on the result
     # we might decide that it was something else ;)
-    fields = URL._pr_to_fields(urlparse(ri))
+    fields = URL._pr_to_fields(urlparse(ri), guessing=True)
     lgr.log(5, "Parsed ri %s into fields %s", ri, fields)
     type_ = 'url'
     # Special treatments
@@ -625,14 +625,14 @@ class URL(RI):
         return ParseResult(**pr_fields)
 
     @classmethod
-    def _pr_to_fields(cls, pr):
+    def _pr_to_fields(cls, pr, guessing=False):
         """ParseResult is a tuple so immutable, which complicates adjusting it
 
         This function converts ParseResult into dict"""
-
         if pr.params:
-            lgr.debug("ParseResults contains params %r, which will be ignored"
-                        % (pr.params,))
+            (lgr.debug if guessing else lgr.warning)(
+                "ParseResults contains params %s, which will be ignored",
+                repr(pr.params),)
 
         hostname_port = pr.netloc.split('@')[-1]
         is_ipv6 = hostname_port.count(':') >= 2

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -190,7 +190,6 @@ def _check_ri(ri, cls, exact_str=True, localpath=None, **fields):
         eq_(ri_.localpath, opj(old_localpath, 'sub'))
 
 
-
 def test_url_base():
     # Basic checks
     assert_raises(ValueError, URL, "http://example.com", hostname='example.com')
@@ -211,12 +210,23 @@ def test_url_base():
 
     assert_raises(ValueError, url._set_from_fields, unknown='1')
 
-    with swallow_logs(new_level=logging.DEBUG) as cml:
+    with swallow_logs(new_level=logging.WARNING) as cml:
         # we don't "care" about params ATM so there is a warning if there are any
         purl = URL("http://example.com/;param")
         eq_(str(purl), 'http://example.com/;param')  # but we do maintain original string
         assert_in('ParseResults contains params', cml.out)
         eq_(purl.as_str(), 'http://example.com/')
+
+
+@with_tempfile
+def test_pathri_guessing(filename=None):
+    # Complaining about ;param only at DEBUG level
+    # see https://github.com/datalad/datalad/issues/6872
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        # we don't "care" about params ATM so there is a warning if there are any
+        ri = RI(f"{filename};param")
+        assert isinstance(ri, PathRI)
+        assert_in('ParseResults contains params', cml.out)
 
 
 @known_failure_githubci_win

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -211,7 +211,7 @@ def test_url_base():
 
     assert_raises(ValueError, url._set_from_fields, unknown='1')
 
-    with swallow_logs(new_level=logging.WARNING) as cml:
+    with swallow_logs(new_level=logging.DEBUG) as cml:
         # we don't "care" about params ATM so there is a warning if there are any
         purl = URL("http://example.com/;param")
         eq_(str(purl), 'http://example.com/;param')  # but we do maintain original string


### PR DESCRIPTION
It is #6890 by @adswa with my addition to the solution -- log at DEBUG only while guessing. See the last commit

Our own obscure paths generate filepaths that RFC 1808 on URLs
schemes mistakes to have URL parameter specifications because
they contain a semicolon (see  #6872).
Internally, when urlparse detects parameters in a URL, we warn
that those parameters will not be honored or considered at all.
In general, I find this is a nice thing to do, but annoying when
its actually not a URL with parameters. My initial thought on
how to keep the information but make it less annoying is to
demote the log level of the message from warning to debug.
Alternatively, we could do more parsing and guessing on whether
or not something a URL where parameters make sense, but that
could probably easily introduce more problems or wrong assessments. So this change here could maybe fix #6872 


### Changelog
#### 🏠 Internal
- In order to reduce inconsequential warnings over obscure paths resembling URLs with parameters in tests, a warning about ignoring URL parameters has been demoted to debug log level
