### PR TITLE
Make choices for `status|diff --annex` and `status|diff --untracked` …

### DIFF
--- a/changelog.d/pr-7039.md
+++ b/changelog.d/pr-7039.md
@@ -1,0 +1,5 @@
+### Bug Fixes
+
+- Make choices for `status|diff --annex` and `status|diff --untracked` ….  [PR
+  #7039](https://github.com/datalad/datalad/pull/7039) (by
+  [@mih](https://github.com/mih))

--- a/changelog.d/pr-7039.md
+++ b/changelog.d/pr-7039.md
@@ -1,5 +1,5 @@
 ### Bug Fixes
 
-- Make choices for `status|diff --annex` and `status|diff --untracked` ….  [PR
+- Make choices for `status|diff --annex` and `status|diff --untracked` visible.  [PR
   #7039](https://github.com/datalad/datalad/pull/7039) (by
   [@mih](https://github.com/mih))

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -66,7 +66,6 @@ _common_diffstatus_params = dict(
         constraints=EnsureDataset() | EnsureNone()),
     annex=Parameter(
         args=('--annex',),
-        metavar='MODE',
         # the next two enable a sole `--annex` that auto-translates to
         # `--annex basic`
         const='basic',
@@ -88,7 +87,6 @@ _common_diffstatus_params = dict(
         """),
     untracked=Parameter(
         args=('--untracked',),
-        metavar='MODE',
         constraints=EnsureChoice('no', 'normal', 'all'),
         doc="""If and how untracked content is reported when comparing
         a revision to the state of the working tree. 'no': no untracked


### PR DESCRIPTION
…visible

Now:

```
Usage: datalad diff [-h] [-f REVISION] [-t REVISION] [-d DATASET]
                    [--annex [{basic|availability|all}]]
                    [--untracked {no|normal|all}] [-r] [-R LEVELS]
                    [--version]
                    [PATH ...]
```