### PR TITLE
BF: travis - mark our directory as safe to interact with as root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -245,6 +245,9 @@ before_install:
 install:
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
+  # we are pip sudo install  below and versioneer needs to run git. recent git needs to
+  # be made certain it is safe to do
+  - sudo git config --global --add safe.directory $PWD
   - cd ..; pip install -q codecov; cd -
   - pip install -r requirements-devel.txt
   # So we could test under sudo -E with PATH pointing to installed location


### PR DESCRIPTION
The last commit from https://github.com/datalad/datalad/pull/6913

We are doing   `sudo pip install`   but that then causes versioneer to run
git, and a recent git would fail with the message like

	$ sudo git "rev-parse" "--git-dir"
	fatal: unsafe repository ('/home/travis/build/datalad/datalad' is owned by someone else)
	To add an exception for this directory, call:
		git config --global --add safe.directory /home/travis/build/datalad/datalad
	The command "sudo git "rev-parse" "--git-dir"" exited with 128.

so here we do what it asks us.

Fixes https://github.com/datalad/datalad/issues/6887
Closes https://github.com/datalad/datalad/pull/6913