### PR TITLE
BF: git_ignore_check do not overload possible value of stdout/err if present

### DIFF
--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -76,8 +76,8 @@ def git_ignore_check(expect_fail,
     try:
         yield None
     except CommandError as e:
-        e.stdout = "".join(stdout_buffer) if stdout_buffer else ""
-        e.stderr = "".join(stderr_buffer) if stderr_buffer else ""
+        e.stdout = "".join(stdout_buffer) if stdout_buffer else (e.stdout or "")
+        e.stderr = "".join(stderr_buffer) if stderr_buffer else (e.stderr or "")
         ignore_exception = _get_git_ignore_exception(e)
         if ignore_exception:
             raise ignore_exception


### PR DESCRIPTION
A little more discussion at https://github.com/datalad/datalad/pull/6930 and initially
identified while working on https://github.com/datalad/datalad/pull/6932 and being
unable to get CommandError.stdout for matching while using call_git (but works
with _call_git using different code path, which does not have this git_ignore_check).

One of the two locations where this function is used has stdout=None, so this
lead to wiping out of e.stdout even if it was present.  I think it was not intentional
but @christian-monch would know better
