### PR TITLE
Do not use `gen4`-metadata methods in `datalad metadata`-command

### DIFF
--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1124,13 +1124,19 @@ def gen4_query_aggregated_metadata(reporton: str,
                     }
                 }
         except NoMetadataStoreFound:
+            if len(matching_types) == 2:
+                matching_type = "all"
+            elif len(matching_types) == 0:
+                matching_type = "none"
+            else:
+                matching_type = matching_types[0]
             yield {
                 **kwargs,
                 'path': str(ds.pathobj / relative_path),
                 'status': 'impossible',
                 'message': f'Dataset at {ds.pathobj} does not contain gen4 '
                            f'metadata',
-                'type': matching_types
+                'type': matching_type
             }
 
     return None

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1124,6 +1124,7 @@ def gen4_query_aggregated_metadata(reporton: str,
                     }
                 }
         except NoMetadataStoreFound:
+            lgr.warning(f"Found no gen4-metadata in dataset {dataset.pathobj}.")
             if len(matching_types) == 2:
                 matching_type = "all"
             elif len(matching_types) == 0:

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -1142,7 +1142,7 @@ def query_aggregated_metadata(reporton: str,
                               recursive: bool = False,
                               metadata_source: Optional[str] = None,
                               **kwargs):
-    """Query legacy and NG-metadata stored in a dataset or its metadata store
+    """Query legacy and gen4-metadata stored in a dataset or its metadata store
 
     Parameters
     ----------

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -347,7 +347,7 @@ def legacy_query_aggregated_metadata(reporton, ds, aps, recursive=False,
 def _query_aggregated_metadata_singlepath(
         ds, agginfos, agg_base_path, qap, reporton, cache, dsmeta,
         contentinfo_objloc):
-    """This is the workhorse of query_aggregated_metadata() for querying for a
+    """This is the workhorse of legacy_query_aggregated_metadata() for querying for a
     single path"""
     rpath = qap['rpath']
     containing_ds = qap['metaprovider']
@@ -1010,7 +1010,7 @@ class Metadata(Interface):
             if not query_agg:
                 continue
             # report from aggregated metadata
-            for r in query_aggregated_metadata(
+            for r in legacy_query_aggregated_metadata(
                     reporton,
                     # by default query the reference dataset, only if there is none
                     # try our luck in the dataset that contains the queried path

--- a/datalad/metadata/tests/test_base.py
+++ b/datalad/metadata/tests/test_base.py
@@ -23,7 +23,7 @@ from datalad.api import (
 from datalad.metadata.metadata import (
     _get_containingds_from_agginfo,
     get_metadata_type,
-    query_aggregated_metadata,
+    legacy_query_aggregated_metadata,
 )
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import (
@@ -118,7 +118,7 @@ def test_aggregation(path=None):
     ds = Dataset(opj(path, 'origin')).create(force=True)
     # before anything aggregated we would get nothing and only a log warning
     with swallow_logs(new_level=logging.WARNING) as cml:
-        assert_equal(list(query_aggregated_metadata('all', ds, [])), [])
+        assert_equal(list(legacy_query_aggregated_metadata('all', ds, [])), [])
     assert_re_in('.*Found no aggregated metadata.*update', cml.out)
     ds.config.add('datalad.metadata.nativetype', 'frictionless_datapackage',
                   scope='branch')


### PR DESCRIPTION
Fixes #7000 

This PR fixes issue #7000. It restricts legacy metadata code that implents `datalad metadata` to only use legacy metadata query methods.

### Changelog
#### 🐛 Bug Fixes
- Do not process gen4-metadata in `datalad metadata` command ... Fixes #7000
