### PR TITLE
Acknowledge git-config comment chars

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -1114,12 +1114,14 @@ def quote_config(v):
       To-be-quoted string
     """
     white = (' ', '\t')
+    comment = ('#', ';')
     # backslashes need to be quoted in any case
     v = v.replace('\\', '\\\\')
     # must not have additional unquoted quotes
     v = v.replace('"', '\\"')
-    if v[0] in white or v[-1] in white:
+    if v[0] in white or v[-1] in white or any(c in v for c in comment):
         # quoting the value due to leading/trailing whitespace
+        # or occurrence of comment char
         v = '"{}"'.format(v)
     return v
 

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -704,7 +704,7 @@ def test_write_config_section(path=None):
     # can we handle a bare repo?
     gr = GitRepo(path, create=True, bare=True)
 
-    obscure = "ds-;&%b5{}'ΔЙקم๗あ.datc"
+    obscure = "ds-; &%b5{}# some % "
     # test cases
     # first 3 args are write_config_section() parameters
     # 4th arg is a list with key/value pairs that should end up in a
@@ -721,16 +721,13 @@ def test_write_config_section(path=None):
         ('short', ' s p a c e ', {"a123": ' space all over '}, [
             ('short. s p a c e .a123', ' space all over '),
         ]),
+        ('submodule', obscure, {
+            'path': obscure,
+            'url': f"./{obscure}"}, [
+            (f"submodule.{obscure}.path", obscure),
+            (f"submodule.{obscure}.url", f"./{obscure}"),
+        ]),
     ]
-    if not on_windows:
-        # on windows our test setup lacks the full unicode fancy
-        testcfg.append(
-            ('submodule', obscure, {
-                'path': obscure,
-                'url': f"./{obscure}"}, [
-                (f"submodule.{obscure}.path", obscure),
-                (f"submodule.{obscure}.url", f"./{obscure}"),
-            ]))
 
     for tc in testcfg:
         # using append mode to provoke potential interference by

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -50,6 +50,7 @@ from datalad.tests.utils_pytest import (
 from datalad.utils import (
     Path,
     get_home_envvars,
+    on_windows,
     swallow_logs,
 )
 
@@ -703,6 +704,7 @@ def test_write_config_section(path=None):
     # can we handle a bare repo?
     gr = GitRepo(path, create=True, bare=True)
 
+    obscure = "ds-;&%b5{}'ΔЙקم๗あ.datc"
     # test cases
     # first 3 args are write_config_section() parameters
     # 4th arg is a list with key/value pairs that should end up in a
@@ -720,6 +722,15 @@ def test_write_config_section(path=None):
             ('short. s p a c e .a123', ' space all over '),
         ]),
     ]
+    if not on_windows:
+        # on windows our test setup lacks the full unicode fancy
+        testcfg.append(
+            ('submodule', obscure, {
+                'path': obscure,
+                'url': f"./{obscure}"}, [
+                (f"submodule.{obscure}.path", obscure),
+                (f"submodule.{obscure}.url", f"./{obscure}"),
+            ]))
 
     for tc in testcfg:
         # using append mode to provoke potential interference by

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -50,7 +50,6 @@ from datalad.tests.utils_pytest import (
 from datalad.utils import (
     Path,
     get_home_envvars,
-    on_windows,
     swallow_logs,
 )
 


### PR DESCRIPTION
Previously we ignored them in values as mandatory reasons for quoting.
This change expands the `quote_config()` helper to perform this
additional test.

Fixes datalad/datalad#6943