### PR TITLE
NF: foreach-dataset --o-s relpath - capture and pass-through prefixing with path to subds

### DIFF
--- a/changelog.d/pr-7071.md
+++ b/changelog.d/pr-7071.md
@@ -1,0 +1,7 @@
+### 🚀 Enhancements and New Features
+
+- `foreach-dataset` command got a new possible value for the --output-streamns|--o-s
+  option 'relpath' to capture and pass-through prefixing with path to subds.  Very
+  handy for e.g. running `git grep` command across subdatasets.
+  [PR #7071](https://github.com/datalad/datalad/pull/7071)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/local/foreach_dataset.py
+++ b/datalad/local/foreach_dataset.py
@@ -13,6 +13,9 @@ __docformat__ = 'restructuredtext'
 
 import inspect
 import logging
+import os.path as op
+import sys
+from typing import Union
 
 from argparse import REMAINDER
 from itertools import chain
@@ -167,9 +170,11 @@ class ForEachDataset(Interface):
             `contains` is used"""),
         output_streams=Parameter(
             args=("--output-streams", "--o-s"),
-            constraints=EnsureChoice('capture', 'pass-through'),
-            doc="""whether to capture and return outputs from 'cmd' in the record ('stdout', 'stderr') or
-            just 'pass-through' to the screen (and thus absent from returned record)."""),
+            constraints=EnsureChoice('capture', 'pass-through', 'relpath'),
+            doc="""ways to handle outputs. 'capture' and return outputs from 'cmd' in the record ('stdout',
+            'stderr'); 'pass-through' to the screen (and thus absent from returned record); prefix with 'relpath'
+            and just pass-through (similar to like grep does), and if `dataset` is specified - relative to top
+            of that dataset, if not - to current directory."""),
         chpwd=Parameter(
             args=("--chpwd",),
             constraints=EnsureChoice('ds', 'pwd'),
@@ -316,7 +321,7 @@ class ForEachDataset(Interface):
                         if output_streams == 'pass-through':
                             res = cmd_f(*cmd_a, **cmd_kw)
                             out = {}
-                        elif output_streams == 'capture':
+                        elif output_streams in ('capture', 'relpath'):
                             with swallow_outputs() as cmo:
                                 res = cmd_f(*cmd_a, **cmd_kw)
                                 out = {
@@ -342,7 +347,7 @@ class ForEachDataset(Interface):
                         cmd_expanded,
                         cwd=ds.path if chpwd == 'ds' else pwd,
                         protocol=protocol)
-                if output_streams == 'capture':
+                if output_streams in ('capture', 'relpath'):
                     status_rec.update(out)
                     # provide some feedback to user in default rendering
                     if any(out.values()):
@@ -377,7 +382,7 @@ class ForEachDataset(Interface):
                     warning += \
                         "Execution of Python commands in parallel threads while changing directory " \
                         "is not thread-safe. "
-                if output_streams == 'capture':
+                if output_streams in ('capture', 'relpath'):
                     warning += \
                         "Execution of Python commands in parallel while capturing output is not possible."
                 if warning:
@@ -395,6 +400,33 @@ class ForEachDataset(Interface):
             **pc_kw
         )
 
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        from datalad.interface.utils import generic_result_renderer
+        if kwargs.get('output_streams') == 'relpath':
+            from datalad.log import no_progress
+            with no_progress():
+                ds: Union[str, Dataset] = kwargs.get('dataset')
+                if ds:
+                    if not isinstance(ds, Dataset):
+                        ds = Dataset(ds)  # so all ///, ^ etc get treated
+                    refpath = ds.path
+                else:
+                    refpath = getpwd()
+                for k in ('stdout', 'stderr'):
+                    v = res.get(k)
+                    if v:
+                        path = res.get('path')
+                        relpath = op.relpath(path, refpath) if path else ''
+                        if relpath == op.curdir:
+                            relpath = ''
+                        if relpath and not relpath.endswith(op.sep):
+                            relpath += op.sep
+                        out = getattr(sys, k)
+                        for l in v.splitlines():
+                            out.write(f"{relpath}{l}\n")
+        else:
+            generic_result_renderer(res)
 
 # Reduced version from run
 def format_command(command, **kwds):

--- a/datalad/local/foreach_dataset.py
+++ b/datalad/local/foreach_dataset.py
@@ -173,8 +173,9 @@ class ForEachDataset(Interface):
             constraints=EnsureChoice('capture', 'pass-through', 'relpath'),
             doc="""ways to handle outputs. 'capture' and return outputs from 'cmd' in the record ('stdout',
             'stderr'); 'pass-through' to the screen (and thus absent from returned record); prefix with 'relpath'
-            and just pass-through (similar to like grep does), and if `dataset` is specified - relative to top
-            of that dataset, if not - to current directory."""),
+            captured output (similar to like grep does) and write to stdout and stderr. In 'relpath', relative path
+            is relative to the top of the dataset if `dataset` is specified, and if not - relative to current
+            directory."""),
         chpwd=Parameter(
             args=("--chpwd",),
             constraints=EnsureChoice('ds', 'pwd'),

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Logging setup and utilities, including progress reporting"""
 
+from contextlib import contextmanager
 from functools import partial
 import inspect
 import logging
@@ -546,6 +547,16 @@ def with_progress(items, lgrcall=None, label="Total", unit=" Files"):
             label=label, update=1, increment=True,
             noninteractive_level=5)
     log_progress(lgr.info, pid, "%s: done", base_label, noninteractive_level=5)
+
+
+@contextmanager
+def no_progress():
+    """Context manager to clear progress bars for the duration of the context"""
+    log_progress(lgr.info, None, 'Clear progress bars', maint='clear',
+                 noninteractive_level=5)
+    yield
+    log_progress(lgr.info, None, 'Refresh progress bars', maint='refresh',
+                 noninteractive_level=5)
 
 
 class LoggerHelper(object):

--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -71,26 +71,23 @@ class ConsoleLog(object):
         self.out = out
 
     def message(self, msg, cr='\n'):
-        from datalad.log import log_progress
-        log_progress(lgr.info, None, 'Clear progress bars', maint='clear',
-                     noninteractive_level=5)
-        try:
-            self.out.write(msg)
-        except UnicodeEncodeError as e:
-            # all unicode magic has failed and the receiving end cannot handle
-            # a particular unicode char. rather than crashing, we replace the
-            # offending chars to be able to message at least something, and we
-            # log that we did that
-            encoding = self.out.encoding
-            lgr.debug(
-                "Replacing unicode chars in message output for display: %s",
-                e)
-            self.out.write(
-                msg.encode(encoding, "replace").decode(encoding))
-        if cr:
-            self.out.write(cr)
-        log_progress(lgr.info, None, 'Refresh progress bars', maint='refresh',
-                     noninteractive_level=5)
+        from datalad.log import no_progress
+        with no_progress():
+            try:
+                self.out.write(msg)
+            except UnicodeEncodeError as e:
+                # all unicode magic has failed and the receiving end cannot handle
+                # a particular unicode char. rather than crashing, we replace the
+                # offending chars to be able to message at least something, and we
+                # log that we did that
+                encoding = self.out.encoding
+                lgr.debug(
+                    "Replacing unicode chars in message output for display: %s",
+                    e)
+                self.out.write(
+                    msg.encode(encoding, "replace").decode(encoding))
+            if cr:
+                self.out.write(cr)
 
     def error(self, error):
         self.message("ERROR: %s" % error)

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -199,7 +199,7 @@ def test_message_pbar_state_logging_is_demoted():
     lgr = LoggerHelper(name).get_initialized_logger()
     ui = ConsoleLog()
 
-    with patch("datalad.ui.dialog.lgr", lgr):
+    with patch("datalad.log.lgr", lgr):
         with swallow_logs(name=name, new_level=20) as cml:
             ui.message("testing 0")
             assert_not_in("Clear progress bars", cml.out)

--- a/docs/source/design/progress_reporting.rst
+++ b/docs/source/design/progress_reporting.rst
@@ -199,4 +199,6 @@ particular activity identifier (it always impacts all active progress bars):
 This call will trigger a temporary discontinuation of any progress bar display.
 Progress bars can either be re-enabled all at once, by an analog message with
 ``maint='refresh'``, or will re-show themselves automatically when the next
-update is received.
+update is received. A :py:func:`~datalad.log.no_progress` context manager helper
+can be used to surround your context with those two calls to prevent progress
+bars from interfering.


### PR DESCRIPTION
First commit is just a helper, 2nd is the actual changes with following ATM description:

Motivation for this feature is frequent use of  `foreach-dataset  git grep PATTERN` on e.g
captured by con/tinuous logs as I did in e.g. https://github.com/datalad/datalad/issues/6848 :

    $> datalad foreach-dataset "git grep 'FAILED .*test_nested_pushclone_cycle_allplatforms'  | grep cron || :"
    foreach-dataset(ok): /mnt/datasets/datalad/ci/logs/2022 (dataset)
    03/cron/20220603T193647/173dc6f/travis-14100-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
    foreach-dataset(ok): /mnt/datasets/datalad/ci/logs/2022/01 (dataset)
    10/cron/20220610T193717/029f839/travis-14136-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
    20/cron/20220520T193556/84f979a/travis-14036-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
    27/cron/20220527T193600/310fd9f/travis-14055-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
    foreach-dataset(ok): /mnt/datasets/datalad/ci/logs/2022/06 (dataset)
    foreach-dataset(ok): /mnt/datasets/datalad/ci/logs/2022/05 (dataset) 
    ...

As you could see - the default pass-through + default rendering there is "suboptimal" since

- main hurdle: paths from `grep` are relative to that subdataset and not
  readily cut-pasteable since we need to join with subdataset path first
- pollutes with default renderer 'ok' or not for  a given dataset (hence needed
  || : to avoid complains)
- prints all those (ok) which we do not quite care about -- we just want to see output
  as this hierarchy was a single dataset, so if nothing hit -- we just carry forward.

With this PR and "relpath" mode, we adjust renderer so that output looks like:

    (git)smaug:/mnt/datasets/datalad/ci/logs/2022[master]git
    $> datalad foreach-dataset --o-s relpath "git grep 'FAILED .*test_nested_pushclone_cycle_allplatforms'  | grep cron "
    06/03/cron/20220603T193647/173dc6f/travis-14100-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
    06/10/cron/20220610T193717/029f839/travis-14136-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
    05/20/cron/20220520T193556/84f979a/travis-14036-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
    05/27/cron/20220527T193600/310fd9f/travis-14055-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
    07/15/cron/20220715T194006/52e822a/travis-14276-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
  
pros:

- readily usable path which melded relative path to the subdataset
  with output of  grep
- since we ignore status -- no errors reported even though I had no ||:
- no useless ok's
- with "smart" treatment of either "dataset" argument is provided or not
  IMHO reported relative paths are quite neat despite C1 (below)
- I thought it could be sufficiently closely matched simply via
  `datalad -f '{path}{stdout}' foreach-dataset --o-s capture` but "not":

        $> datalad -f '{path}/{stdout}' foreach-dataset --o-s capture "git grep 'FAILED .*test_nested_pushclone_cycle_allplatforms'  | grep cron ||:"
        /mnt/datasets/datalad/ci/logs/2022/
        /mnt/datasets/datalad/ci/logs/2022/01/
        /mnt/datasets/datalad/ci/logs/2022/06/03/cron/20220603T193647/173dc6f/travis-14100-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
        10/cron/20220610T193717/029f839/travis-14136-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms

        /mnt/datasets/datalad/ci/logs/2022/05/20/cron/20220520T193556/84f979a/travis-14036-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms
        27/cron/20220527T193600/310fd9f/travis-14055-failed/14.txt:FAILED ../core/distributed/tests/test_push.py::test_nested_pushclone_cycle_allplatforms

        /mnt/datasets/datalad/ci/logs/2022/04/

  since we would get bunch of empty lines, those paths for datasets without hits etc.
  So - decided that it is worth adding this new mode

cons:

- C1: overfitting "grep" use case since we prefix with actual path and without
  any separation (like via :).  So may be we should name it `grep` instead of `relpath`.
- C2: someone might want full path! But hey -- there is a reason why I named it "relpath"

both cons somewhat point to may be choosing another, better describing name. **Please suggest one!**

Note: "relpath" idea in output rendering was more generally excercised but
never finalized in other PRs

- https://github.com/datalad/datalad/pull/2679
- https://github.com/datalad/datalad/pull/4454

and argued in https://github.com/datalad/datalad/issues/3994 to be "less useful" which I would disagree.

NB code is based off `maint` but positioning against master since a new feature, it would be a sin to propose to `maint`.