### PR TITLE
BF: don't write output from within sshrun

### DIFF
--- a/changelog.d/pr-7072.md
+++ b/changelog.d/pr-7072.md
@@ -1,0 +1,6 @@
+### Bug Fixes
+
+- Avoid writing to stdout/stderr from within datalad sshrun. This could lead to
+  broken pipe errors when cloning via SSH and was superfluous to begin with.
+  Fixes https://github.com/datalad/datalad/issues/6599 via
+  https://github.com/datalad/datalad/pull/7072 (by @bpoldrack)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1158,7 +1158,6 @@ def _postclonetest_prepare(lcl, storepath, storepath2, link):
 
 
 # TODO?: make parametric again on _test_ria_postclonecfg
-@known_failure_osx  # https://github.com/datalad/datalad/issues/6599
 @known_failure_windows  # https://github.com/datalad/datalad/issues/5134
 @slow  # 14 sec on travis
 def test_ria_postclonecfg():

--- a/datalad/support/sshconnector.py
+++ b/datalad/support/sshconnector.py
@@ -174,11 +174,13 @@ class BaseSSHConnection(object):
           (probably most) of the available configuration options should not be
           set here because they can critically change the properties of the
           connection. This exists to allow options like SendEnv to be set.
+        log_output: bool
+          Whether to capture and return stdout+stderr.
 
         Returns
         -------
         tuple of str
-          stdout, stderr of the command run.
+          stdout, stderr of the command run, if `log_output` was `True`
         """
         raise NotImplementedError
 

--- a/datalad/support/sshrun.py
+++ b/datalad/support/sshrun.py
@@ -116,10 +116,13 @@ class SSHRun(Interface):
         # use an empty temp file as stdin if none shall be connected
         stdin_ = tempfile.TemporaryFile() if no_stdin else sys.stdin
         try:
-            out, err = ssh(cmd, stdin=stdin_, log_output=False,
-                           options=options)
+            # We pipe the SSH process' stdout/stderr by means of
+            # `log_output=False`. That's necessary to let callers - for example
+            # git-clone - communicate with the SSH process. Hence, we expect no
+            # output being returned from this call:
+            out, err = ssh(cmd, stdin=stdin_, log_output=False, options=options)
+            assert not out
+            assert not err
         finally:
             if no_stdin:
                 stdin_.close()
-        os.write(1, out.encode('UTF-8'))
-        os.write(2, err.encode('UTF-8'))


### PR DESCRIPTION
`datalad sshrun` explicitly calls SSH with `log_output=False` which results in the use of `NoCapture` protocol with the runner. Meaning, stdout/stderr of SSH is written out anyway already. When SSH returns, `sshrun` tried to write both to its stdout/stderr. But: It could not possibly have anything to write. That would not be an issue in and of itself, but `sshrun` is not necessarily used directly. In particular it is called by `git` (due to `GIT_SSH_COMMAND=datalad sshrun`). This resulted in a problem when apparently `git` has closed the pipe to its ssh executable (`sshrun`) already and we tried to write to it (although we really didn't even have something to write).

This ultimately led to issue datalad#6599, where the actual `ssh ... git-upload-pack` execution succeeded and returned 0, but `datalad sshrun` itself produced a broken pipe error trying to write to stdout and hence returning non-zero.

It's not entirely clear when exactly this happens. When exactly the pipe is closed may be depend on git version as the failing builds are running 2.35.1 (MacOS on appveyor) whereas otherbuilds have either newer or older versions of git. In any case:
There can't be anything to write out to begin with, so don't even try.

Closes #6599
Closes #7078