### PR TITLE
BF(TEMP): use git-annex from neurodebian -devel to gain fix for bug detected with datalad-crawler

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -23,6 +23,7 @@ jobs:
       shell: bash
       run: |
         bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+        sudo sed -i-devel.list -e 's,/debian ,/debian-devel ,g' /etc/apt/sources.list.d/neurodebian.sources.list
         sudo apt-get update -qq
         sudo apt-get install eatmydata
         sudo eatmydata apt-get install git-annex-standalone


### PR DESCRIPTION
the issue is https://git-annex.branchable.com/bugs/regression__58___fails_to___39__add_.__39___if_file_was_renamed/
and should be addressed in 10.20220724+git144-gc25ade4d9-1~ndall+1, which likely would not
be released for a bit more since would trigger upgrades to v9.  To make CI green again, built
curent snapshot and uploaed to -devel of neurodebian

[skip travis]
[skip appveyor]
