### PR TITLE
RF: remove unused code str-ing PurePath

### DIFF
--- a/changelog.d/pr-7073.md
+++ b/changelog.d/pr-7073.md
@@ -1,0 +1,5 @@
+### Bug Fixes
+
+- RF: remove unused code str-ing PurePath.  [PR
+  #7073](https://github.com/datalad/datalad/pull/7073) (by
+  [@yarikoptic](https://github.com/yarikoptic))

--- a/changelog.d/pr-7073.md
+++ b/changelog.d/pr-7073.md
@@ -1,4 +1,4 @@
-### Bug Fixes
+### Internal
 
 - RF: remove unused code str-ing PurePath.  [PR
   #7073](https://github.com/datalad/datalad/pull/7073) (by

--- a/datalad/dataset/repo.py
+++ b/datalad/dataset/repo.py
@@ -222,10 +222,6 @@ class PathBasedFlyweight(Flyweight):
         # Custom handling for few special abbreviations if defined by the class
         path_ = cls._flyweight_preproc_path(path)
 
-        # mirror what is happening in __init__
-        if isinstance(path, ut.PurePath):
-            path = str(path)
-
         # Sanity check for argument `path`:
         # raise if we cannot deal with `path` at all or
         # if it is not a local thing:


### PR DESCRIPTION
Is of no use since we operate on path_ not path down below that block. Originally introduced in b0258db13236491c6e582a16ee4fc3129f240f87 (#3191).

Should be safe since RI which is coming next can take Path just fine:

	❯ python -c 'from pathlib import Path; from datalad.support.network import RI; print(repr(RI(Path("/home"))))'
	PathRI(path='/home')
	❯ python -c 'from pathlib import Path; from datalad.support.network import RI; print(repr(RI("/home")))'
	PathRI(path='/home')
