### PR TITLE
Remove `simplejson` in favor of using `json`

### DIFF
--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -138,16 +138,16 @@ def test_help_np():
     ok_startswith(stdout, 'Usage: datalad')
     # Sections start/end with * if ran under DATALAD_HELP2MAN mode
     sections = [l[1:-1] for l in filter(re.compile(r'^\*.*\*$').match, stdout.split('\n'))]
-    for s in {'Essential commands',
-              'Commands for metadata handling',
-              'Miscellaneous commands',
+    for s in {'Essential',
+              'Metadata',
+              'Miscellaneous',
               'General information',
               'Global options',
-              'Plumbing commands',
+              'Plumbing',
               }:
         assert_in(s, sections)
         # should be present only one time!
-        eq_(stdout.count(s), 1)
+        eq_(stdout.count(f"*{s}*"), 1)
 
     assert_all_commands_present(stdout)
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -54,8 +54,6 @@ from datalad.runner.utils import (
     AssemblingDecoderMixIn,
     LineSplitter,
 )
-# must not be loads, because this one would log, and we need to log ourselves
-from datalad.support.json_py import json_loads
 from datalad.support.exceptions import CapturedException
 from datalad.support.annex_utils import (
     _fake_json_for_non_existing,
@@ -3677,14 +3675,12 @@ class AnnexJsonProtocol(WitlessProtocol):
             data = self._unprocessed + data
             self._unprocessed = None
         # this is where the JSON records come in
-        # json_loads() is already logging any error, which is OK, because
-        # under no circumstances we would expect broken JSON
         lines = data.splitlines()
         data_ends_with_eol = data.endswith(os.linesep.encode())
         del data
         for iline, line in enumerate(lines):
             try:
-                j = json_loads(line)
+                j = json.loads(line)
             except Exception as exc:
                 if line.strip():
                     # do not complain on empty lines

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3990,4 +3990,9 @@ def readlines_until_ok_or_failed(stdout, maxlines=100):
 
 def readline_json(stdout):
     toload = stdout.readline().strip()
-    return json_loads(toload) if toload else {}
+    try:
+        return json.loads(toload) if toload else {}
+    except json.JSONDecodeError:
+        lgr.error('Received undecodable JSON output: %s', line)
+        raise
+

--- a/datalad/support/json_py.py
+++ b/datalad/support/json_py.py
@@ -20,13 +20,7 @@ from os.path import (
 from os import makedirs
 import os
 import os.path as op
-
-# wrapped below
-from simplejson import load as jsonload
-from simplejson import dump as jsondump
-# simply mirrored for now
-from simplejson import loads as json_loads
-from simplejson import JSONDecodeError
+import json
 
 from datalad.support.exceptions import CapturedException
 
@@ -36,8 +30,7 @@ json_dump_kwargs = dict(
     indent=0,
     separators=(',', ':\n'),
     sort_keys=True,
-    ensure_ascii=False,
-    encoding='utf-8', )
+    ensure_ascii=False,)
 
 # achieve minimal representation, but still deterministic
 compressed_json_dump_kwargs = dict(
@@ -90,7 +83,7 @@ def dump2fileobj(obj, fileobj, **kwargs):
     **kwargs
       Keyword arguments to be passed on to simplejson.dump()
     """
-    return jsondump(
+    return json.dump(
         obj,
         codecs.getwriter('utf-8')(fileobj),
         **kwargs)
@@ -122,7 +115,7 @@ def dump2stream(obj, fname, compressed=False):
     with _open(fname, mode='wb') as f:
         jwriter = codecs.getwriter('utf-8')(f)
         for o in obj:
-            jsondump(o, jwriter, **compressed_json_dump_kwargs)
+            json.dump(o, jwriter, **compressed_json_dump_kwargs)
             f.write(b'\n')
 
 
@@ -156,7 +149,7 @@ def load_xzstream(fname):
 def loads(s, *args, **kwargs):
     """Helper to log actual value which failed to be parsed"""
     try:
-        return json_loads(s, *args, **kwargs)
+        return json.loads(s, *args, **kwargs)
     except:
         lgr.error(
             "Failed to load content from %r with args=%r kwargs=%r"
@@ -183,8 +176,8 @@ def load(fname, fixup=True, compressed=None, **kw):
     with _suitable_open(fname, compressed)(fname, 'rb') as f:
         try:
             jreader = codecs.getreader('utf-8')(f)
-            return jsonload(jreader, **kw)
-        except JSONDecodeError as exc:
+            return json.load(jreader, **kw)
+        except json.JSONDecodeError as exc:
             if not fixup:
                 raise
             ce = CapturedException(exc)

--- a/datalad/support/tests/test_json_py.py
+++ b/datalad/support/tests/test_json_py.py
@@ -9,9 +9,9 @@
 
 import logging
 import os.path as op
+from json import JSONDecodeError
 
 from datalad.support.json_py import (
-    JSONDecodeError,
     dump,
     dump2stream,
     dump2xzstream,


### PR DESCRIPTION
Fixes issue #7034 

This PR removes `simplejson` in favor of the "builtin" `json`-module. 

Remark: this changes are also contained in PR #7014 

In addition this PR fixes the test `datalad.cli.tests.test_main.test_help_np`, by adapting the group names used in the test to the group names of the command groups.

### Changelog
#### 🪓 Deprecations and removals
- replace `simplejson` with `json` and remove `simplejson`