### PR TITLE
OPT: always call with "--literal-pathspecs" to disable support of git pathspecs

### DIFF
--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -104,7 +104,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
     """
     # Could be used to e.g. disable automatic garbage and autopacking
     # ['-c', 'receive.autogc=0', '-c', 'gc.auto=0']
-    _GIT_COMMON_OPTIONS = ["-c", "diff.ignoreSubmodules=none"]
+    _GIT_COMMON_OPTIONS = ["-c", "diff.ignoreSubmodules=none", "--literal-pathspecs"]
     _git_cmd_prefix = ["git"] + _GIT_COMMON_OPTIONS
 
     # Begin Flyweight:


### PR DESCRIPTION
Mostly to fire up discussion and investigate the effects from such a change (are refspecs used anywhere?).

"Explicit better than implicit" and we never really promoted or used (AFAIK) git pathspecs,
and really just used/relied on paths, while referring to them as pathspecs:

	(git)lena:~datalad/datalad-master[rf--literal-pathspecs]
	$> git grep pathspec
	datalad/core/local/tests/test_save.py:    # GitRepo.save_) drops the pathspec if there are no staged changes.
	datalad/core/local/tests/test_status.py:        # error: pathspec 'bar/f' did not match any file(s) known to git
	datalad/dataset/gitrepo.py:    _GIT_COMMON_OPTIONS = ["-c", "diff.ignoreSubmodules=none", "--literal-pathspecs"]
	datalad/distribution/tests/test_update.py:    # because it will try to commit with a pathspec, which git doesn't allow
	datalad/support/annexrepo.py:           <pathspec>. This removes as well as modifies index entries to match
	datalad/support/annexrepo.py:           If no <pathspec> is given when --update option is used, all tracked
	datalad/support/gitrepo.py:    # into untracked submodules when multiple pathspecs are given, returning
	datalad/support/gitrepo.py:           <pathspec>. This removes as well as modifies index entries to match
	datalad/support/gitrepo.py:           If no <pathspec> is given when --update option is used, all tracked
	datalad/support/gitrepo.py:                        if l.startswith("error: pathspec")
	datalad/support/tests/test_annexrepo.py:                stderr = "error: pathspec 'nonex1' did not match any file(s) " \
	datalad/support/tests/test_annexrepo.py:                         "error: pathspec 'nonex2' did not match any file(s) " \
	datalad/support/tests/test_annexrepo.py:    msg = "pathspec 'error' did not match" if not dl_cfg.getbool(

that is why I decided that it might lead to slightly improved (but likely
unnoticable) improvement on git performance and overall just more explicit mode
of operation.  But benefit could be argued and we could also argue if we should
may be actually do support  pathsspecs as we actually do now!:

with version before this PR:

	$> datalad status '*.jpg'
	untracked: sub-02/1.jpg (file)

and this PR:

	$> datalad status '*.jpg'
	nothing to save, working tree clean

But then if we want to keep supporting them,  we better

- adjust DOCs to state it explicitly since now we just talk about PATHs -
use --literal-pathspecs only when we know that it is already a PATH and not
pathspec.



### Changelog
#### 🪓 Deprecations and removals
- Remove support of PATHs provided to commands to actually be git pathspecs.
