### PR TITLE
DOC: fix capitalization of some service names

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yml
@@ -16,7 +16,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Datalad information
+      label: DataLad information
       description: |
         What version of DataLad and git-annex do you use (run `datalad --version`)? 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -576,7 +576,7 @@ Refer datalad/config.py for information on how to add these environment variable
   It is used by tests to create a temporary git directory while testing git annex archives etc
 - *DATALAD_TESTS_NONETWORK*: 
   Skips network tests completely if this flag is set
-  Examples include test for s3, git_repositories, openfmri etc
+  Examples include test for S3, git_repositories, OpenfMRI, etc
 - *DATALAD_TESTS_SSH*: 
   Skips SSH tests if this flag is **not** set.  If you enable this,
   you need to set up a "datalad-test" and "datalad-test2" target in

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -163,7 +163,7 @@ class Clone(Interface):
     result_xfm = 'successdatasets-or-none'
 
     _examples_ = [
-        dict(text="Install a dataset from Github into the current directory",
+        dict(text="Install a dataset from GitHub into the current directory",
              code_py="clone("
              "source='https://github.com/datalad-datasets/longnow"
              "-podcasts.git')",

--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Tooling for creating a publication target on Github-like systems
+"""Tooling for creating a publication target on GitHub-like systems
 """
 
 import logging
@@ -200,7 +200,7 @@ class _GitHubLike(object):
 
     # TODO what are the actual constraints?
     def normalize_reponame(self, path):
-        """Turn name into a Github-like service compliant repository name
+        """Turn name into a GitHub-like service compliant repository name
 
         Useful for sanitizing directory names.
         """

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -98,7 +98,7 @@ class Install(Interface):
     result_filter = is_result_matching_pathsource_argument
 
     _examples_ = [
-        dict(text="Install a dataset from Github into the current directory",
+        dict(text="Install a dataset from GitHub into the current directory",
              code_py="install("
              "source='https://github.com/datalad-datasets/longnow"
              "-podcasts.git')",

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -327,18 +327,18 @@ _definitions = {
     },
     'datalad.github.token-note': {
         'ui': ('question', {
-            'title': 'Github token note',
+            'title': 'GitHub token note',
             'text': 'Description for a Personal access token to generate.'}),
         'default': 'DataLad',
     },
     'datalad.tests.nonetwork': {
         'ui': ('yesno', {
-               'title': 'Skips network tests completely if this flag is set Examples include test for s3, git_repositories, openfmri etc'}),
+               'title': 'Skips network tests completely if this flag is set, Examples include test for S3, git_repositories, OpenfMRI, etc'}),
         'type': EnsureBool(),
     },
     'datalad.tests.nonlo': {
         'ui': ('question', {
-               'title': 'Specifies network interfaces to bring down/up for testing. Currently used by travis.'}),
+               'title': 'Specifies network interfaces to bring down/up for testing. Currently used by Travis CI.'}),
     },
     'datalad.tests.noteardown': {
         'ui': ('yesno', {

--- a/datalad/local/tests/test_gitcredential.py
+++ b/datalad/local/tests/test_gitcredential.py
@@ -157,7 +157,7 @@ def test_datalad_credential_helper(path=None):
 def test_credential_cycle(path=None):
 
     # Test that we break a possible cycle when DataLad is configured to query
-    # git-credential and Git is configured to query Datalad.
+    # git-credential and Git is configured to query DataLad.
     # This may happen in a not-so-obvious fashion, if git-credential-datalad
     # was configured generally rather than for a specific URL, while there's a
     # datalad provider config pointing to Git for a particular URL.

--- a/datalad/metadata/definitions.py
+++ b/datalad/metadata/definitions.py
@@ -11,7 +11,7 @@
 # identifiers that defines an ontology as a whole
 vocabulary_id = 'http://purl.org/dc/dcam/VocabularyEncodingScheme'
 
-# this is the canonical version string of Datalad's current metadata scheme
+# this is the canonical version string of DataLad's current metadata scheme
 version = '2.0'
 
 # for maximum compatibility with git-annex' metadata setup, _keys_ in this

--- a/datalad/metadata/extractors/datalad_core.py
+++ b/datalad/metadata/extractors/datalad_core.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Metadata extractor for Datalad's own core storage"""
+"""Metadata extractor for DataLad's own core storage"""
 
 from datalad.metadata.extractors.base import BaseMetadataExtractor
 

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -349,7 +349,7 @@ Move/Rename/Delete
 ~~~~~~~~~~~~~~~~~~
 
 Just move/rename/delete some files around e.g. for a custom view of
-the dataset (e.g. to conform openfmri layout). Key would simply be
+the dataset (e.g. to conform to OpenfMRI layout). Key would simply be
 reused ;)
 
 Q: should it be 'Within-branch' filter?
@@ -541,7 +541,7 @@ a URI should be associated with an "Hosting" (many-to-one), so we could
 e.g. provide authentication information per actual "Hosting" as the
 entity.  But now we are getting back to DataProvider, which is the
 Hosting, or actually also a part of it (since Hosting could serve
-multiple Providers, e.g. openfmri -> providers per each dataset?)
+multiple Providers, e.g. OpenfMRI -> providers per each dataset?)
 But also Provider might use/point to multiple Hostings (e.g. mirrors
 listed on nitp-2013).
 

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -99,7 +99,7 @@ desired data redundancy across the network of dataset, or to prevent
 publication of sensitive data to publicly accessible repositories. Individual
 datasets in a hierarchy of (sub)datasets need not be stored at the same location.
 Continuing with an earlier example, it is possible to post a curated
-collection of datasets, as a superdataset, on Github, while the actual datasets
+collection of datasets, as a superdataset, on GitHub, while the actual datasets
 live on different servers all around the world.
 
 Basic command line usage

--- a/docs/source/design/credentials.rst
+++ b/docs/source/design/credentials.rst
@@ -13,7 +13,7 @@ Credential management
 
 Various components of DataLad need to be passed credentials to interact with services that require authentication. 
 This includes downloading files, but also things like REST API usage or authenticated cloning.
-Key components of Datalad's credential management are credentials types, providers, authenticators and downloaders.
+Key components of DataLad's credential management are credentials types, providers, authenticators and downloaders.
 
 Credentials
 ===========
@@ -80,7 +80,7 @@ However, providers don't talk to a backend, credentials do.
 Hence, a more seamless integration requires some changes in the design of datalad's credential system as a whole.
 
 In the opposite direction - making Git aware of datalad's credentials, there's no special casing, though.
-Datalad comes with a `git-credential-datalad` executable.
+DataLad comes with a `git-credential-datalad` executable.
 Whenever Git is configured to use it by setting `credential.helper=datalad`, it will be able to query datalad's credential system for a provider matching the URL in question and retrieve the referenced by this provider credentials.
 This helper can also store a new provider+credentials when asked to do so by Git.
 It can do this interactively, asking a user to confirm/change that config or - if `credential.helper='datalad --non-interactive'` - try to non-interactively store with its defaults.

--- a/docs/source/design/file_url_handling.rst
+++ b/docs/source/design/file_url_handling.rst
@@ -11,7 +11,7 @@ File URL handling
 
    This specification describes the current implementation.
 
-Datalad datasets can record URLs for file content access as metadata. This is a
+DataLad datasets can record URLs for file content access as metadata. This is a
 feature provided by git-annex and is available for any annexed file. DataLad
 improves upon the git-annex functionality in two ways:
 

--- a/docs/source/design/python_imports.rst
+++ b/docs/source/design/python_imports.rst
@@ -38,11 +38,11 @@ The following rules apply to any ``import`` statement in the code base:
 
   - 3rd-party packages
 
-  - Datalad core (absolute imports)
+  - DataLad core (absolute imports)
 
-  - Datalad extensions
+  - DataLad extensions
   
-  - Datalad core ("local" relative imports)
+  - DataLad core ("local" relative imports)
   
   Sorting imports can be aided by https://github.com/PyCQA/isort (e.g. ``python -m isort -m3 --fgw 2 --tc <filename>``).
 

--- a/docs/source/design/threaded_runner.rst
+++ b/docs/source/design/threaded_runner.rst
@@ -15,7 +15,7 @@ Threaded runner
 Threads
 =======
 
-Datalad often requires the execution of subprocesses. While subprocesses are executed, datalad, i.e. its main thread, should be able to read data from stdout and stderr of the subprocess as well as write data to stdin of the subprocess. This requires a way to efficiently multiplex reading from stdout and stderr of the subprocess as well as writing to stdin of the subprocess.
+DataLad often requires the execution of subprocesses. While subprocesses are executed, datalad, i.e. its main thread, should be able to read data from stdout and stderr of the subprocess as well as write data to stdin of the subprocess. This requires a way to efficiently multiplex reading from stdout and stderr of the subprocess as well as writing to stdin of the subprocess.
 
 Since non-blocking IO and waiting on multiple sources (poll or select) differs vastly in terms of capabilities and API on different OSs, we decided to use blocking IO and threads to multiplex reading from different sources.
 

--- a/tools/Dockerfile.fullmaster
+++ b/tools/Dockerfile.fullmaster
@@ -22,7 +22,7 @@ RUN rm -f master.zip
 # clean up
 RUN apt-get clean
 
-RUN git config --global user.name "Docker Datalad"
+RUN git config --global user.name "Docker DataLad"
 RUN git config --global user.email "docker-datalad@example.com"
 
 ENTRYPOINT ["datalad"]


### PR DESCRIPTION
I noticed a "Github" in a config file while helping someone with DataLad, and it caused me to twitch enough to fix it and a few other strings I found. ;-)

This is by no means comprehensive, but I did some `grep`ing around and tried to catch all I could find.

I intentionally chose to not fix occurrences in code comments and tests.

- Github -> GitHub
- openfmri -> OpenfMRI
- s3 -> S3
- travis -> Travis CI

This also fixes "Datalad" mis-capitalizations. For this, I did fix all occurrences, to make future `grep`ing easier.
- Datalad -> DataLad


### Changelog
#### 📝 Documentation
- fix capitalization of some service and software names
