### PR TITLE
Revert "Remove chardet version upper limit" to bring back upper limit <= 5.0.0 on chardet 

### DIFF
--- a/changelog.d/pr-7057.md
+++ b/changelog.d/pr-7057.md
@@ -1,0 +1,3 @@
+### Internal
+
+- Revert "Remove chardet version upper limit" (introduced in 0.17.6~11^2) to bring back upper limit <= 5.0.0 on chardet. Otherwise we can get some deprecation warnings from requests [PR #7057](https://github.com/datalad/datalad/pull/7057) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from _datalad_build_support.setup import (
 requires = {
     'core': [
         'platformdirs',
-        'chardet>=3.0.4',      # rarely used but small/omnipresent
+        'chardet>=3.0.4, <5.0.0',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
         'importlib-metadata >=3.6; python_version < "3.10"',


### PR DESCRIPTION
This reverts commit 0f27cd5045883d814b27cb7d678449a98323f768.

Original change sounded kosher and "we agreed" with reasoning but original PR https://github.com/datalad/datalad/pull/7029 for some reason did not have Travis CI runs and now after it was merged we keep getting tests failed when submitting PRs against maint with failures like

	____________________________ test_run_datalad_help _____________________________
	[gw0] linux -- Python 3.8.6 /tmp/dl-miniconda-jm48jjoo/bin/python

		@assert_cwd_unchanged
		def test_run_datalad_help():
			out, err = check_run_and_get_output("datalad --help")
			ok_startswith(out, "Usage: ")
			# There could be a warning from coverage that no data was collected, should be benign
			lines = [l for l in err.split(os.linesep) if ('no-data-collected' not in l) and l]
	>       eq_(lines, [])

	../datalad/tests/test_installed.py:47:
	_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

	first = ["/tmp/dl-miniconda-jm48jjoo/lib/python3.8/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 ...ported version!", '  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn\'t match a supported "']
	second = [], msg = None

		def assert_equal(first, second, msg=None):
			if msg is None:
	>           assert first == second
	E           assert ['/tmp/dl-min... supported "'] == []
	E             Left contains 2 more items, first extra item: "/tmp/dl-miniconda-jm48jjoo/lib/python3.8/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.8) or chardet (5.0.0)/charset_normalizer (2.0.4) doesn't match a supported v
	ersion!"
	E             Full diff:
	E               [
	E             -  ,
	E             +  '/tmp/dl-miniconda-jm48jjoo/lib/python3.8/site-packages/requests/__init__.py:102: '
	E             +  'RequestsDependencyWarning: urllib3 (1.26.8) or chardet '
	E             +  "(5.0.0)/charset_normalizer (2.0.4) doesn't match a supported version!",
	E             +  '  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) '
	E             +  'doesn\'t match a supported "',
	E               ]

	../datalad/tests/utils_pytest.py:107: AssertionError

@kimsin98 feel welcome to reincarnate #7029 but we should make sure it doesn't break testing again -- there must be more to the story.