### PR TITLE
Let get_status_dict() use exception message if none is passed

### DIFF
--- a/changelog.d/pr-7037.md
+++ b/changelog.d/pr-7037.md
@@ -1,0 +1,5 @@
+### Bug Fixes
+
+- Let get_status_dict() use exception message if none is passed.  [PR
+  #7037](https://github.com/datalad/datalad/pull/7037) (by
+  [@mih](https://github.com/mih))

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -107,6 +107,8 @@ def get_status_dict(action=None, ds=None, path=None, type=None, logger=None,
             if isinstance(exception, CapturedException) \
             else format_oneline_tb(
                 exception, include_str=False)
+        if error_message is None and isinstance(exception, CapturedException):
+            d['error_message'] = exception.message
         if isinstance(exception, CommandError):
             d['exit_code'] = exception.code
     if kwargs:


### PR DESCRIPTION
A result with an exception attached has no error message, unless one is explicitly given, even when the exception is a CapturedException and could provide a message.

This change reports such an exception-provided message in the result.