### PR TITLE
Update chardet version limit from 5 to 6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from _datalad_build_support.setup import (
 requires = {
     'core': [
         'platformdirs',
-        'chardet>=3.0.4, <5.0.0',      # rarely used but small/omnipresent
+        'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
         'importlib-metadata >=3.6; python_version < "3.10"',


### PR DESCRIPTION
#6777 is obsolete with psf/requests#6179. Could also remove the upper limit since it seems requests wants to drop the dependency eventually (https://github.com/psf/requests/issues/6177#issuecomment-1168148782).

### Changelog
#### 🏠 Internal
- Update chardet version limit to allow ver 5, matching `requests` dependencies.