### PR TITLE
Let `create` touch the dataset root, if not saving in parent dataset

### DIFF
--- a/changelog.d/pr-7036.md
+++ b/changelog.d/pr-7036.md
@@ -1,0 +1,5 @@
+### Bug Fixes
+
+- Let `create` touch the dataset root, if not saving in parent dataset.  [PR
+  #7036](https://github.com/datalad/datalad/pull/7036) (by
+  [@mih](https://github.com/mih))

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -450,6 +450,12 @@ class Create(Interface):
                 return_type='generator',
                 result_renderer='disabled',
             )
+        else:
+            # if we do not save, we touch the root directory of the new
+            # dataset to signal a change in the nature of the directory.
+            # this is useful for apps like datalad-gooey (or other
+            # inotify consumers) to pick up on such changes.
+            tbds.pathobj.touch()
 
         res.update({'status': 'ok'})
         yield res


### PR DESCRIPTION
This communicates the "nature change" of the directory (from plain to dataset) to systems like inotify.

Without this, a dataset creation in an existing, empty subdirectory would go undiscovered, unless the empty subdirectory is explicitly watched itself.

With this change, that comes at virtually no additional cost, it is sufficient to watch the parent directory if the previously empty target subdirectory.