### PR TITLE
BF(TST): prevent auto-upgrade of "remote" test sibling, do not use local path for URL

### DIFF
--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -277,12 +277,13 @@ def test_target_ssh_simple(origin=None, src_path=None, target_rootpath=None):
         # could use local path, but then it would not use "remote" git-annex
         # and thus potentially lead to incongruent result. So make URLs a bit
         # different by adding trailing /. to regular target_url
+        target_url = "ssh://datalad-test" + target_path + "/."
         cpkwargs = dict(
             dataset=source,
             name="local_target",
             sshurl="ssh://datalad-test",
             target_dir=target_path,
-            target_url="ssh://datalad-test" + target_path + "/.",
+            target_url=target_url,
             target_pushurl="ssh://datalad-test" + target_path,
             ui=have_webui(),
         )
@@ -295,9 +296,9 @@ def test_target_ssh_simple(origin=None, src_path=None, target_rootpath=None):
         if src_is_annex and target_description:
             target_description = AnnexRepo(target_path,
                                            create=False).get_description()
-            eq_(target_description, target_path)
+            eq_(target_description, target_url)
 
-        eq_("ssh://datalad-test" + target_path + "/.",
+        eq_(target_url,
             source.repo.get_remote_url("local_target"))
         eq_("ssh://datalad-test" + target_path,
             source.repo.get_remote_url("local_target", push=True))


### PR DESCRIPTION
Our docker image for testing of interactions over ssh still has git-annex  7.20190819+git2-g908476a9b-1~ndall+1
and that is great so we can ensure that datalad works well even with older versions  (note - current minimal
supported is 8.20200309 but upgrade to that one would not matter in this case).

We use create_sibling to create remote through ssh but on the path which is also available locally.
And then instead of always interacting with that repository remotely, we had direct interactions with it
using AnnexRepo or creating a sibling not over ssh but pointing directly to that path.  That would have lead
local git-annex possibly to upgrade it to later version of git annex repo (10 ATM) whenever remote (docker)
instance of git-annex would not know that version. And with annex version 10, a new command was added
"filter-process" which it records within .git/config for that annex.

So if we ever upgrade it by acessing a local path, "git push" fails since then
it runs git-annex filter-process and that fails in turn, and we do not even see
that error.  Citing it here in full FTR from https://github.com/datalad/datalad/issues/6901#issuecomment-1218512898

	(git-annex)lena:~/.tmp/datalad_temp_test_target_ssh_simplerf0k0b97[dl-test-branch]git
	$> SSH_AGENT_PID= SSH_AUTH_SOCK= git push local_target dl-test-branch
	Enumerating objects: 9, done.
	Counting objects: 100% (9/9), done.
	Delta compression using up to 12 threads
	Compressing objects: 100% (9/9), done.
	Writing objects: 100% (9/9), 798 bytes | 798.00 KiB/s, done.
	Total 9 (delta 2), reused 0 (delta 0), pack-reused 0
	Invalid argument `filter-process'

	Usage: git-annex COMMAND
	  git-annex - manage files with git, without checking their contents in

	  Commonly used commands:

	  add             PATH ...                  add files to annex
	...
	fatal: the remote end hung up unexpectedly
	To ssh://datalad-test/home/yoh/.tmp/datalad_temp_test_target_ssh_simplexx85c2vs/basic
	 ! [remote rejected] dl-test-branch -> dl-test-branch (Could not update working tree to new HEAD)
	error: failed to push some refs to 'ssh://datalad-test/home/yoh/.tmp/datalad_temp_test_target_ssh_simplexx85c2vs/basic'

where in the tests we only see that "Could not update" making it
difficult to pin point the problem.

In this commit I prevent auto-upgrade on that repo, and if then local operation
fails -- I just skip direct interaction with such AnnexRepo. And I also
replaced "replace"ing  of the repo using local path, and instead using "custom"
ssh url so we could still compare that all urls are assigned as expected.

Closes #6901

PS I added `release` label . Auto-releasing would fail as previous one failed due to already too long of a changelog, uff, so I will release it manually after this PR is merged. It is needed to bring our CI in datalad/git-annex back to green.
