### PR TITLE
Fix test helpers for results

### DIFF
--- a/changelog.d/pr-7002.md
+++ b/changelog.d/pr-7002.md
@@ -1,0 +1,4 @@
+### Tests
+
+- Fix broken test helpers for result record testing that would falsely pass.
+  [PR #7002](https://github.com/datalad/datalad/pull/7002) (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -105,11 +105,13 @@ def test_invalid_args(path=None, otherpath=None, alienpath=None):
     # clone into a URL-like path.
 
     # install to an "invalid URL" path
-    res = clone('Zoidberg', path='ssh://mars:Zoidberg', on_failure='ignore')
+    res = clone('Zoidberg', path='ssh://mars:Zoidberg', on_failure='ignore',
+                result_xfm=None)
     assert_status('error', res)
 
     # install to a "remote location" path
-    res = clone('Zoidberg', path='ssh://mars/Zoidberg', on_failure='ignore')
+    res = clone('Zoidberg', path='ssh://mars/Zoidberg', on_failure='ignore',
+                result_xfm=None)
     assert_status('error', res)
 
     # make fake dataset
@@ -118,7 +120,8 @@ def test_invalid_args(path=None, otherpath=None, alienpath=None):
     # make real dataset, try to install outside
     ds_target = create(Path(otherpath) / 'target')
     assert_raises(ValueError, ds_target.clone, ds.path, path=ds.path)
-    assert_status('error', ds_target.clone(ds.path, path=alienpath, on_failure='ignore'))
+    assert_status('error', ds_target.clone(ds.path, path=alienpath,
+                                           on_failure='ignore', result_xfm=None))
 
 
 @integration
@@ -159,7 +162,7 @@ def test_clone_datasets_root(tdir=None):
         # and a third time into an existing something, that is not a dataset:
         (tdir / 'sub' / 'a_file.txt').write_text("something")
 
-        res = clone('///', path="sub", on_failure='ignore')
+        res = clone('///', path="sub", on_failure='ignore', result_xfm=None)
         assert_message(
             'target path already exists and not empty, refuse to clone into target path',
             res)
@@ -375,9 +378,10 @@ def test_notclone_known_subdataset(src_path=None, path=None):
     assert_in('subm 1', ds.subdatasets(state='absent', result_xfm='relpaths'))
     assert_not_in('subm 1', ds.subdatasets(state='present', result_xfm='relpaths'))
     # clone is not meaningful
-    res = ds.clone('subm 1', on_failure='ignore')
+    res = ds.clone('subm 1', on_failure='ignore', result_xfm=None)
     assert_status('error', res)
-    assert_message('Failed to clone from all attempted sources: %s',
+    assert_message("Failed to clone from any candidate source URL. "
+                   "Encountered errors per each url were:\n- %s",
                    res)
     # get does the job
     res = ds.get(path='subm 1', get_data=False)
@@ -395,9 +399,10 @@ def test_notclone_known_subdataset(src_path=None, path=None):
 def test_failed_clone(dspath=None):
     ds = create(dspath)
     res = ds.clone("http://nonexistingreallyanything.datalad.org/bla", "sub",
-                   on_failure='ignore')
+                   on_failure='ignore', result_xfm=None)
     assert_status('error', res)
-    assert_message('Failed to clone from all attempted sources: %s',
+    assert_message("Failed to clone from any candidate source URL. "
+                   "Encountered errors per each url were:\n- %s",
                    res)
 
 

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1476,7 +1476,10 @@ def assert_status(label, results):
     in this sequence.
     """
     label = ensure_list(label)
-    results = ensure_list(results)
+    results = ensure_result_list(results)
+    if len(results) == 0:
+        # If there are no results, an assertion about all results must fail.
+        raise AssertionError("No results retrieved")
     for i, r in enumerate(results):
         try:
             assert_in('status', r)
@@ -1495,7 +1498,13 @@ def assert_message(message, results):
     This only tests the message template string, and not a formatted message
     with args expanded.
     """
-    for r in ensure_list(results):
+
+    results = ensure_result_list(results)
+    if len(results) == 0:
+        # If there are no results, an assertion about all results must fail.
+        raise AssertionError("No results retrieved")
+
+    for r in results:
         assert_in('message', r)
         m = r['message'][0] if isinstance(r['message'], tuple) else r['message']
         assert_equal(m, message)
@@ -1510,7 +1519,7 @@ def _format_res(x):
 def assert_result_count(results, n, **kwargs):
     """Verify specific number of results (matching criteria, if any)"""
     count = 0
-    results = ensure_list(results)
+    results = ensure_result_list(results)
     for r in results:
         if not len(kwargs):
             count += 1
@@ -1527,8 +1536,9 @@ def assert_result_count(results, n, **kwargs):
 
 
 def _check_results_in(should_contain, results, **kwargs):
+    results = ensure_result_list(results)
     found = False
-    for r in ensure_list(results):
+    for r in results:
         if all(k in r and r[k] == v for k, v in kwargs.items()):
             found = True
             break
@@ -1556,6 +1566,7 @@ def assert_not_in_results(results, **kwargs):
 def assert_result_values_equal(results, prop, values):
     """Verify that the values of all results for a given key in the status dicts
     match the given sequence"""
+    results = ensure_result_list(results)
     assert_equal(
         [r[prop] for r in results],
         values)
@@ -1571,7 +1582,8 @@ def assert_result_values_cond(results, prop, cond):
     prop: str
     cond: callable
     """
-    for r in ensure_list(results):
+    results = ensure_result_list(results)
+    for r in results:
         ok_(cond(r[prop]),
             msg="r[{prop}]: {value}".format(prop=prop, value=r[prop]))
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -738,6 +738,21 @@ def ensure_list(s, copy=False, iterate=True):
     return ensure_iter(s, list, copy=copy, iterate=iterate)
 
 
+def ensure_result_list(r):
+    """Return a list of result records
+
+    Largely same as ensure_list, but special casing a single dict being passed
+    in, which a plain `ensure_list` would iterate over. Hence, this deals with
+    the three ways datalad commands return results:
+    - single dict
+    - list of dicts
+    - generator
+
+    Used for result assertion helpers.
+    """
+    return [r] if isinstance(r, dict) else ensure_list(r)
+
+
 def ensure_list_from_str(s, sep='\n'):
     """Given a multiline string convert it to a list of return None if empty
 


### PR DESCRIPTION
The helpers for testing result records had a couple of bugs.
Most noteably, some (e.g. `assert_status`) would pass when no result was
given at all. Therefore command calls that did not return any result
were passing assertions about the `status` field of their results.

Furthermore, most of those helpers did not properly deal with all three
"representations" of results that are (and need to be) passed to them:
1. list of dict
2. single dict
3. generator

That's because `ensure_list` is used with the incoming results, but this
turns dicts that are not encapsulated by a list into a list of their
keys rather than a single-item list of dict. Reason for that is, that a
dict is iterable.

The falsely passing helpers also hid bugs in the tests - mostly command calls (`clone`) failing to set `result_xfm` correctly and therefore not getting result records back, but then proceeding to assertions about such result records.

This patch should fix this.


