### PR TITLE
push: Assume 0 bytes pushed if git-annex does not provide bytesize

### DIFF
--- a/changelog.d/pr-7049.md
+++ b/changelog.d/pr-7049.md
@@ -1,0 +1,5 @@
+### Bug Fixes
+
+- push: Assume 0 bytes pushed if git-annex does not provide bytesize.  [PR
+  #7049](https://github.com/datalad/datalad/pull/7049) (by
+  [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -888,7 +888,7 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
         else:
             file_list += bytes(Path(c['path']).relative_to(ds.pathobj))
             file_list += b'\0'
-            nbytes += c['bytesize']
+            nbytes += c.get('bytesize', 0)
             seen_keys.add(key)
     lgr.debug('Counted %d bytes of annex data to transfer',
               nbytes)


### PR DESCRIPTION
Otherwise we can get KeyError and underlying code can provide records without bytesize. Reported in https://neurostars.org/t/datalad-push-causes-keyerror-bytesize-keyerror/23570 with 

datalad==0.15.4
git==2.35.0
git-annex==8.20210903

<details>
<summary>first I failed to reproduce with the following script following user report with --fast</summary> 

```shell
#!/bin/bash
# https://neurostars.org/t/datalad-push-causes-keyerror-bytesize-keyerror/23570
set -eu

cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-XXXXXXX)"
set -eu

datalad create -f .

git annex addurl --fast --file sample3.csv https://filesamples.com/samples/document/csv/sample3.csv
datalad save sample3.csv

git remote add --fetch gin git@gin.g-node.org:/yarikoptic/test-push.git
datalad -l debug push --to gin

```
</details>


<details>
<summary>but then reproduced nicely with --relaxed</summary> 

```shell
#!/bin/bash
# https://neurostars.org/t/datalad-push-causes-keyerror-bytesize-keyerror/23570
set -eu

cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-XXXXXXX)"
set -eu

datalad create -f .

git annex addurl --relaxed --file sample3.csv https://filesamples.com/samples/document/csv/sample3.csv
datalad save sample3.csv

ls -l 

git remote add --fetch gin git@gin.g-node.org:/yarikoptic/test-push.git
datalad push --to gin --force=all
```
</details>

and verified that with this PR we do not crash.  Given that git-annex unlikely to even provide progress report if not enough time passed, I think I would not bother crafting a unittest which would trigger this condition atm.  