### PR TITLE
Reimplement GitRepo.get_submodules_() without get_content_info() and avoiding O(N^2) performance hit

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2369,11 +2369,14 @@ class GitRepo(CoreGitRepo):
             return
 
         posix_mod_paths = [m.relative_to(self.pathobj).as_posix() for m in modinfo]
-        if paths:
+        if paths is not None:
             # constrain the report by the given paths, make sure all paths are POSIX
             posix_mod_paths = get_parent_paths(
                 [ut.PurePath(p).as_posix() for p in paths],
                 posix_mod_paths, only_with_parents=True)
+            if not posix_mod_paths:
+                # if no paths "survived", nothing to report
+                return
         for r in self.call_git_items_(
             ['ls-files', '--stage', '-z'],
             sep='\0',

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -959,6 +959,16 @@ def test_GitRepo_get_submodules(path=None):
          for s in repo.get_submodules(sorted_=True)],
         ["s_abc", "s_xyz"])
 
+    # Limit by path
+    eq_([s["gitmodule_name"]
+         for s in repo.get_submodules(paths=["s_abc"])],
+        ["s_abc"])
+
+    # Limit by non-existing/non-matching path
+    eq_([s["gitmodule_name"]
+         for s in repo.get_submodules(paths=["s_unknown"])],
+        [])
+
 
 @with_tempfile
 def test_get_submodules_parent_on_unborn_branch(path=None):


### PR DESCRIPTION
This PR is based on work by @mih in https://github.com/datalad/datalad/issues/6941 so it 

Fixes #6940
Fixes #6941

but I took only 1 commit relevant to the stated in the title work, others were already merged in their own #6944 .  While working on the solution and adding a unittest I realized (well -- added test failed ;-) ) that we still have inconsistent handling of the invocation of git commands whenever we DO provide `paths` but the list is empty as if eg "nothing matched".  Awhile back we had already a fix introduced at higher level of get_content_info in https://github.com/datalad/datalad/commit/ec0243c92822f36ada5e87557eb9f5f53929c9ff . In this PR (last commit ATM) I am attempting to fix it in the core -- at the point of invocation of any git command via `_generator_call_git` and also fixing some conditions I did encounter in the code where IMHO it should be `if paths is not None` instead of just `if paths`.

I thought that #6941 was against `maint` and only now realized that it was against `master`.  Indeed the initial change (since code worked ok, just performance was bad) worth `master` and the fix for `paths` can also have "far going manifestations", so I would be ok to rebase it against `master`. But originally submitting as was "planned" against `maint` to see how CI reacts to those "core fixes"