### PR TITLE
Send one character (no newline) to stdout in protocol test to guarantee a single "message" and thus a single custom value

### DIFF
--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -194,18 +194,12 @@ def test_runner_parametrized_protocol():
             super().pipe_data_received(fd, self.value)
 
     res = runner.run(
-        py2cmd('print(1)'),
+        py2cmd('print(1, end="")'),
         protocol=ProtocolInt,
         # value passed to protocol constructor
         value=b'5',
     )
-    try:
-        eq_(res['stdout'], '5')
-    except AssertionError:
-        # TODO: remove when dropping support for python3.8
-        if res['stdout'] == '55' and sys.version_info[:2] == (3, 8):
-            pytest.xfail("got 55 and not 5, see https://github.com/datalad/datalad/issues/4921")
-        raise
+    eq_(res['stdout'], '5')
 
 
 @integration  # ~3 sec

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -2434,7 +2434,7 @@ def test_files_split(topdir=None, *, cls):
         os.unlink(f)
         with open(f, 'w') as f:
             f.write('1')
-    dl.save(dataset=r.path, path=dirs)
+    dl.save(dataset=r.path, path=dirs, result_renderer="disabled")
 
 
 @skip_if_on_windows


### PR DESCRIPTION
Fixes issue #4921 

This PR modifies the test `datalad.support.tests.test_witless_runner.test_parameterized_protocol()`
to only send a single character to `stdout` of the subprocess, i.e. `1`. Previously two characters were
sent, i.e. `1` and `\n`. Depending on the behavior of the stdout-pipe, the data might be split up or
delivered in toto. In the first case, which is rare, the `protocol.pipe_data_received()` will be called
twice, leading to an unexpected result.

### Changelog
#### 🐛 Bug Fixes
- Fix a faulty test that made wrong assumptions about pipe-behavior. Fixes #4921
