### PR TITLE
BF: use default GITHUB_TOKEN for release workflow instead of a GITMATE one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           python -m build
           twine upload dist/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITMATE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 


### PR DESCRIPTION
after https://github.com/datalad/datalad/pull/7024 we got release workflow erroring out with

	+ python3 tools/ci/release-comment.py datalad datalad 0.17.6 changelog.d/pr-6997.md changelog.d/pr-7009.md changelog.d/pr-7011.md changelog.d/pr-7024.md changelog.d/pr-7028.md changelog.d/pr-7036.md changelog.d/pr-7037.md changelog.d/pr-7039.md changelog.d/pr-7041.md Traceback (most recent call last): File "/home/runner/work/datalad/datalad/tools/ci/release-comment.py", line 160, in <module> main() File "/home/runner/work/datalad/datalad/tools/ci/release-comment.py", line 148, in main rc.comment_on_pr(prnum) File "/home/runner/work/datalad/datalad/tools/ci/release-comment.py", line 108, in comment_on_pr self.comment_on_issueoid( File "/home/runner/work/datalad/datalad/tools/ci/release-comment.py", line 123, in comment_on_issueoid r.raise_for_status() File "/opt/hostedtoolcache/Python/3.10.6/x64/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status raise HTTPError(http_error_msg, response=self) requests.exceptions.HTTPError: [40](https://github.com/datalad/datalad/actions/runs/3084869492/jobs/4987517315#step:7:41)1 Client Error: Unauthorized for url: https://api.github.com/repos/datalad/datalad/issues/6997/comments Error: Process completed with exit code 1.

so may be it was not the best
[decision](https://github.com/datalad/datalad/pull/7024#issuecomment-1251075505) to use dedicated (but likely more limited in scopes) yarikoptic-gitmate token. I think it would be good to just revert to use that generic token instead of trying to figure out the scope and assigning a "better" gitmate one.

no changelog is needed

@jwodder - anything I might be missing which would forbid using default token here?