### PR TITLE
BF: blacklist 23.9.0 of keyring as introduces regression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ requires = {
     ],
     'downloaders': [
         'boto',
-        'keyring>=20.0', 'keyrings.alt',
+        'keyring>=20.0,!=23.9.0',
+        'keyrings.alt',
         'msgpack',
         'requests>=1.2',
     ],


### PR DESCRIPTION
Ref: https://github.com/jaraco/keyring/issues/593

We better release asap to not cause the chain reaction through downstreams.  May be without yet "scriv-edited" changelogs since not fully implemented so I will not bother adding one here either.