### PR TITLE
Faciliate backports to Debian bullseye

### DIFF
--- a/debian/patches/bullseye-dsc-patch
+++ b/debian/patches/bullseye-dsc-patch
@@ -1,0 +1,13 @@
+diff --git a/debian/control b/debian/control
+index d88d575da..b94e31430 100644
+--- a/debian/control
++++ b/debian/control
+@@ -34,7 +33,7 @@ Build-Depends: debhelper (>= 11),
+                python3-pytest,
+                python3-packaging,
+                python3-pil,
+-               python3-platformdirs,
++               python3-appdirs,
+                python3-pyperclip,
+                python3-requests,
+                python3-secretstorage,

--- a/debian/patches/revert_platformdirs
+++ b/debian/patches/revert_platformdirs
@@ -1,0 +1,130 @@
+diff --git a/datalad/cli/helpers.py b/datalad/cli/helpers.py
+index b657b6558..8d6a227f6 100644
+--- a/datalad/cli/helpers.py
++++ b/datalad/cli/helpers.py
+@@ -25,7 +25,7 @@ from datalad.support.exceptions import CapturedException
+ from datalad.ui.utils import get_console_width
+ from datalad.utils import is_interactive
+ 
+-from platformdirs import AppDirs
++from appdirs import AppDirs
+ 
+ dirs = AppDirs("datalad", "datalad.org")
+ 
+diff --git a/datalad/downloaders/tests/test_providers.py b/datalad/downloaders/tests/test_providers.py
+index 36f8a692f..57c4706c5 100644
+--- a/datalad/downloaders/tests/test_providers.py
++++ b/datalad/downloaders/tests/test_providers.py
+@@ -122,7 +122,7 @@ url_re = https?://crcns\\.org/.*
+ authentication_type = none
+ """}},
+    '.git': { "HEAD" : ""}})
+-@patch.multiple("platformdirs.AppDirs", site_config_dir=None, user_config_dir=None)
++@patch.multiple("appdirs.AppDirs", site_config_dir=None, user_config_dir=None)
+ def test_Providers_from_config__files(sysdir=None, userdir=None, dsdir=None):
+     """Test configuration file precedence
+ 
+@@ -146,14 +146,14 @@ def test_Providers_from_config__files(sysdir=None, userdir=None, dsdir=None):
+ 
+         # Test that the system defaults take precedence over the dataset
+         # defaults (we're still within the dsdir)
+-        with patch.multiple("platformdirs.AppDirs", site_config_dir=sysdir, user_config_dir=None):
++        with patch.multiple("appdirs.AppDirs", site_config_dir=sysdir, user_config_dir=None):
+             providers = Providers.from_config_files(reload=True)
+             provider = providers.get_provider('https://crcns.org/data....')
+             assert_equal(provider.name, 'syscrcns')
+ 
+         # Test that the user defaults take precedence over the system
+         # defaults
+-        with patch.multiple("platformdirs.AppDirs", site_config_dir=sysdir, user_config_dir=userdir):
++        with patch.multiple("appdirs.AppDirs", site_config_dir=sysdir, user_config_dir=userdir):
+             providers = Providers.from_config_files(reload=True)
+             provider = providers.get_provider('https://crcns.org/data....')
+             assert_equal(provider.name, 'usercrcns')
+@@ -161,7 +161,7 @@ def test_Providers_from_config__files(sysdir=None, userdir=None, dsdir=None):
+ 
+ @with_tempfile(mkdir=True)
+ def test_providers_enter_new(path=None):
+-    with patch.multiple("platformdirs.AppDirs", site_config_dir=None,
++    with patch.multiple("appdirs.AppDirs", site_config_dir=None,
+                         user_config_dir=path):
+         providers_dir = op.join(path, "providers")
+         providers = Providers.from_config_files(reload=True)
+diff --git a/datalad/interface/common_cfg.py b/datalad/interface/common_cfg.py
+index 5ceb6fb53..b5b8e415e 100644
+--- a/datalad/interface/common_cfg.py
++++ b/datalad/interface/common_cfg.py
+@@ -18,7 +18,7 @@ from os import environ
+ from os.path import expanduser
+ from os.path import join as opj
+ 
+-from platformdirs import AppDirs
++from appdirs import AppDirs
+ 
+ from datalad.support.constraints import (
+     EnsureBool,
+diff --git a/datalad/local/run_procedure.py b/datalad/local/run_procedure.py
+index 4d195b1de..8732fc851 100644
+--- a/datalad/local/run_procedure.py
++++ b/datalad/local/run_procedure.py
+@@ -219,10 +219,10 @@ class RunProcedure(Interface):
+     Directories identified by the configuration settings
+ 
+     - 'datalad.locations.user-procedures' (determined by
+-      platformdirs.user_config_dir; defaults to '$HOME/.config/datalad/procedures'
++      appdirs.user_config_dir; defaults to '$HOME/.config/datalad/procedures'
+       on GNU/Linux systems)
+     - 'datalad.locations.system-procedures' (determined by
+-      platformdirs.site_config_dir; defaults to '/etc/xdg/datalad/procedures' on
++      appdirs.site_config_dir; defaults to '/etc/xdg/datalad/procedures' on
+       GNU/Linux systems)
+     - 'datalad.locations.dataset-procedures'
+ 
+diff --git a/datalad/support/cookies.py b/datalad/support/cookies.py
+index add967d08..cb40e88b0 100644
+--- a/datalad/support/cookies.py
++++ b/datalad/support/cookies.py
+@@ -11,7 +11,7 @@
+ import atexit
+ import logging
+ import shelve
+-import platformdirs
++import appdirs
+ import os.path
+ 
+ from .network import get_tld
+@@ -46,7 +46,7 @@ class CookiesDB(object):
+             filename = self._filename
+             cookies_dir = os.path.dirname(filename)
+         else:
+-            cookies_dir = os.path.join(platformdirs.user_config_dir(), 'datalad')  # FIXME prolly shouldn't hardcode 'datalad'
++            cookies_dir = os.path.join(appdirs.user_config_dir(), 'datalad')  # FIXME prolly shouldn't hardcode 'datalad'
+             filename = os.path.join(cookies_dir, 'cookies')
+ 
+         # TODO: guarantee restricted permissions
+diff --git a/datalad/support/external_versions.py b/datalad/support/external_versions.py
+index 03baeaefd..ab5e0dc3f 100644
+--- a/datalad/support/external_versions.py
++++ b/datalad/support/external_versions.py
+@@ -182,7 +182,7 @@ class ExternalVersions(object):
+     }
+     _INTERESTING = (
+         'annexremote',
+-        'platformdirs',
++        'appdirs',
+         'boto',
+         'exifread',
+         'git',
+diff --git a/setup.py b/setup.py
+index d736ff577..d9d74cbb6 100755
+--- a/setup.py
++++ b/setup.py
+@@ -25,7 +25,7 @@ from _datalad_build_support.setup import (
+ 
+ requires = {
+     'core': [
+-        'platformdirs',
++        'appdirs',
+         'chardet>=3.0.4, <5.0.0',      # rarely used but small/omnipresent
+         'colorama; platform_system=="Windows"',
+         'distro; python_version >= "3.8"',

--- a/debian/patches/series-bullseye
+++ b/debian/patches/series-bullseye
@@ -1,0 +1,1 @@
+revert_platformdirs


### PR DESCRIPTION
The `platformdirs` dependency (since 0.16.0) is a pain in the butt to backport to the present Debian stable release. Rather backporting chains of 2nd-level dependencies, this change reverts that move, and brings back `appdirs` on this platform.

This patch setup assume the good 'old `backport-dsc` tool and can be applied with

`backport-dsc -d bullseye -s dl11 datalad_0.17.1-2.dsc`

Where `datalad_0.17.1-2.dsc` is generated with `gbp`

```
gbp buildpackage --git-builder="dpkg-source -b ." --git-postbuild=
```

or whatever floats your boat.

The recorded (and included) run-record captures how the actual patch can be regenerated for future releases of DataLad (rather than having to fiddle with the diff directly).

Otherwise this change is entirely orthogonal to the rest of the Debian packing.