### PR TITLE
Let `EnsureChoice` report the value is failed validating

### DIFF
--- a/changelog.d/pr-7067.md
+++ b/changelog.d/pr-7067.md
@@ -1,0 +1,5 @@
+### Bug Fixes
+
+- Let `EnsureChoice` report the value is failed validating.  [PR
+  #7067](https://github.com/datalad/datalad/pull/7067) (by
+  [@mih](https://github.com/mih))

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -299,7 +299,7 @@ class EnsureChoice(Constraint):
 
     def __call__(self, value):
         if value not in self._allowed:
-            raise ValueError("value is not one of %s" % (self._allowed,))
+            raise ValueError(f"value {value} is not one of {self._allowed}")
         return value
 
     def long_description(self):


### PR DESCRIPTION
Just that. Feel free to reject. It was just bothering me enough that I had this change in my local deployment to help me figure what is actually happening.