### PR TITLE
Use pytest to test datalad-metalad in test_extensions-workflow

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -67,6 +67,14 @@ jobs:
         # TODO: later whenever some extensions would migrate to pytest -- use pytest
         # python -m pytest -c ../tox.ini -s -v --cov=datalad --pyargs $(echo ${{ matrix.extension }} | tr '-' '_')
         python -m coverage xml
+      if: matrix.extension != 'datalad-metalad' || matrix.extension == 'datalad-hirni'
+    - name: ${{ matrix.extension }} tests
+      run: |
+        mkdir -p __testhome__
+        cd __testhome__
+        python -m pytest -c ../tox.ini -s -v --cov=datalad --pyargs $(echo ${{ matrix.extension }} | tr '-' '_')
+        python -m coverage xml
+      if: matrix.extension == 'datalad-metalad'
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -39,8 +39,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-devel.txt
-        # we are using pytest here but extensions still tested with nose
-        pip install nose
     - name: Install ${{ matrix.extension }} extension
       run: |
         pip install https://github.com/datalad/${{ matrix.extension }}/archive/master.zip
@@ -61,6 +59,8 @@ jobs:
         datalad wtf
     - name: ${{ matrix.extension }} tests
       run: |
+        # These extensions are still tested with nose
+        pip install nose
         mkdir -p __testhome__
         cd __testhome__
         python -m nose -s -v --with-cov --cover-package datalad $(echo ${{ matrix.extension }} | tr '-' '_')

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -39,6 +39,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-devel.txt
+    - name: Install nose to test ${{ matrix.extension }} extension
+      run: |
+        pip install nose
+      if: matrix.extension != 'datalad-metalad'
     - name: Install ${{ matrix.extension }} extension
       run: |
         pip install https://github.com/datalad/${{ matrix.extension }}/archive/master.zip
@@ -59,8 +63,6 @@ jobs:
         datalad wtf
     - name: ${{ matrix.extension }} tests
       run: |
-        # These extensions are still tested with nose
-        pip install nose
         mkdir -p __testhome__
         cd __testhome__
         python -m nose -s -v --with-cov --cover-package datalad $(echo ${{ matrix.extension }} | tr '-' '_')


### PR DESCRIPTION
This PR modifies the test_extensions-workflow to use `pytest` if the tested extension is `datalad-metalad`. The extension `datalad-metalad` recently switched from `nose` to `pytest` because `nose` does not work with python 3.10.

This should fix errors in `test (datalad-metalad)


### Changelog
#### 🛡 Tests
- switch test runner for `datalad-metalad` extension from `nose` to `pytest`.
