### PR TITLE
Add workflow for autogenerating changelog snippets

### DIFF
--- a/.github/workflows/add-changelog-snippet.yml
+++ b/.github/workflows/add-changelog-snippet.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Configure Git identity
         run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@users.noreply.github.com"
+          git config --global user.name "DataLad Bot"
+          git config --global user.email "bot@datalad.org"
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/add-changelog-snippet.yml
+++ b/.github/workflows/add-changelog-snippet.yml
@@ -15,7 +15,7 @@ jobs:
   add:
     runs-on: ubuntu-latest
     if: >
-      github.repository == 'datalad/datalad'
+      github.repository_owner == 'datalad'
         && contains(github.event.pull_request.labels.*.name, 'CHANGELOG-missing')
     steps:
       - name: Check out repository

--- a/.github/workflows/add-changelog-snippet.yml
+++ b/.github/workflows/add-changelog-snippet.yml
@@ -2,7 +2,14 @@ name: Add changelog.d snippet
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    # "labeled" is also triggered when a PR is created with one or more labels
+    types: [synchronize, labeled]
+
+# Prevent the workflow from running multiple jobs at once when a PR is created
+# with multiple labels:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   add:

--- a/.github/workflows/add-changelog-snippet.yml
+++ b/.github/workflows/add-changelog-snippet.yml
@@ -1,0 +1,56 @@
+name: Add changelog.d snippet
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    if: >
+      github.repository == 'datalad/datalad'
+        && contains(github.event.pull_request.labels.*.name, 'CHANGELOG-missing')
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '^3.7'
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade requests
+
+      - name: Generate changelog.d snippet
+        run: |
+          python3 tools/ci/mkchlog-snippet.py \
+            ${{ github.repository_owner }} \
+            ${{ github.event.repository.name }} \
+            ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit
+        run: |
+          git add changelog.d
+          if ! git diff --quiet --cached
+          then git commit -m '[skip ci] Autogenerate changelog.d snippet for pull request'
+               git push origin HEAD:${{ github.head_ref }}
+          else echo "No changes to commit"
+          fi
+
+      - name: Remove CHANGELOG-missing label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: CHANGELOG-missing
+
+# vim:set et sts=2:

--- a/tools/ci/mkchlog-snippet.py
+++ b/tools/ci/mkchlog-snippet.py
@@ -177,6 +177,9 @@ def get_pr_info(repo_owner: str, repo_name: str, prnum: int, token: str) -> Pull
     labels: set[str] = set()
     with requests.Session() as s:
         s.headers["Authorization"] = f"bearer {token}"
+        # We need to loop in order to get all pages of closed issues & labels.
+        # The other PR details will be the same in every response, so we just
+        # grab the last set of details once the pagination is done.
         while True:
             r = s.post(GRAPHQL_API_URL, json={"query": q, "variables": variables})
             r.raise_for_status()

--- a/tools/ci/mkchlog-snippet.py
+++ b/tools/ci/mkchlog-snippet.py
@@ -54,7 +54,7 @@ class PullRequest:
         sys.exit("Pull request lacks semver labels")
 
     def as_snippet(self) -> str:
-        item = self.title
+        item = self.title.strip()
         if not item.endswith((".", "!", "?")):
             item += "."
         if self.closed_issues:

--- a/tools/ci/mkchlog-snippet.py
+++ b/tools/ci/mkchlog-snippet.py
@@ -79,14 +79,14 @@ class PullRequest:
         item = self.title.strip()
         if not item.endswith((".", "!", "?")):
             item += "."
+        item += "  "
         if self.closed_issues:
             item += (
-                "  Fixes "
+                "Fixes "
                 + ", ".join(i.as_link() for i in self.closed_issues)
-                + f" via {self.as_link()} (by {self.author.as_link()})"
+                + " via "
             )
-        else:
-            item += f"  {self.as_link()} (by {self.author.as_link()})"
+        item += f"{self.as_link()} (by {self.author.as_link()})"
         item = textwrap.fill(
             item,
             width=79,

--- a/tools/ci/mkchlog-snippet.py
+++ b/tools/ci/mkchlog-snippet.py
@@ -67,6 +67,7 @@ class PullRequest:
             initial_indent="- ",
             subsequent_indent="  ",
             break_long_words=False,
+            break_on_hyphens=False,
         )
         return f"### {self.category}\n\n{item}\n"
 

--- a/tools/ci/mkchlog-snippet.py
+++ b/tools/ci/mkchlog-snippet.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+python3 mkchlog-snippet.py [-d <outdir>] <repo owner> <repo name> <PR number>
+
+This script generates a changelog snippet for a given pull request in a GitHub
+repository.  The snippet is saved to a file in the `changelog.d` directory by
+default or to another directory specified with the `-d` option.
+
+Requirements:
+- Python 3.7+
+- requests
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+SEMVER_LABELS = [
+    # (Label name, category name) in descending order of precedence
+    ("semver-major", "Breaking Changes"),
+    ("semver-minor", "Enhancements and New Features"),
+    ("semver-patch", "Bug Fixes"),
+    ("semver-dependencies", "Dependencies"),
+    ("semver-documentation", "Documentation"),
+    ("semver-internal", "Internal"),
+    ("semver-performance", "Performance"),
+    ("semver-tests", "Tests"),
+]
+
+GRAPHQL_API_URL = os.environ.get("GITHUB_GRAPHQL_URL", "https://api.github.com/graphql")
+
+
+@dataclass
+class PullRequest:
+    title: str
+    url: str
+    author: str
+    closed_issues: list[str]
+    labels: set[str]
+
+    @property
+    def category(self) -> str:
+        for lbl, cat in SEMVER_LABELS:
+            if lbl in self.labels:
+                return cat
+        sys.exit("Pull request lacks semver labels")
+
+    def as_snippet(self) -> str:
+        item = self.title
+        if not item.endswith((".", "!", "?")):
+            item += "."
+        if self.closed_issues:
+            item += f"  Fixes {', '.join(self.closed_issues)} via {self.url} (by @{self.author})"
+        else:
+            item += f"  {self.url} (by @{self.author})"
+        item = textwrap.fill(
+            item,
+            width=79,
+            initial_indent="- ",
+            subsequent_indent="  ",
+            break_long_words=False,
+        )
+        return f"### {self.category}\n\n{item}\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--outdir", default="changelog.d", type=Path)
+    parser.add_argument("repo_owner")
+    parser.add_argument("repo_name")
+    parser.add_argument("prnum", type=int)
+    args = parser.parse_args()
+    try:
+        token = os.environ["GITHUB_TOKEN"]
+    except KeyError:
+        sys.exit("GITHUB_TOKEN not set")
+    pr = get_pr_info(
+        repo_owner=args.repo_owner,
+        repo_name=args.repo_name,
+        prnum=args.prnum,
+        token=token,
+    )
+    args.outdir.mkdir(parents=True, exist_ok=True)
+    outfile = args.outdir / f"pr-{args.prnum}.md"
+    outfile.write_text(pr.as_snippet())
+    print("Changelog snippet saved to", outfile)
+
+
+def get_pr_info(repo_owner: str, repo_name: str, prnum: int, token: str) -> PullRequest:
+    q = (
+        "query(\n"
+        "  $repo_owner: String!,\n"
+        "  $repo_name: String!,\n"
+        "  $prnum: Int!,\n"
+        "  $closing_cursor: String,\n"
+        "  $label_cursor: String\n"
+        ") {\n"
+        "  repository(owner: $repo_owner, name: $repo_name) {\n"
+        "    pullRequest(number: $prnum) {\n"
+        "      title\n"
+        "      url\n"
+        "      author {\n"
+        "        login\n"
+        "      }\n"
+        "      closingIssuesReferences(\n"
+        "        first: 50,\n"
+        "        orderBy: {field: CREATED_AT, direction:ASC},\n"
+        "        after: $closing_cursor\n"
+        "      ) {\n"
+        "        nodes {\n"
+        "          url\n"
+        "        }\n"
+        "        pageInfo {\n"
+        "          endCursor\n"
+        "          hasNextPage\n"
+        "        }\n"
+        "      }\n"
+        "      labels(first: 50, after: $label_cursor) {\n"
+        "        nodes {\n"
+        "          name\n"
+        "        }\n"
+        "        pageInfo {\n"
+        "          endCursor\n"
+        "          hasNextPage\n"
+        "        }\n"
+        "      }\n"
+        "    }\n"
+        "  }\n"
+        "}\n"
+    )
+    variables = {
+        "repo_owner": repo_owner,
+        "repo_name": repo_name,
+        "prnum": prnum,
+        "closing_cursor": None,
+        "label_cursor": None,
+    }
+    closed_issues: list[str] = []
+    labels: set[str] = set()
+    with requests.Session() as s:
+        s.headers["Authorization"] = f"bearer {token}"
+        while True:
+            r = s.post(GRAPHQL_API_URL, json={"query": q, "variables": variables})
+            r.raise_for_status()
+            resp = r.json()
+            if resp.get("errors"):
+                sys.exit(
+                    "GraphQL API Error:\n" + json.dumps(resp, sort_keys=True, indent=4)
+                )
+            data = resp["data"]["repository"]["pullRequest"]
+            issue_page = data["closingIssuesReferences"]
+            closed_issues.extend(n["url"] for n in issue_page["nodes"])
+            variables["closing_cursor"] = issue_page["pageInfo"]["endCursor"]
+            label_page = data["labels"]
+            labels.update([n["name"] for n in label_page["nodes"]])
+            variables["label_cursor"] = label_page["pageInfo"]["endCursor"]
+            if (
+                not issue_page["pageInfo"]["hasNextPage"]
+                and not label_page["pageInfo"]["hasNextPage"]
+            ):
+                return PullRequest(
+                    title=data["title"],
+                    url=data["url"],
+                    author=data["author"]["login"],
+                    closed_issues=closed_issues,
+                    labels=labels,
+                )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of #6918.  The workflow won't affect this PR itself, but you can see it in action in a test repository at https://github.com/datalad/temp-release-devel/pull/4.

### Changelog
#### 🏠 Internal
- Add a workflow for autogenerating changelog snippets

[travis skip]
[appveyor skip]