### PR TITLE
UX: push - provide specific error with details if push failed due to permission issue

### DIFF
--- a/changelog.d/pr-7011.md
+++ b/changelog.d/pr-7011.md
@@ -1,0 +1,5 @@
+### Bug Fixes
+
+- UX: push - provide specific error with details if push failed due to
+  permission issue.  [PR #7011](https://github.com/datalad/datalad/pull/7011)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -443,14 +443,27 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
     target = None
     if not _target:
         try:
-            # let Git figure out what needs doing
-            # we will reuse the result further down again, so nothing is wasted
-            wannabe_gitpush = repo.push(remote=None, git_options=['--dry-run'])
-            # we did not get an explicit push target, get it from Git
-            target = set(p.get('remote', None) for p in wannabe_gitpush)
-            # handle case where a pushinfo record did not have a 'remote'
-            # property -- should not happen, but be robust
-            target.discard(None)
+            try:
+                # let Git figure out what needs doing
+                # we will reuse the result further down again, so nothing is wasted
+                wannabe_gitpush = repo.push(remote=None, git_options=['--dry-run'])
+                # we did not get an explicit push target, get it from Git
+                target = set(p.get('remote', None) for p in wannabe_gitpush)
+                # handle case where a pushinfo record did not have a 'remote'
+                # property -- should not happen, but be robust
+                target.discard(None)
+            except CommandError as e:
+                if 'Please make sure you have the correct access rights' in e.stderr:
+                    # there is a default push target but we have no permission
+                    yield dict(
+                        res_kwargs,
+                        status='impossible',
+                        message='Attempt to push to default target resulted in following '
+                                'error.  Address the error or specify different target with --to: '
+                                + e.stderr,
+                    )
+                    return
+                raise
         except Exception as e:
             lgr.debug(
                 'Dry-run push to determine default push target failed, '


### PR DESCRIPTION
I kept getting an error like

	$> datalad push
	publish(impossible): . (dataset) [No push target given, and none could be auto-detected, please specify via --to]
	action summary:
	  publish (impossible: 1)

and kept tuning the .git/config to specify extra options like push-remote etc,
but nothing helped.  Only when looking at -l debug I saw that the issue has
nothing to do with default target not being given but rather with permissions
issue.  IMHO "none could be auto-detected" is although technically true that
datalad FAILS to auto-detect it, is semantically wrong since it could be
autodetected but datalad can't.  That is why I decided that in cases whenever
it is a matter of permission issue, we can report that error in full.

edit: details on how such errors were triggered were added to commit message. ATM it is https://github.com/datalad/datalad/commit/9647b4906a02b4374599e700b0e0f86ead56455f