### PR TITLE
use GITMATE token for actual push of changelog

### DIFF
--- a/.github/workflows/add-changelog-snippet.yml
+++ b/.github/workflows/add-changelog-snippet.yml
@@ -59,5 +59,7 @@ jobs:
                git push origin HEAD:${{ github.head_ref }}
           else echo "No changes to commit"
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITMATE_GITHUB_TOKEN }}
 
 # vim:set et sts=2:

--- a/changelog.d/pr-7058.md
+++ b/changelog.d/pr-7058.md
@@ -1,0 +1,5 @@
+### Internal
+
+- use GITMATE token for actual push of changelog.  [PR
+  #7058](https://github.com/datalad/datalad/pull/7058) (by
+  [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
Without that we use default token and github actions still do not run, although there is no guarantee that this would change it

Supplement to #7024 (a73411af88186750d136a6aa465af76e6df13508)