### PR TITLE
Fix datalad --help to not have *Global options* empty and list options in "options:" section

### DIFF
--- a/changelog.d/pr-7028.md
+++ b/changelog.d/pr-7028.md
@@ -1,0 +1,6 @@
+### Bug Fixes
+
+- Fix datalad --help to not have *Global options* empty with python 3.10 and
+  list options in "options:" section.
+  [PR #7028](https://github.com/datalad/datalad/pull/7028)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -78,7 +78,7 @@ class HelpAction(argparse.Action):
         options = []
         in_options = False
         for line in helpstr.splitlines():
-            if line == 'optional arguments:':
+            if line in ('options:', 'optional arguments:'):
                 in_options = True
                 continue
             (options if in_options else preamble).append(line)

--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -149,6 +149,14 @@ def test_help_np():
         # should be present only one time!
         eq_(stdout.count(s), 1)
 
+    # check that we have global options actually listed after "Global options"
+    # ATM -c is the first such option
+    assert re.search(r"Global options\W*-c ", stdout, flags=re.MULTILINE)
+    # and -c should be listed only once - i.e. that we do not duplicate sections
+    # and our USAGE summary has only [global-opts]
+    assert re.match("Usage: .*datalad.* \[global-opts\] command \[command-opts\]", stdout)
+    assert stdout.count(' -c ') == 1
+
     assert_all_commands_present(stdout)
 
     if not get_terminal_size()[0] or 0:


### PR DESCRIPTION
Detected while considering #7027 (note: that one is against `master`, this one -- `maint`)

I believe came up as a regression of e89ce439a3b24607e4809a664a961a678063cded and since we had no unittest. So I also added a test.

Without this fix  --help looked like

	options:
	  -c (:name|name=value)
	...
	*Global options*

and nothing at the end after *Global options*.
