### PR TITLE
BF: Remove duplicate key in result record

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -356,7 +356,6 @@ class CreateSiblingRia(Interface):
                         sname, dpath),
                     type='sibling',
                     name=sname,
-                    ds=ds,
                     **res_kwargs,
                 )
                 failed = True

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -155,6 +155,11 @@ def _test_create_store(host, base_path=None, ds_path=None, clone_path=None):
                             status='ok',
                             action='get',
                             path=op.join(installed_ds.path, 'ds', 'file1.txt'))
+    # repeat the call to ensure it doesn't crash (see #6950)
+    res = ds.create_sibling_ria("ria+ssh://test-store:", "datastore", on_failure='ignore')
+    assert_result_count(res, 1, status='error', action='create-sibling-ria', message=(
+                        "a sibling %r is already configured in dataset %r",
+                        'datastore', ds.path))
 
     # now, again but recursive.
     res = ds.create_sibling_ria("ria+ssh://test-store:", "datastore",


### PR DESCRIPTION
Should be a fix and testcase for #6950.

### Changelog
#### 🐛 Bug Fixes
-  When ``create-sibling-ria`` was invoked with a sibling name of a pre-existing sibling, a duplicate key in the result record caused a crashed. This was fixed. 
