### PR TITLE
Trigger release workflow on `pull_request_target`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Auto-release on PR merge
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - maint
     types:


### PR DESCRIPTION
See #7048.

The change in this PR may or may not take effect in the workflow that is run when it is merged; to be safe, this PR should *not* be labelled with "release", and a separate "release" PR should be made after it is merged in order to test it.