### PR TITLE
Add support for annex add --batch and use it if more than a single file (and not directories) is provided

### DIFF
--- a/changelog.d/pr-6977.md
+++ b/changelog.d/pr-6977.md
@@ -1,0 +1,11 @@
+### 🏎 Performance
+
+- `AnnexRepo.add_()` now uses `git annex add --batch` when adding more than a
+  single file, avoiding the per-file process startup overhead that especially
+  affected larger `datalad save` invocations. Falls back to the non-batched
+  invocation when any of the given paths is a directory, since
+  `git annex add --batch` does not (yet) descend into them
+  (see [git-annex todo](https://git-annex.branchable.com/todo/make_add_--batch_add_directories_content/)).
+  Fixes [#5721](https://github.com/datalad/datalad/issues/5721) via
+  [PR #6977](https://github.com/datalad/datalad/pull/6977)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1795,23 +1795,29 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             if backend:
                 options.extend(('--backend', backend))
-            batch = None  # TODO
-            if batch or (batch is None and len(files) > 1):
-                # TODO: interfacing total_nbytes etc
-                # Note: took the same 166s here and 169s on master for AnnexRepo only of
-                # python -m nose -s -v datalad/support/tests/test_annexrepo.py:test_files_split
-                yield from self._batched.get(
-                    'add',
-                    json=True,
-                    annex_options=self._get_annex_options(jobs),
-                    path=self.path
-                ).yield_(files)
-            else:
-                yield from self._call_annex_records(
-                        ['add'] + options,
-                        files=files,
-                        jobs=jobs,
-                        total_nbytes=sum(expected_additions.values()))
+            yield from self._maybe_batched_add(
+                files, options, jobs, expected_additions, batch=None)
+
+    def _maybe_batched_add(self, files, options, jobs, expected_additions, batch=None):
+        # Common code to be reused across existing implementations of "annex add" invocation
+        if batch or (batch is None and len(files) > 1):
+            # TODO: interfacing total_nbytes etc
+            # Note: took the same-ish 144s here and 169s on master for AnnexRepo only of
+            # python -m nose -s -v datalad/support/tests/test_annexrepo.py:test_files_split
+            yield from self._batched.get(
+                'add',
+                json=True,
+                annex_options=options + self._get_annex_options(jobs),
+                path=self.path
+            ).yield_(files)
+        else:
+            yield from self._call_annex_records(
+                    ['add'] + options,
+                    files=files,
+                    jobs=jobs,
+                    total_nbytes=sum(expected_additions.values())
+                    if expected_additions else None
+            )
 
     @normalize_paths
     def get_file_key(self, files, batch=None):
@@ -3577,13 +3583,13 @@ class AnnexRepo(GitRepo, RepoInterface):
         if git is True:
             yield from GitRepo._save_add(self, files, git_opts=git_opts)
         else:
-            for r in self._call_annex_records(
-                    ['add'] + options,
-                    files=list(files.keys()),
-                    # TODO
+            for r in self._maybe_batched_add(
+                    list(files.keys()),
+                    options,
+                    # TODO: was marked TODO -- keeping a TODO
                     jobs=None,
-                    total_nbytes=sum(expected_additions.values())
-                    if expected_additions else None):
+                    expected_additions=expected_additions
+            ):
                 yield get_status_dict(
                     action=r.get('command', 'add'),
                     refds=self.pathobj,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -951,23 +951,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         cmd.append('annex')
         cmd += args
 
-        if lgr.getEffectiveLevel() <= 8:
-            cmd.append('--debug')
-
-        if self._annex_common_options:
-            cmd += self._annex_common_options
-
-        if jobs == 'auto':
-            # Limit to # of CPUs (but at least 3 to start with)
-            # and also an additional config constraint (by default 1
-            # due to https://github.com/datalad/datalad/issues/4404)
-            jobs = self._n_auto_jobs or min(
-                self.config.obtain('datalad.runtime.max-annex-jobs'),
-                max(3, cpu_count()))
-            # cache result to avoid repeated calls to cpu_count()
-            self._n_auto_jobs = jobs
-        if jobs and jobs != 1:
-            cmd.append('-J%d' % jobs)
+        cmd += self._get_annex_options(jobs)
 
         runner = self._git_runner
         env = None
@@ -1034,6 +1018,27 @@ class AnnexRepo(GitRepo, RepoInterface):
 
             # we don't know how to handle this, just pass it on
             raise
+
+    def _get_annex_options(self, jobs):
+        """Common logic to populate annex call options across our spectrum of annex invocations
+        """
+        cmd = []
+        if lgr.getEffectiveLevel() <= 8:
+            cmd.append('--debug')
+        if self._annex_common_options:
+            cmd += self._annex_common_options
+        if jobs == 'auto':
+            # Limit to # of CPUs (but at least 3 to start with)
+            # and also an additional config constraint (by default 1
+            # due to https://github.com/datalad/datalad/issues/4404)
+            jobs = self._n_auto_jobs or min(
+                self.config.obtain('datalad.runtime.max-annex-jobs'),
+                max(3, cpu_count()))
+            # cache result to avoid repeated calls to cpu_count()
+            self._n_auto_jobs = jobs
+        if jobs and jobs != 1:
+            cmd.append('-J%d' % jobs)
+        return cmd
 
     def _call_annex_records(self, args, files=None, jobs=None,
                             git_options=None,
@@ -1706,7 +1711,6 @@ class AnnexRepo(GitRepo, RepoInterface):
         -------
         list of dict or dict
         """
-
         return list(self.add_(
             files, git=git, backend=backend, options=options, jobs=jobs,
             git_options=git_options, annex_options=annex_options, update=update
@@ -1791,12 +1795,23 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             if backend:
                 options.extend(('--backend', backend))
-            for r in self._call_annex_records(
-                    ['add'] + options,
-                    files=files,
-                    jobs=jobs,
-                    total_nbytes=sum(expected_additions.values())):
-                yield r
+            batch = None  # TODO
+            if batch or (batch is None and len(files) > 1):
+                # TODO: interfacing total_nbytes etc
+                # Note: took the same 166s here and 169s on master for AnnexRepo only of
+                # python -m nose -s -v datalad/support/tests/test_annexrepo.py:test_files_split
+                yield from self._batched.get(
+                    'add',
+                    json=True,
+                    annex_options=self._get_annex_options(jobs),
+                    path=self.path
+                ).yield_(files)
+            else:
+                yield from self._call_annex_records(
+                        ['add'] + options,
+                        files=files,
+                        jobs=jobs,
+                        total_nbytes=sum(expected_additions.values()))
 
     @normalize_paths
     def get_file_key(self, files, batch=None):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1711,6 +1711,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         -------
         list of dict or dict
         """
+
         return list(self.add_(
             files, git=git, backend=backend, options=options, jobs=jobs,
             git_options=git_options, annex_options=annex_options, update=update
@@ -1800,16 +1801,38 @@ class AnnexRepo(GitRepo, RepoInterface):
 
     def _maybe_batched_add(self, files, options, jobs, expected_additions, batch=None):
         # Common code to be reused across existing implementations of "annex add" invocation
-        if batch or (batch is None and len(files) > 1):
-            # TODO: interfacing total_nbytes etc
-            # Note: took the same-ish 144s here and 169s on master for AnnexRepo only of
-            # python -m nose -s -v datalad/support/tests/test_annexrepo.py:test_files_split
-            yield from self._batched.get(
+        do_batch = batch or (batch is None and len(files) > 1)
+        if do_batch:
+            # git-annex add --batch does not (yet) descend into directories, see
+            # https://git-annex.branchable.com/todo/make_add_--batch_add_directories_content/
+            # Fall back to non-batched invocation if any path is a directory.
+            # Higher-level interfaces typically pass individual files, so this
+            # check is mostly a safety net for direct low-level callers.
+            do_batch = not any(isdir(opj(self.path, f)) for f in files)
+            if batch and not do_batch:
+                lgr.debug("Not using git annex --batch since some of the given paths are "
+                          "directories and git-annex add --batch does not support that yet")
+
+        if do_batch:
+            # TODO: interfacing total_nbytes for a progress bar with batch mode
+            # NB: `git annex add --batch` buffers annex-branch state internally
+            # and only fully commits it on process exit. Callers that query
+            # annex state (e.g. get_annexed_files -> git annex find) right after
+            # a batched add would otherwise see stale info. So we do NOT retain
+            # the process across _maybe_batched_add calls: we spawn one, feed
+            # all files, and close it — still avoiding per-file process startup
+            # within the call, without introducing cross-call state leakage.
+            batched_add = BatchedAnnex(
                 'add',
                 json=True,
                 annex_options=options + self._get_annex_options(jobs),
-                path=self.path
-            ).yield_(files)
+                path=self.path,
+            )
+            try:
+                for f in files:
+                    yield batched_add.proc1(f)
+            finally:
+                batched_add.close()
         else:
             yield from self._call_annex_records(
                     ['add'] + options,


### PR DESCRIPTION
Resurrects #5722 which could not be reopened since I force-pushed.

- Closes #5721.

## Summary

`AnnexRepo.add_()` now uses `git annex add --batch` when adding more than one file,
avoiding per-file `git annex add` process startup — which was previously the main
overhead on large `datalad save` invocations. Falls back to the non-batched
invocation when any of the paths is a directory, since `git annex add --batch`
does not (yet) descend into directories
(see [git-annex todo](https://git-annex.branchable.com/todo/make_add_--batch_add_directories_content/)).

Also observed to mitigate the OSX-specific
[performance regression on our tests](https://git-annex.branchable.com/bugs/significant_performance_regression_impacting_datal/#comment-4df4242f85746baef8afd32e0632c37c).

## Checklist

- [x] detected/reported an inconsistency against git-annex: https://git-annex.branchable.com/todo/make_add_--batch_add_directories_content/ . Worked around in the code by still using non-batched version if any path is a directory. Adds "checking overhead" but there is no other way ATM. Most likely not relevant much since higher level interfaces likely "analyze" folders and point to specific files.
- [x] remove TEMP `if True` to always try batch mode — restored intended `batch or (batch is None and len(files) > 1)` semantics, so single-file adds still take the plain (non-batched) path.
- [x] seek @christian-monch  wisdom on properly using BatchedCommand as a generator — resolved: current `proc1`-per-file loop faithfully reproduces the old `yield_` semantics, per [Christian's comment](https://github.com/datalad/datalad/pull/6977#discussion_r957200637). Removed the stale TODO/note about it.
- [x] see if any positive effect on OSX with bleeding edge annex in relation to [recent regression on our tests on OSX](https://git-annex.branchable.com/bugs/significant_performance_regression_impacting_datal/#comment-4df4242f85746baef8afd32e0632c37c) — yes, mitigates it, see git-annex issue.
- [x] no effect on benchmarks... if anything only `0.92  plugins.addurls.addurls1.time_addurls('*')` is happier.
- [x] added a scriv changelog fragment (`changelog.d/pr-6977.md`).
- [ ] `total_nbytes` (progress-bar accounting) not yet wired through in the batched path — left as a TODO in `_maybe_batched_add`.

## Test plan

- [x] Full `datalad/support/tests/test_annexrepo.py` (154 tests) passes locally — including `test_unannex_etc` which surfaced a real regression: `git annex add --batch` buffers annex-branch state internally and only fully commits on process exit. Fixed by spawning a fresh `BatchedAnnex` inside `_maybe_batched_add` and closing it after all files are fed, so downstream queries (`git annex find`, etc.) see committed state right after `add_()` returns.
- [x] Full `datalad/core/local/tests/test_save.py` (46 tests) and `test_create.py` (33 tests) pass.
- [x] `test_files_split[GitRepo|AnnexRepo]`, `test_AnnexRepo_add_to_annex`, `test_AnnexRepo_add_to_git`, `test_annex_add_no_dotfiles` pass individually.
- [x] `test_diff.py` + `test_status.py` + `test_run.py` (50 tests) pass.
- [x] Manual smoke test: 3-file batch add uses one batch process; batch process is closed after the call so `_batched` is not populated with an `add` entry.
- [ ] Full CI passes
