### PR TITLE
Adapt tests to modified command group names

### DIFF
--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -138,16 +138,16 @@ def test_help_np():
     ok_startswith(stdout, 'Usage: datalad')
     # Sections start/end with * if ran under DATALAD_HELP2MAN mode
     sections = [l[1:-1] for l in filter(re.compile(r'^\*.*\*$').match, stdout.split('\n'))]
-    for s in {'Essential commands',
-              'Commands for metadata handling',
-              'Miscellaneous commands',
+    for s in {'Essential',
+              'Metadata',
+              'Miscellaneous',
               'General information',
               'Global options',
-              'Plumbing commands',
+              'Plumbing',
               }:
         assert_in(s, sections)
         # should be present only one time!
-        eq_(stdout.count(s), 1)
+        eq_(stdout.count(f'*{s}*'), 1)
 
     assert_all_commands_present(stdout)
 


### PR DESCRIPTION
This PR fixes the test that verifies the command group names. It basically adapts the verified command group names to the changes from 8decbdc7c63d869665c5711a21aa9e837eda6f9f. This should fix a bunch of failing tests on `master` that are run on *Travis* and *Appveyor*

### Changelog
#### 🏠 Internal
- Fix an error in the command group names-test
