### PR TITLE
DATALAD_TESTS_GITCONFIG env variable to provide custom settings for git during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     - PYTEST_SELECTION=
     - PYTEST_SELECTION_OP=not
   # Two matrix runs for "recent python and git-annex with the recent supported by git annex
-  # new version of repo"
+  # new version of repo" and various extra options/features enabled for git-annex
   - python: '3.10'
     dist: focal
     env:
@@ -64,6 +64,7 @@ matrix:
       - PYTEST_SELECTION_OP=not
       - DATALAD_REPO_VERSION=10
       - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex -m conda"
+      - DATALAD_TESTS_GITCONFIG="\n[annex]\n stalldetection = 1KB/120s\n"
   - python: '3.10'
     dist: focal
     env:
@@ -71,6 +72,7 @@ matrix:
       - PYTEST_SELECTION_OP=
       - DATALAD_REPO_VERSION=10
       - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex -m conda"
+      - DATALAD_TESTS_GITCONFIG="\n[annex]\n stalldetection = 1KB/120s\n"
   - if: type = cron
     python: 3.7
     # Single run for Python 3.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -612,6 +612,8 @@ Refer datalad/config.py for information on how to add these environment variable
   is - change behavior of tests, that decorated with any of the `known_failure`,
   to not skip, but executed and *fail* if they would pass (indicating that the
   decorator may be removed/reconsidered).
+- *DATALAD_TESTS_GITCONFIG*:
+  Additional content to add to `~/.gitconfig` in the tests `HOME` environment. `\n` is replaced with `os.linesep`.
 - *DATALAD_CMD_PROTOCOL*:
   Specifies the protocol number used by the Runner to note shell command or python function call times and allows for dry runs.
   'externals-time' for ExecutionTimeExternalsProtocol, 'time' for ExecutionTimeProtocol and 'null' for NullProtocol.

--- a/datalad/conftest.py
+++ b/datalad/conftest.py
@@ -89,7 +89,7 @@ def setup_package():
 	# allowed by default
 	allowed-url-schemes = http https file
 	allowed-http-addresses = all
-"""
+""" + os.environ.get('DATALAD_TESTS_GITCONFIG', '').replace('\\n', os.linesep)
             # TODO: split into a function + context manager
             with make_tempfile(mkdir=True) as new_home:
                 pass


### PR DESCRIPTION
Although could be just once in a lifetime bug, we just got into an odd issue with an unlocked file with content being marked as modified https://git-annex.branchable.com/bugs/reports_file___34__modified__34___whenever_it_is_not/#comment-4e61c4c0f493e98f9416e09de4cfb33f which seems to boil down to have a rarely used `annex.stalldetection` set.

By adding one more env variable for TESTS we can now add such specific setting to be tested in the tests.

TODOs
- [x] make sure that tests pass -- we do might trigger that issue