### PR TITLE
Fix leftout Miscellaneous commands in a test

### DIFF
--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -140,7 +140,7 @@ def test_help_np():
     sections = [l[1:-1] for l in filter(re.compile(r'^\*.*\*$').match, stdout.split('\n'))]
     for s in {'Essential commands',
               'Commands for metadata handling',
-              'Miscellaneous commands',
+              'Miscellaneous',
               'General information',
               'Global options',
               'Plumbing commands',


### PR DESCRIPTION
Redness fatigue made us merge https://github.com/datalad/datalad/pull/7027 without seeing that test failed.  Daily tests of datalad/git-annex started to fail which let me to detect this
