### PR TITLE
ENH(TST): Disable coverage reporting on travis while running pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -272,6 +272,7 @@ script:
       -m "${PYTEST_SELECTION:+$PYTEST_SELECTION_OP($PYTEST_SELECTION) and }not(turtle)"
       --doctest-modules
       --cov=datalad
+      --cov-report=
       --pyargs
       $TESTS_TO_PERFORM
   - cd ..


### PR DESCRIPTION
I found those reports spit out at the end of the pytest very annoying to avoid
while searching for failed tests.  And they aren't really useful since we

- at large anyways relying on codecov reporting while combining across
different CIs and runs

- have `report` at the end upon success when submitting to codecov. So we
can look at those if desired, and they are nicly folded in their own step

If desired -- can do for other runs (appveyor etc).
