### PR TITLE
Forbid drop operation from symlink'ed annex (e.g. due to being cloned with --reckless=ephemeral) to prevent data-loss

### DIFF
--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -727,6 +727,9 @@ def _kill_dataset(ds):
 def _drop_allkeys(ds, repo, force=False, jobs=None):
     """
     """
+    assert not (repo.dot_git / 'annex').is_symlink(), \
+        "Dropping from a symlinked annex is unsupported to prevent data-loss"
+
     cmd = ['drop', '--all']
     if force:
         cmd.append('--force')
@@ -757,6 +760,8 @@ def _drop_files(ds, repo, paths, force=False, jobs=None):
     ------
     dict
     """
+    assert not (repo.dot_git / 'annex').is_symlink(), \
+        "Dropping from a symlinked annex is unsupported to prevent data-loss"
     cmd = ['drop']
     if force:
         cmd.append('--force')


### PR DESCRIPTION
This is a blunt, but effective measure to prevent a data security issue,
where dropping annex keys from 'here' is actually also dropping them
from 'origin' -- thereby potentially deleting the last existing copy.

Even once a more elegant error anticipation and handling is implemented,
it should be kept for safety reasons.

Closes datalad/datalad#6948

PS: I will be working on a more elegant wrapping of this fix. But given the severity, this should be merged and released ASAP. https://github.com/datalad/datalad/issues/4750 continues to remain as a reminder.

I came to the conclusion that it might be best to remove the entire feature. I filed https://github.com/datalad/datalad/issues/6961

Spellchecker errors are addressed in https://github.com/datalad/datalad/pull/6956