### PR TITLE
Ensure that `BatchedCommandError` is raised if the subprocesses of `BatchedCommand` fails or raises a `CommandError`

### DIFF
--- a/changelog.d/pr-7068.md
+++ b/changelog.d/pr-7068.md
@@ -1,6 +1,3 @@
 ### Internal
 
-- Ensure that `BatchedCommandError` is raised if the subprocesses of
-  `BatchedCommand` fails or raises a `CommandError`.  [PR
-  #7068](https://github.com/datalad/datalad/pull/7068) (by
-  [@christian-monch](https://github.com/christian-monch))
+- Ensure that `BatchedCommandError` is raised if the subprocesses of `BatchedCommand` fails or raises a `CommandError`.  [PR #7068](https://github.com/datalad/datalad/pull/7068) (by [@christian-monch](https://github.com/christian-monch))

--- a/changelog.d/pr-7068.md
+++ b/changelog.d/pr-7068.md
@@ -1,0 +1,6 @@
+### Internal
+
+- Ensure that `BatchedCommandError` is raised if the subprocesses of
+  `BatchedCommand` fails or raises a `CommandError`.  [PR
+  #7068](https://github.com/datalad/datalad/pull/7068) (by
+  [@christian-monch](https://github.com/christian-monch))

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -401,7 +401,7 @@ class BatchedCommand(SafeDelCloseMixin):
             if not self.process_running():
                 self._initialize()
 
-            # Remember request end send it to subprocess
+            # Remember request and send it to subprocess
             if not isinstance(request, str):
                 request = ' '.join(request)
             self.stdin_queue.put((request + "\n").encode())

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -336,7 +336,7 @@ class BatchedCommand(SafeDelCloseMixin):
                     msg=f"{type(self).__name__}: exited with {result} after "
                         f"request: {self.last_request}",
                     code=result
-                )
+                ) from CommandError
         return False
 
     def __call__(self,
@@ -402,7 +402,7 @@ class BatchedCommand(SafeDelCloseMixin):
                 stderr=command_error.stderr,
                 cwd=command_error.cwd,
                 **command_error.kwargs
-            )
+            ) from command_error
 
         finally:
             self._active -= 1

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -222,7 +222,7 @@ class BatchedCommand(SafeDelCloseMixin):
         self.runner: Optional[WitlessRunner] = None
         self.encoding = None
         self.wait_timed_out = None
-        self.return_code = None
+        self.return_code: Optional[int] = None
         self._abandon_cache = None
         self.last_request: Optional[str] = None
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2766,8 +2766,9 @@ class AnnexRepo(GitRepo, RepoInterface):
                     ':'.join(annex_cmd), annex_cmd,
                     path=self.path)(key_)
             except CommandError:
-                # git-annex will signal an unknown remote by exiting with
-                # return code 1.
+                # git-annex runs in batch mode, but will still signal some
+                # errors, e.g. an unknown remote, by exiting with a non-zero
+                # return code.
                 return False
             try:
                 return {

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -2761,9 +2761,14 @@ class AnnexRepo(GitRepo, RepoInterface):
                 return False
         else:
             annex_cmd = ["checkpresentkey"] + ([remote] if remote else [])
-            out = self._batched.get(
-                ':'.join(annex_cmd), annex_cmd,
-                path=self.path)(key_)
+            try:
+                out = self._batched.get(
+                    ':'.join(annex_cmd), annex_cmd,
+                    path=self.path)(key_)
+            except CommandError:
+                # git-annex will signal an unknown remote by exiting with
+                # return code 1.
+                return False
             try:
                 return {
                     # happens on travis in direct/heavy-debug mode, that process

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -170,7 +170,7 @@ exit(3)
     with pytest.raises(BatchedCommandError) as exception_info:
         bc("line two")
     assert exception_info.value.code == 3
-    assert exception_info.value.request == first_request
+    assert exception_info.value.last_processed_request == first_request
     assert bc.return_code == 3
 
     # Check for restart
@@ -194,7 +194,7 @@ print(a*b)
     with pytest.raises(BatchedCommandError) as exception_info:
         _ = bc(first_request)
     assert exception_info.value.code == 1
-    assert exception_info.value.request is None
+    assert exception_info.value.last_processed_request is None
     assert bc.return_code == 1
     assert bc.last_request is None
     bc.close(return_stderr=False)


### PR DESCRIPTION
Fixes #6834

This PR ensures that `BatchedCommand` raises a `BatchedCommandError` if the subprocesses of `BatchedCommand` exits with a non-zero value or raises a `CommandError`.


### Changelog
#### 🐛 Bug Fixes
- Adapt `BatchedCommand`-tests to actual behavior. Fixes #6834
#### 💫 Enhancements and new features
- Ensure the errors from sub-processes of `BatchedCommand` are signaled to the caller via `BatchedCommandError`-exception
