### PR TITLE
Make the manpages build reproducible via datalad.source.epoch (to be used in Debian packaging)

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -26,3 +26,11 @@ jobs:
     - name: Build docs
       run: |
         make -C docs html doctest;
+    - name: Test building manpages
+      run: |
+        # with custom date
+        DATALAD_SOURCE_EPOCH=100000000 python setup.py build_manpage
+        grep '\.TH "datalad" "1" "1973' ./build/man/datalad.1
+        # no custom date - should be good for the next 980 years
+        python setup.py build_manpage
+        grep '\.TH "datalad" "1" "2' ./build/man/datalad.1

--- a/_datalad_build_support/formatters.py
+++ b/_datalad_build_support/formatters.py
@@ -7,7 +7,9 @@
 
 import argparse
 import datetime
+import os
 import re
+import time
 from textwrap import wrap
 
 
@@ -34,7 +36,9 @@ class ManPageFormatter(argparse.HelpFormatter):
 
         self._prog = prog
         self._section = 1
-        self._today = datetime.date.today().strftime('%Y\\-%m\\-%d')
+        self._today = datetime.datetime.utcfromtimestamp(
+            int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+        ).strftime('%Y\\-%m\\-%d')
         self._ext_sections = ext_sections
         self._version = version
 

--- a/_datalad_build_support/formatters.py
+++ b/_datalad_build_support/formatters.py
@@ -27,7 +27,7 @@ class ManPageFormatter(argparse.HelpFormatter):
                  authors=None,
                  version=None
                  ):
-
+        from datalad import cfg
         super(ManPageFormatter, self).__init__(
             prog,
             indent_increment=indent_increment,
@@ -37,7 +37,7 @@ class ManPageFormatter(argparse.HelpFormatter):
         self._prog = prog
         self._section = 1
         self._today = datetime.datetime.utcfromtimestamp(
-            int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+            cfg.obtain('datalad.source.epoch')
         ).strftime('%Y\\-%m\\-%d')
         self._ext_sections = ext_sections
         self._version = version

--- a/changelog.d/pr-6997.md
+++ b/changelog.d/pr-6997.md
@@ -1,0 +1,5 @@
+### Internal
+
+- Make the build reproducible (on Debian) via SOURCE_DATE_EPOCH for dates in
+  manpages.  [PR #6997](https://github.com/datalad/datalad/pull/6997) (by
+  [@yarikoptic](https://github.com/yarikoptic))

--- a/changelog.d/pr-6997.md
+++ b/changelog.d/pr-6997.md
@@ -1,5 +1,6 @@
 ### Internal
 
-- Make the build reproducible (on Debian) via SOURCE_DATE_EPOCH for dates in
-  manpages.  [PR #6997](https://github.com/datalad/datalad/pull/6997) (by
+- Introduce datalad.source.epoch configuration to make the build reproducible
+  (on Debian only ATM) by providing date to use in the manpages.
+  [PR #6997](https://github.com/datalad/datalad/pull/6997) (by
   [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -17,6 +17,7 @@ import logging
 from os import environ
 from os.path import expanduser
 from os.path import join as opj
+import time
 
 from platformdirs import AppDirs
 
@@ -24,6 +25,7 @@ from datalad.support.constraints import (
     EnsureBool,
     EnsureChoice,
     EnsureInt,
+    EnsureFloat,
     EnsureListOf,
     EnsureNone,
     EnsureStr,
@@ -708,6 +710,18 @@ _definitions = {
                     "ignore the incompatibility."}),
         'type': EnsureChoice('warning', 'error', 'none'),
         'default': 'warning',
+
+    },
+    'datalad.source.epoch': {
+        'ui': ('question', {
+            'title': 'Datetime epoch to use for dates in built materials',
+            'text': "Datetime to use for reproducible builds. Originally introduced "
+                    "for Debian packages to interface SOURCE_DATE_EPOCH described at "
+                    "https://reproducible-builds.org/docs/source-date-epoch/ ."
+                    "By default - current time"
+        }),
+        'type': EnsureFloat(),
+        'default': time.time(),
 
     },
     'datalad.ssh.executable': {


### PR DESCRIPTION
I think it is worth adding to our codebase to avoid posssible conflicts in the
patch and also to facilitate similar reproducibility in other distributions
where so would be desired.

Origin: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1010318