### PR TITLE
Do not skip CI for autogen changelog.d snippet

### DIFF
--- a/.github/workflows/add-changelog-snippet.yml
+++ b/.github/workflows/add-changelog-snippet.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           git add changelog.d
           if ! git diff --quiet --cached
-          then git commit -m '[skip ci] Autogenerate changelog.d snippet for pull request'
+          then git commit -m 'Autogenerate changelog.d snippet for pull request'
                git push origin HEAD:${{ github.head_ref }}
           else echo "No changes to commit"
           fi


### PR DESCRIPTION
With that skip ci we make all CI, but appveyor skip, and then the status for that PR includes only appveyor and WiP requiring to explicitly look at prior commit status to assess full picture.  I guess we should just rely on CIs to be able to cancel a possible existing run if more pushed to the PR branch

Observed in https://github.com/datalad/datalad/pull/7011

[skip ci]
[appveyor skip]

### PR checklist

- [ ] Provide an overview of the changes you're making and explain why you're proposing them, ideally in the form of a changelog (template below)
- [ ] Include `Fixes #NNN` somewhere in the description if this PR addresses an existing issue.
- [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
  Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
- [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
- [ ] **Delete these instructions**. :-)

Thanks for contributing!

### Changelog
#### 🐛 Bug Fixes
- Description... Fixes #issue
#### 💫 Enhancements and new features
-
#### 🪓 Deprecations and removals
-
#### 📝 Documentation
-
#### 🏠 Internal
-
#### 🛡 Tests
-
