### PR TITLE
BF(TST): do not expect log message for guessing Path to be possibly a URL on windows

### DIFF
--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -226,7 +226,10 @@ def test_pathri_guessing(filename=None):
         # we don't "care" about params ATM so there is a warning if there are any
         ri = RI(f"{filename};param")
         assert isinstance(ri, PathRI)
-        assert_in('ParseResults contains params', cml.out)
+        if not on_windows:
+            # Does not happen on Windows since paths with \ instead of / do not
+            # look like possible URLs
+            assert_in('ParseResults contains params', cml.out)
 
 
 @known_failure_githubci_win


### PR DESCRIPTION
Since paths are actually containg \ not / like on POSIX/in urls.

Prehistory:

In #6891 I have missed the fact that windows on appveyor was not happy! (on the importance of having CI green!!!!):

https://ci.appveyor.com/project/mih/datalad/builds/44287617/job/fgp764p65r1ba5oj

	____________________________ test_pathri_guessing _____________________________
	filename = 'C:\\DLTMP\\datalad_temp_pwl4puuu'
		@with_tempfile
		def test_pathri_guessing(filename=None):
			# Complaining about ;param only at DEBUG level
			# see https://github.com/datalad/datalad/issues/6872
			with swallow_logs(new_level=logging.DEBUG) as cml:
				# we don't "care" about params ATM so there is a warning if there are any
				ri = RI(f"{filename};param")
				assert isinstance(ri, PathRI)
	>           assert_in('ParseResults contains params', cml.out)
	..\datalad\support\tests\test_network.py:229:
	_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
	first = 'ParseResults contains params', second = '', msg = None
		def assert_in(first, second, msg=None):
			if msg is None:
	>           assert first in second
	E           AssertionError: assert 'ParseResults contains params' in ''
	..\datalad\tests\utils_pytest.py:131: AssertionError
	============================== warnings summary ===============================
	datalad/support/tests/test_cookies.py::test_no_blows

and indeed only on windows:

	(git)smaug:/mnt/datasets/datalad/ci/logs/2022/08[master]git
	$> git grep FAIL.*test_pathri_guessing
	02/pr/6907/7226824/appveyor-8314-failed/84vlamobs20bbih0.txt:[00:46:09] FAILED ..\datalad\support\tests\test_network.py::test_pathri_guessing - Asser...
	02/push/rf-minor/7226824/appveyor-8313-failed/pl2n7yc5jfgv9lpe.txt:[00:40:49] FAILED ..\datalad\support\tests\test_network.py::test_pathri_guessing - Asser...

	$> cd ../07

	$> git grep FAIL.*test_pathri_guessing
	26/pr/6891/2dfa4f6/appveyor-8280-failed/fgp764p65r1ba5oj.txt:[00:39:18] FAILED ..\datalad\support\tests\test_network.py::test_pathri_guessing - Asser...
	29/pr/6898/fe417e0/appveyor-8300-failed/twx5hrhmt2u5ks4n.txt:[00:40:33] FAILED ..\datalad\support\tests\test_network.py::test_pathri_guessing - Asser...
	29/pr/6899/c3e2ed8/appveyor-8301-failed/8cbph0v7xetnpm8g.txt:[00:39:12] FAILED ..\datalad\support\tests\test_network.py::test_pathri_guessing - Asser...
	29/pr/6902/2f9e1ac/appveyor-8302-failed/l4xy5rv7a0p88wk5.txt:[00:39:36] FAILED ..\datalad\support\tests\test_network.py::test_pathri_guessing - Asser...
	29/push/maint/825c8e0/appveyor-8299-failed/xn68pxgkuxf27iya.txt:[00:37:40] FAILED ..\datalad\support\tests\test_network.py::test_pathri_guessing - Asser...
	git grep FAIL.*test_pathri_guessing  5.46s user 8.23s system 102% cpu 13.398 total

