### PR TITLE
More correct summary reporting for relaxed (no size) --annex

### DIFF
--- a/changelog.d/pr-7050.md
+++ b/changelog.d/pr-7050.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- More correct summary reporting for relaxed (no size) --annex.  [PR #7050](https://github.com/datalad/datalad/pull/7050) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -461,10 +461,10 @@ class Status(Interface):
         # fish out sizes of annexed files. those will only be present
         # with --annex ...
         annexed = [
-            (int(r['bytesize']), r.get('has_content', None))
+            (int(r.get('bytesize', 0)), r.get('has_content', None))
             for r in results
             if r.get('action', None) == 'status' \
-            and 'key' in r and 'bytesize' in r]
+            and 'key' in r]
         if annexed:
             have_availability = any(a[1] is not None for a in annexed)
             total_size = bytes2human(sum(a[0] for a in annexed))


### PR DESCRIPTION
See individual commits for more info. Inspired by https://github.com/datalad/datalad/pull/7049 
- first commit - report at least correct number of annexed files
- 2nd - if relaxed file is present, takes its size from io.stat.  But may be we should move that logic into get_content_info or alike?

also thought to tune up `bytes2human` to not report odd looking float Byte sizes such as `1.0 B` instead of `1 B` but decided to not bother .

- [x] add changelog when taking out of draft. Want first to agree on the course of action