### PR TITLE
ENH(TEMP): set git core.quotePath to false in tests fixture

### DIFF
--- a/datalad/conftest.py
+++ b/datalad/conftest.py
@@ -82,6 +82,10 @@ def setup_package():
         email = test@example.com
 [core]
 	askPass =
+	# "display" unicode filenames in status etc.
+	# discovered at https://stackoverflow.com/questions/34549040/git-not-displaying-unicode-file-names
+	# TODO: make this parametric in the testing, but depending on what?
+	quotePath = false
 [datalad "log"]
         exc = 1
 [annex "security"]


### PR DESCRIPTION
That causes paths "displayed" properly to the users, and I wonder if any
of our tests/interfaces which use utf-8 would be succeptable.  Might be worth
adding this config setting to one of the CI runs, but for that we would need
to make it optional, and not always false like here
