### PR TITLE
BF+ENH(TST): fix typo in code of wtf filesystems reports

### DIFF
--- a/datalad/local/tests/test_wtf.py
+++ b/datalad/local/tests/test_wtf.py
@@ -37,6 +37,8 @@ from datalad.tests.utils_pytest import (
 )
 from datalad.utils import ensure_unicode
 
+from datalad.support.external_versions import external_versions
+
 
 @with_tree({OBSCURE_FILENAME: {}})
 def test_wtf(topdir=None):
@@ -77,6 +79,11 @@ def test_wtf(topdir=None):
         wtf(dataset=ds.path, sensitive='all')
         assert_not_in(_HIDDEN, cmo.out)  # all is shown
         assert_in('user.name: ', cmo.out)
+        if external_versions['psutil']:
+            # filesystems detail should be reported
+            assert_in('max_pathlength:', cmo.out)
+        else:
+            assert_in("Hint: install psutil", cmo.out)
 
     # Sections selection
     #

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -157,7 +157,7 @@ def _get_fs_type(loc, path):
             # if the mountpoint is the test path or its parent
             # take it, whenever there is no match, or a longer match
             if (mp == path or mp in path.parents) and (
-                    match is None or len(p.parents) > len(match.parents)):
+                    match is None or len(mp.parents) > len(match.parents)):
                 match = mp
         match = parts[match]
         for sattr, tattr in (('fstype', 'type'),

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -146,7 +146,7 @@ def _describe_system():
     }
 
 
-def _get_fs_type(loc, path):
+def _get_fs_type(loc, path, _was_warned=[]):
     """Return file system info for given Paths. Provide pathlib path as input"""
     res = {'path': path}
     try:
@@ -169,6 +169,11 @@ def _get_fs_type(loc, path):
         ce = CapturedException(exc)
         # if an exception occurs, leave out the fs type. The result renderer can
         # display a hint based on its lack in the report
+        if not _was_warned:
+            (lgr.debug if isinstance(exc, ImportError) else lgr.warning) (
+                "Could not determine filesystem types due to %s", ce)
+            # Rely on side-effect of [] as default arg
+            _was_warned.append("warned")
     return res
 
 


### PR DESCRIPTION
Detected while looking at https://github.com/datalad/datalad/issues/6917#issuecomment-1205048868 and it was impossible to detect that there is an underlying issue in the code since no logging and swallowing of all exceptions silently.  Added logging, and some rudimentary testing (let's see if works on windows. edit: appveyor was green, so I guess it did!).