### PR TITLE
BF: if early attempt to parse resulted in error, setup subparsers

### DIFF
--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -165,7 +165,7 @@ def setup_parser(
     all_parsers = {}  # name: (sub)parser
 
     if (completing and status == 'allknown') or status \
-            in ('allparsers', 'subcommand'):
+            in ('allparsers', 'subcommand', 'error'):
         # parseinfo could be None here, when we could not identify
         # a subcommand, but need to locate matching ones for
         # completion

--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -204,6 +204,15 @@ def test_combined_short_option():
     assert_in("too few arguments", stderr)
 
 
+# https://github.com/datalad/datalad/issues/6814
+@with_tempfile(mkdir=True)
+def test_conflicting_short_option(tempdir=None):
+    # datalad -f|--format   requires a value. regression made parser ignore command
+    # and its options
+    with chpwd(tempdir):  # can't just use -C tempdir since we do "in process" run_main
+        run_main(['create', '-f'])
+
+
 # apparently a bit different if following a good one so let's do both
 err_invalid = "error: (invalid|too few arguments|unrecognized argument)"
 err_insufficient = err_invalid  # "specify"


### PR DESCRIPTION
Without that using a short option for a command which is also
present on top level results in early attempt error and then no
parsers even tried, thus giving that error from the main/top parser to the user

Fixes #6814

Regression was introduced in 0b4937de63c44509001cd9c64bbeb7b24176685c ( AKA 0.16.0^2~68^2~17 )

I have not investigated possible impact on completion etc, but when tried - still worked fine.