### PR TITLE
DOC: update strings for command categories

### DIFF
--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -97,7 +97,6 @@ def setup_parser(
         prog='datalad',
         # usage="%(prog)s ...",
         description=help_gist,
-        epilog='"Be happy!"',
         formatter_class=formatter_class,
         add_help=False,
         # TODO: when dropping support for Python 3.8: uncomment below

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -20,7 +20,7 @@ __docformat__ = 'restructuredtext'
 # the name of the `_group_*` variable determines the sorting in the command overview
 # alphanum ascending order
 _group_0dataset = (
-    'Essential commands',
+    'Essential',
     [
         # source module, source object[, dest. cmdline name[, dest python name]]
         # src module can be relative, but has to be relative to the main 'datalad' package
@@ -35,7 +35,7 @@ _group_0dataset = (
     ])
 
 _group_1siblings = (
-    'Commands for collaborative workflows',
+    'Collaborative workflows',
     [
         ('datalad.distributed.create_sibling_github', 'CreateSiblingGithub'),
         ('datalad.distributed.create_sibling_gitlab', 'CreateSiblingGitlab'),
@@ -64,7 +64,7 @@ _group_2dataset = (
     ])
 
 _group_2metadata = (
-    'Commands for metadata handling',
+    'Metadata',
     [
         ('datalad.metadata.search', 'Search',
          'search', 'search'),
@@ -77,7 +77,7 @@ _group_2metadata = (
     ])
 
 _group_3misc = (
-    'Miscellaneous commands',
+    'Miscellaneous',
     [
         ('datalad.local.configuration', 'Configuration'),
         ('datalad.local.wtf', 'WTF'),
@@ -94,7 +94,7 @@ _group_3misc = (
     ])
 
 _group_4plumbing = (
-    'Plumbing commands',
+    'Plumbing',
     [
         ('datalad.distribution.create_test_dataset', 'CreateTestDataset',
          'create-test-dataset'),


### PR DESCRIPTION
The new DataLad Gooey-GUI-Gewwee uses the category strings for commands for the UI, which increases the visibility of this problem.

This PR intends to achieve the following:
- make the text consistent (the word "commands" alternate between the front or back of the text description)
- reduce redundancy (they are all commands, no need to use the word "command" to redefine them)

I looked at `git --help`, and I /really/ like the way that they organize their subcommands. However, such a change for DataLad would involve a pretty significant reorganization of the subcommand categories, which I anticipate would be controversial. I aim for this change to enter first, and if there's desire for a further refinement of organization, then that could follow.

Lastly, this PR removes an epilogue from the DataLad help. Accusations of me of being a curmudgeon would not be entirely out of line --- but I do find the current rendering to be confusing. If indeed we want people to be happy, we should not confuse them in the process.

If there's strong support for the retention of the terse-and-imperative-message-of-optimism, then I can amend this PR to adjust the surrounding whitespace.

### Changelog
#### 📝 Documentation
- Command categories in help text are more consistently named.
