### PR TITLE
BF: make logic more consistent for files=[] argument (which is False but not None)

### DIFF
--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -330,6 +330,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
                 files,
                 protocol=GeneratorStdOutErrCapture,
                 env=env)
+        elif files is not None:
+            # it was an empty structure, so we did provide paths but "empty",
+            # then we must not return anything. For more reasoning see
+            # ec0243c92822f36ada5e87557eb9f5f53929c9ff which added similar code pattern
+            # within get_content_info
+            return
         else:
             generator = self._git_runner.run(
                 cmd,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3370,7 +3370,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             cmd = ['find'] + cmd
             # stringify any pathobjs
-            if paths is not None:
+            if paths:  # we have early exit above in case of [] and not None
                 files = [str(p) for p in paths]
             else:
                 cmd += ['--include', '*']

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3370,7 +3370,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             cmd = ['find'] + cmd
             # stringify any pathobjs
-            if paths:
+            if paths is not None:
                 files = [str(p) for p in paths]
             else:
                 cmd += ['--include', '*']

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2714,7 +2714,7 @@ class GitRepo(CoreGitRepo):
         # TODO limit by file type to replace code in subdatasets command
         info = OrderedDict()
 
-        if paths:
+        if paths:  # is not None separate after
             # path matching will happen against what Git reports
             # and Git always reports POSIX paths
             # any incoming path has to be relative already, so we can simply
@@ -2873,7 +2873,7 @@ class GitRepo(CoreGitRepo):
             Can be 'added', 'untracked', 'clean', 'deleted', 'modified'.
         """
         lgr.debug('Query status of %r for %s paths',
-                  self, len(paths) if paths else 'all')
+                  self, len(paths) if paths is not None else 'all')
         return self.diffstatus(
             fr='HEAD' if self.get_hexsha() else None,
             to=None,
@@ -2944,7 +2944,7 @@ class GitRepo(CoreGitRepo):
         if _cache is None:
             _cache = {}
 
-        if paths:
+        if paths is not None:
             # at this point we must normalize paths to the form that
             # Git would report them, to easy matching later on
             paths = map(ut.Path, paths)
@@ -2982,7 +2982,7 @@ class GitRepo(CoreGitRepo):
                         # included with `-m` alone
                         ['ls-files', '-z', '-m', '-d'],
                         # low-level code cannot handle pathobjs
-                        files=[str(p) for p in paths] if paths else None,
+                        files=[str(p) for p in paths] if paths is not None else None,
                         sep='\0',
                         read_only=True)
                     if p)


### PR DESCRIPTION
Similar problem was resolved previously at higher level in
http://github.com/datalad/datalad/commit/ec0243c92822f36ada5e87557eb9f5f53929c9ff
for get_content_info.  But IMHO it could and should be resolved at the
lowest/common point of invocation, that is why I added it to
_generator_call_git which is underlying most (if not all, hard to tell now ;) )
git invocations.

I also fixed a few other invocations where it was pure `if files` or `if paths`.

This commit was initially proposed as a part of the #6974 but there it failed and later I realized that approach I proposed in that PR for `get_modules_` was flawed, so this PR is dedicated to only this change (although at once across different commands/levels). Want to see if we could distill it independently.