### PR TITLE
RF(BK?): dissolve support for old style Interfaces without @eval_results

### DIFF
--- a/datalad/cli/tests/test_exec.py
+++ b/datalad/cli/tests/test_exec.py
@@ -53,31 +53,6 @@ def _new_args(**kwargs):
     )
 
 
-
-
-def test_call_from_parser_old_style():
-    # test that old style commands are invoked without any additional arguments
-    class DummyOne(Interface):
-        @staticmethod
-        def __call__(arg=None):
-            eq_(arg, "nothing")
-            return "magical"
-    val = call_from_parser(DummyOne, _args(arg="nothing"))
-    eq_(val, "magical")
-
-
-def test_call_from_parser_old_style_generator():
-    # test that old style commands are invoked without any additional arguments
-    class DummyOne(Interface):
-        @staticmethod
-        def __call__(arg=None):
-            eq_(arg, "nothing")
-            yield "nothing is"
-            yield "magical"
-    val = call_from_parser(DummyOne, _args(arg="nothing"))
-    eq_(val, ["nothing is", "magical"])
-
-
 def test_call_from_parser_default_args():
     class DummyOne(Interface):
         # explicitly without @eval_results
@@ -99,27 +74,6 @@ def test_call_from_parser_default_args():
     # just to be sure no evil spirits chase away our Dummy
     val = call_from_parser(DummyOne, _new_args(arg="nothing"))
     eq_(val, ["nothing is", "magical"])
-
-
-def test_call_from_parser_result_filter():
-    class DummyOne(Interface):
-        @staticmethod
-        def __call__(**kwargs):
-            yield kwargs
-
-    # call_from_parser doesn't add result_filter to the keyword arguments
-    assert_not_in("result_filter",
-                  call_from_parser(DummyOne, _new_args())[0])
-    # with dissolution of _OLD_STYLE_COMMANDS and just relying on having
-    # @eval_results, no result_filter is added, since those commands are
-    # not guaranteed to return/yield any record suitable for filtering.
-    # The effect is the same -- those "common" options are not really applicable
-    # to Interface's which do not return/yield expected records
-    assert_not_in(
-        "result_filter",
-        call_from_parser(
-            DummyOne,
-            _new_args(common_report_type="dataset"))[0])
 
 
 def test_get_result_filter_arg_vs_config():

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -415,12 +415,9 @@ def build_doc(cls, **kwargs):
 
 
     # update class attributes that may override defaults
-    if not _has_eval_results_call(cls):
-        add_args = None
-    else:
-        # defaults for all common parameters are guaranteed to be available
-        # from the class
-        add_args = {k: getattr(cls, k) for k in eval_params}
+    # Defaults for all common parameters are guaranteed to be available
+    # from the class
+    add_args = {k: getattr(cls, k) for k in eval_params}
 
     # ATTN: An important consequence of this update() call is that it
     # fulfills the docstring's promise of overriding any existing
@@ -631,11 +628,3 @@ def get_allargs_as_kwargs(call, args, kwargs):
     # from their signature...
     #assert (nargs == len(kwargs_))
     return kwargs_
-
-
-# Only needed to support command implementations before the introduction
-# of @eval_results
-def _has_eval_results_call(cls):
-    """Return True if cls has a __call__ decorated with @eval_results
-    """
-    return getattr(getattr(cls, '__call__', None), '_eval_results', False)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -446,9 +446,7 @@ def eval_results(wrapped):
             lgr.log(2, "Returning return_func from eval_func for %s", wrapped_class)
             return return_func(*args, **kwargs)
 
-    ret = eval_func
-    ret._eval_results = True
-    return ret
+    return eval_func
 
 
 def generic_result_renderer(res):


### PR DESCRIPTION
I saw TODO and "acted". But then at the end I decided to ask grep and found that we have 2 interfaces
which do that still. So it might be a bit early or we could just make those interfaces
also into @eval_results ones. WDYT?

TODOs
- [ ] see if we want to proceed with such change
- [ ] ? make `@eval_results` a no-op and just to become part of any `Interface` (somehow), and remove all of its references in this repo (and eventually in extensions through deprecation cycle)

### Changelog
#### 🪓 Deprecations and removals
- Remove explicit support for `Interface` subclasses without `@eval_results`
