### PR TITLE
BUG: fix versioneer.py to work with PEP 660

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1826,6 +1826,8 @@ def get_cmdclass(cmdclass=None):
             cfg = get_config_from_root(root)
             versions = get_versions()
             _build_py.run(self)
+            if self.editable_mode:
+                return
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             if cfg.versionfile_build:


### PR DESCRIPTION
Patch from https://patch-diff.githubusercontent.com/raw/shapely/shapely/pull/1475.patch mentioned in https://github.com/pypa/setuptools/issues/3501 to workaround that issue which just came up and leading all our builds to error out.