### PR TITLE
Fix type annotations in `cmd.py` and `runner.py`

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -12,6 +12,7 @@ via stdin. For each instruction send over stdin, a response is read and
 returned. The response structure is determined by "output_proc"
 
 """
+from __future__ import annotations
 
 import logging
 import os
@@ -29,7 +30,7 @@ from typing import (
 )
 from datetime import datetime
 from operator import attrgetter
-from weakref import WeakValueDictionary
+from weakref import WeakValueDictionary, ReferenceType, ref
 
 # start of legacy import block
 # to avoid breakage of code written before datalad.runner
@@ -174,7 +175,7 @@ class BatchedCommand(SafeDelCloseMixin):
 
     # Collection of active BatchedCommands as a mapping from object IDs to
     # instances
-    _active_instances = WeakValueDictionary()
+    _active_instances: WeakValueDictionary[int, BatchedCommand] = WeakValueDictionary()
 
     def __init__(self,
                  cmd: Union[str, Tuple, List],
@@ -185,15 +186,15 @@ class BatchedCommand(SafeDelCloseMixin):
                  ):
 
         command = cmd
-        self.command = [command] if not isinstance(command, List) else command
-        self.path = path
-        self.output_proc = output_proc
-        self.timeout = timeout
-        self.exception_on_timeout = exception_on_timeout
+        self.command: list = [command] if not isinstance(command, List) else command
+        self.path: Optional[str] = path
+        self.output_proc: Optional[Callable] = output_proc
+        self.timeout: Optional[float] = timeout
+        self.exception_on_timeout: bool = exception_on_timeout
 
         self.stdin_queue = None
         self.stderr_output = b""
-        self.runner = None
+        self.runner: Optional[WitlessRunner] = None
         self.generator = None
         self.encoding = None
         self.wait_timed_out = None

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -19,6 +19,7 @@ import os
 import queue
 import sys
 import warnings
+from queue import Queue
 from subprocess import TimeoutExpired
 from typing import (
     Any,
@@ -56,6 +57,7 @@ from datalad.runner.coreprotocols import StdOutErrCapture
 from datalad.runner.nonasyncrunner import (
     STDERR_FILENO,
     STDOUT_FILENO,
+    _ResultGenerator,
 )
 from datalad.runner.protocol import GeneratorMixIn
 from datalad.runner.runner import WitlessRunner
@@ -192,10 +194,8 @@ class BatchedCommand(SafeDelCloseMixin):
         self.timeout: Optional[float] = timeout
         self.exception_on_timeout: bool = exception_on_timeout
 
-        self.stdin_queue = None
         self.stderr_output = b""
         self.runner: Optional[WitlessRunner] = None
-        self.generator = None
         self.encoding = None
         self.wait_timed_out = None
         self.return_code = None
@@ -206,6 +206,10 @@ class BatchedCommand(SafeDelCloseMixin):
         self.clean_inactive()
         assert id(self) not in self._active_instances
         self._active_instances[id(self)] = self
+
+        # pure declarations
+        self.stdin_queue: Queue
+        self.generator: _ResultGenerator
 
     @classmethod
     def clean_inactive(cls):

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -276,7 +276,7 @@ class ThreadedRunner:
                     stderr=decoded_output.get("stderr", None)
                 )
 
-    def run(self) -> dict | Generator:
+    def run(self) -> dict | _ResultGenerator:
         """
         Run the command as specified in __init__.
 
@@ -319,7 +319,7 @@ class ThreadedRunner:
         with self.initialization_lock:
             return self._locked_run()
 
-    def _locked_run(self) -> dict | Generator:
+    def _locked_run(self) -> dict | _ResultGenerator:
         if self.generator is not None:
             raise RuntimeError("ThreadedRunner.run() was re-entered")
 
@@ -686,7 +686,7 @@ def run_command(cmd: str | list,
                 protocol_kwargs: Optional[dict] = None,
                 timeout: Optional[float] = None,
                 exception_on_error: bool = True,
-                **popen_kwargs) -> dict | Generator:
+                **popen_kwargs) -> dict | _ResultGenerator:
     """
     Run a command in a subprocess
 

--- a/datalad/runner/runner.py
+++ b/datalad/runner/runner.py
@@ -126,13 +126,14 @@ class WitlessRunner(object):
 
         Returns
         -------
-          Union[Any, Generator]
+          dict | _ResultGenerator
 
             If the protocol is not a subclass of `GeneratorMixIn`, the
             result of protocol._prepare_result will be returned.
 
-            If the protocol is a subclass of `GeneratorMixIn`, a Generator
-            will be returned. This allows to use this method in constructs like:
+            If the protocol is a subclass of `GeneratorMixIn`, a Generator, i.e.
+            a `_ResultGenerator`, will be returned. This allows to use this
+            method in constructs like:
 
                 for protocol_output in runner.run():
                     ...

--- a/datalad/runner/runner.py
+++ b/datalad/runner/runner.py
@@ -11,11 +11,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Generator
+from typing import cast
 
 from .coreprotocols import NoCapture
 from .exception import CommandError
-from .nonasyncrunner import ThreadedRunner
+from .nonasyncrunner import (
+    ThreadedRunner,
+    _ResultGenerator,
+)
 from .protocol import GeneratorMixIn
 
 
@@ -49,7 +52,6 @@ class WitlessRunner(object):
 
         self.threaded_runner = None
 
-
     def _get_adjusted_env(self, env=None, cwd=None, copy=True):
         """Return an adjusted copy of an execution environment
 
@@ -72,7 +74,7 @@ class WitlessRunner(object):
             env=None,
             timeout=None,
             exception_on_error=True,
-            **kwargs) -> dict | Generator:
+            **kwargs) -> dict | _ResultGenerator:
         """Execute a command and communicate with it.
 
         Parameters
@@ -193,7 +195,7 @@ class WitlessRunner(object):
         if issubclass(protocol, GeneratorMixIn):
             return results_or_iterator
         else:
-            results = results_or_iterator
+            results = cast(dict, results_or_iterator)
 
         # log before any exception is raised
         lgr.debug("Finished %r with status %s", cmd, results['code'])

--- a/datalad/runner/runner.py
+++ b/datalad/runner/runner.py
@@ -8,8 +8,10 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Base DataLad command execution runner
 """
+from __future__ import annotations
 
 import logging
+from typing import Generator
 
 from .coreprotocols import NoCapture
 from .exception import CommandError
@@ -70,7 +72,7 @@ class WitlessRunner(object):
             env=None,
             timeout=None,
             exception_on_error=True,
-            **kwargs):
+            **kwargs) -> dict | Generator:
         """Execute a command and communicate with it.
 
         Parameters

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ commands =
     # See https://github.com/datalad/datalad/issues/6884
     mypy --follow-imports skip \
         datalad/api.py \
+        datalad/cmd.py \
         datalad/downloaders/providers.py \
         datalad/metadata/indexers/base.py \
         datalad/runner \


### PR DESCRIPTION
This PR os based on the work and discussions in PR #6899 

### Changelog
#### 🏠 Internal
- Add type annotations to `cmd.py` and `runner.py`
