### PR TITLE
ENH+BF: get_parent_paths - make / into sep option and consistently use "/" as path separator

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2720,22 +2720,23 @@ class GitRepo(CoreGitRepo):
             # any incoming path has to be relative already, so we can simply
             # convert unconditionally
             # note: will be list-ified below
-            paths = map(ut.PurePosixPath,  paths)
+            posix_paths = [ut.PurePath(p).as_posix() for p in paths]
         elif paths is not None:
             return info
+        else:
+            posix_paths = None
 
-        path_strs = list(map(str, paths)) if paths else None
-        if path_strs and (not ref or external_versions["cmd:git"] >= "2.29.0"):
+        if posix_paths and (not ref or external_versions["cmd:git"] >= "2.29.0"):
             # If a path points within a submodule, we need to map it to the
             # containing submodule before feeding it to ls-files or ls-tree.
             #
             # Before Git 2.29.0, ls-tree and ls-files differed in how they
             # reported paths within submodules: ls-files provided no output,
             # and ls-tree listed the submodule. Now they both return no output.
-            submodules = [str(ut.PurePosixPath(s["path"].relative_to(self.pathobj)))
+            submodules = [s["path"].relative_to(self.pathobj).as_posix()
                           for s in self.get_submodules_()]
             # `paths` get normalized into PurePosixPath above, submodules are POSIX as well
-            path_strs = get_parent_paths(path_strs, submodules)
+            posix_paths = get_parent_paths(posix_paths, submodules)
 
         # this will not work in direct mode, but everything else should be
         # just fine
@@ -2769,7 +2770,7 @@ class GitRepo(CoreGitRepo):
         try:
             stdout = self.call_git(
                 cmd,
-                files=path_strs,
+                files=posix_paths,
                 expect_fail=True,
                 read_only=True)
         except CommandError as exc:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2732,7 +2732,7 @@ class GitRepo(CoreGitRepo):
             # Before Git 2.29.0, ls-tree and ls-files differed in how they
             # reported paths within submodules: ls-files provided no output,
             # and ls-tree listed the submodule. Now they both return no output.
-            submodules = [str(s["path"].relative_to(self.pathobj))
+            submodules = [str(ut.PurePosixPath(s["path"].relative_to(self.pathobj)))
                           for s in self.get_submodules_()]
             # `paths` get normalized into PurePosixPath above, submodules are POSIX as well
             path_strs = get_parent_paths(path_strs, submodules)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2734,6 +2734,7 @@ class GitRepo(CoreGitRepo):
             # and ls-tree listed the submodule. Now they both return no output.
             submodules = [str(s["path"].relative_to(self.pathobj))
                           for s in self.get_submodules_()]
+            # `paths` get normalized into PurePosixPath above, submodules are POSIX as well
             path_strs = get_parent_paths(path_strs, submodules)
 
         # this will not work in direct mode, but everything else should be


### PR DESCRIPTION
Code review of this function came up while reviewing the
https://github.com/datalad/datalad/pull/6942 and where get_parent_paths,
which was pretty much "avoided" while resolving infinite recursion of
`get_submodules_ -> get_content_info -> get_submodules_`, was re-introduced
specifically within get_submodules_ .

BF: use consistently "sep" instead of / for check within the loop, and then
os.sep to check if points to up/down folders.

ENH:

- sep became an option so we could use it also with os.sep if so desired
  on paths which are not POSIXed.  By default it would remain "POSIX"
  (although checks were not checking for the POSIX endings before).

- The test became parametric to test for various scenarios of using \ vs /
  vs "the default" (/ - POSIX).
