### PR TITLE
Reimplement GitRepo.get_submodules_() without get_content_info()

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -1114,12 +1114,14 @@ def quote_config(v):
       To-be-quoted string
     """
     white = (' ', '\t')
+    comment = ('#', ';')
     # backslashes need to be quoted in any case
     v = v.replace('\\', '\\\\')
     # must not have additional unquoted quotes
     v = v.replace('"', '\\"')
-    if v[0] in white or v[-1] in white:
+    if v[0] in white or v[-1] in white or any(c in v for c in comment):
         # quoting the value due to leading/trailing whitespace
+        # or occurrence of comment char
         v = '"{}"'.format(v)
     return v
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -959,6 +959,16 @@ def test_GitRepo_get_submodules(path=None):
          for s in repo.get_submodules(sorted_=True)],
         ["s_abc", "s_xyz"])
 
+    # Limit by path
+    eq_([s["gitmodule_name"]
+         for s in repo.get_submodules(paths=["s_abc"])],
+        ["s_abc"])
+
+    # Limit by non-existing/non-matching path
+    eq_([s["gitmodule_name"]
+         for s in repo.get_submodules(paths=["s_unknown"])],
+        [])
+
 
 @with_tempfile
 def test_get_submodules_parent_on_unborn_branch(path=None):

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -704,7 +704,7 @@ def test_write_config_section(path=None):
     # can we handle a bare repo?
     gr = GitRepo(path, create=True, bare=True)
 
-    obscure = "ds-;&%b5{}'ΔЙקم๗あ.datc"
+    obscure = "ds-; &%b5{}# some % "
     # test cases
     # first 3 args are write_config_section() parameters
     # 4th arg is a list with key/value pairs that should end up in a
@@ -721,16 +721,13 @@ def test_write_config_section(path=None):
         ('short', ' s p a c e ', {"a123": ' space all over '}, [
             ('short. s p a c e .a123', ' space all over '),
         ]),
+        ('submodule', obscure, {
+            'path': obscure,
+            'url': f"./{obscure}"}, [
+            (f"submodule.{obscure}.path", obscure),
+            (f"submodule.{obscure}.url", f"./{obscure}"),
+        ]),
     ]
-    if not on_windows:
-        # on windows our test setup lacks the full unicode fancy
-        testcfg.append(
-            ('submodule', obscure, {
-                'path': obscure,
-                'url': f"./{obscure}"}, [
-                (f"submodule.{obscure}.path", obscure),
-                (f"submodule.{obscure}.url", f"./{obscure}"),
-            ]))
 
     for tc in testcfg:
         # using append mode to provoke potential interference by

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -50,6 +50,7 @@ from datalad.tests.utils_pytest import (
 from datalad.utils import (
     Path,
     get_home_envvars,
+    on_windows,
     swallow_logs,
 )
 
@@ -703,6 +704,7 @@ def test_write_config_section(path=None):
     # can we handle a bare repo?
     gr = GitRepo(path, create=True, bare=True)
 
+    obscure = "ds-;&%b5{}'ΔЙקم๗あ.datc"
     # test cases
     # first 3 args are write_config_section() parameters
     # 4th arg is a list with key/value pairs that should end up in a
@@ -720,6 +722,15 @@ def test_write_config_section(path=None):
             ('short. s p a c e .a123', ' space all over '),
         ]),
     ]
+    if not on_windows:
+        # on windows our test setup lacks the full unicode fancy
+        testcfg.append(
+            ('submodule', obscure, {
+                'path': obscure,
+                'url': f"./{obscure}"}, [
+                (f"submodule.{obscure}.path", obscure),
+                (f"submodule.{obscure}.url", f"./{obscure}"),
+            ]))
 
     for tc in testcfg:
         # using append mode to provoke potential interference by


### PR DESCRIPTION
The previous implementation resulted in a circular dependency after
a check for a Git-version dependent reporting behavior was introduced
with 8ff86134405dcd125e41fe3a2544ebc7454efc32

Moreover, the previous implementation also queried a repository for
all content, merely to discard any record that is not a subdataset.
This could slow a responds dramatically for dataset with few subdatasets
but many files.

This change reimplements `get_submodules_()` with a plain call to
`git ls-files` parameterized with the paths of recorded submodules
taken from `.gitmodules`.

This changes the behavior to be more in-line with `git submodule`
by refusing to report on submodules that are not recorded in
.gitmodules.

Fixes datalad/datalad#6940
Fixes datalad/datalad#6941
Fixes datalad/datalad#6943

This PR goes against `master`, because it changes behavior, even if only in corner-cases. The fix for datalad/datalad#6941 is also cherry-picked into a PR against `maint` https://github.com/datalad/datalad/pull/6944

The speed-up is substantial for datasets with many files and at least one subdataset. I have a real-world test cased with a dataset with 160k files and 2 subdatasets showing a speed-up of 350x.

See here for another real-world performance change estimate https://github.com/datalad/datalad-next/pull/92#issuecomment-1214308010