### PR TITLE
Provide "/dev/null" (b:\nul on 💾 Windows) instead of empty string as a git-repo to avoid reading local repo configuration

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -373,7 +373,7 @@ class ConfigManager(object):
             # The caller didn't specify a repository. Unset the git directory
             # when calling 'git config' to prevent a repository in the current
             # working directory from leaking configuration into the output.
-            self._config_cmd = ['git', '--git-dir=', 'config']
+            self._config_cmd = ['git', '--git-dir=/dev/null', 'config']
 
         self._src_mode = source
         run_kwargs = dict()

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -32,6 +32,7 @@ from datalad.runner import (
     KillOutput,
     StdOutErrCapture,
 )
+from datalad.utils import on_windows
 
 lgr = logging.getLogger('datalad.config')
 
@@ -370,10 +371,16 @@ class ConfigManager(object):
                 raise ValueError(
                     'ConfigManager configured to read from a branch of a dataset only, '
                     'but no dataset given')
-            # The caller didn't specify a repository. Unset the git directory
-            # when calling 'git config' to prevent a repository in the current
+            # The caller didn't specify a repository. Unfortunately there is
+            # no known way to tell git to ignore possible local git repository,
+            # and unsetting of --git-dir could cause other problems.
+            # See https://lore.kernel.org/git/YscCKuoDPBbs4iPX@lena.dartmouth.edu/T/ .
+            # Setting the git directory to /dev/null or on Windows analogous nul file
+            # (could be anywhere, see https://stackoverflow.com/a/27773642/1265472)
+            # see allow to achieve the goal to prevent a repository in the current
             # working directory from leaking configuration into the output.
-            self._config_cmd = ['git', '--git-dir=/dev/null', 'config']
+            nul = 'b:\\nul' if on_windows else '/dev/null'
+            self._config_cmd = ['git', f'--git-dir={nul}', 'config']
 
         self._src_mode = source
         run_kwargs = dict()

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -289,6 +289,24 @@ def test_something(path=None, new_home=None):
 
 
 @with_tree(tree={
+    '.gitconfig': """\
+[includeIf "gitdir:**/devbgc/**"]
+    path = ~/.gitconfig_bgc
+
+[custom "datalad"]
+  variable = value
+"""})
+def test_includeif_breaking(new_home=None):
+    patched_env = os.environ.copy()
+    patched_env.pop('GIT_CONFIG_GLOBAL', None)
+    patched_env.update(get_home_envvars(new_home))
+    with patch.dict('os.environ', patched_env, clear=True):
+        cfg = ConfigManager()
+        # just want to make sure we read it and didn't crash
+        assert cfg.get('custom.datalad.variable') == "value"
+
+
+@with_tree(tree={
     'ds': {
         '.datalad': {
             'config': """\


### PR DESCRIPTION
It is the resurrected #6820 but now with "Windows support". More information/references in the diff itself and individual commits.

Closes https://github.com/datalad/datalad/issues/6815