### PR TITLE
Give more information about used token and performed actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           python -m build
           twine upload dist/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITMATE_GITHUB_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 

--- a/tools/ci/release-comment.py
+++ b/tools/ci/release-comment.py
@@ -134,6 +134,9 @@ def main():
         token = os.environ["GITHUB_TOKEN"]
     except KeyError:
         sys.exit("GITHUB_TOKEN not set")
+    if not token:
+        sys.exit("GITHUB_TOKEN is set to an empty value")
+    print(f"GITHUB_TOKEN begins with {token[:6]}")
     with ReleaseCommenter(
         repo_owner=args.repo_owner,
         repo_name=args.repo_name,
@@ -141,12 +144,14 @@ def main():
         token=token,
     ) as rc:
         for name in args.pr_snippets:
+            print(f"Processing {name}")
             basename = os.path.basename(name)
             m = re.fullmatch(r"pr-(\d+)(?:\.[a-z]+)?", basename)
             if m:
                 prnum = int(m[1])
                 rc.comment_on_pr(prnum)
                 for issue in rc.get_closed_issues(prnum):
+                    print(f" commenting on issue {issue}")
                     rc.comment_on_issue(issue)
             else:
                 print(


### PR DESCRIPTION
We have an odd behavior in being unable to comment on issues, and looks like if GITHUB_TOKEN was set to an empty value. Here we will error out if empty and otherwise reveal the beginning of it which by itself should not be leaking too much of a secret to do any harm.

Also print about actions being performed since now it is just silently does its deeds

[ci skip]
[appveyor skip]
