### PR TITLE
DOCfix: fix docstring GeneratorStdOutErrCapture to say that treats both stdout and stderr identically

### DIFF
--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -306,8 +306,7 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                                         AssemblingDecoderMixIn,
                                         StdOutErrCapture):
             """
-            Generator-runner protocol that yields stdout and captures stderr
-            in the provided stderr_buffer.
+            Generator-runner protocol that captures and yields stdout and stderr.
             """
             def __init__(self):
                 GeneratorMixIn.__init__(self)


### PR DESCRIPTION
I am not sure though if it does capture really, although I guess it should due to
StdOutErrCapture... but that is a different story I guess.  The main point is that
there is no stderr_buffer to be seen and we subclass StdOutErrCapture which
has Capture in name for both Out and Err

@christian-monch please approach this fix "critically" since I have little to no clue on how exactly all the layers of the runner work ATM so I could be entirely wrong and stderr_buffer is right there looking into my face somehow ;-)