### PR TITLE
BF: lock across threads check/instantiation of Flyweight instances

### DIFF
--- a/changelog.d/pr-7075.md
+++ b/changelog.d/pr-7075.md
@@ -1,0 +1,3 @@
+### Bug Fixes
+
+- BF: lock across threads check/instantiation of Flyweight instances.  Fixes [#6598](https://github.com/datalad/datalad/issues/6598) via [PR #7075](https://github.com/datalad/datalad/pull/7075) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/dataset/repo.py
+++ b/datalad/dataset/repo.py
@@ -11,6 +11,7 @@
 """
 
 import logging
+import threading
 
 from datalad.support.exceptions import InvalidInstanceRequestError
 from datalad.support.network import RI
@@ -65,6 +66,9 @@ class Flyweight(type):
     c = MyFlyweightClass('whatever', id=2)
     assert c is not a
     """
+
+    # to avoid parallel creation of (identical) instances
+    _lock = threading.Lock()
 
     def _flyweight_id_from_args(cls, *args, **kwargs):
         """create an ID from arguments passed to `__call__`
@@ -144,29 +148,35 @@ class Flyweight(type):
     def __call__(cls, *args, **kwargs):
 
         id_, new_args, new_kwargs = cls._flyweight_id_from_args(*args, **kwargs)
-        instance = cls._unique_instances.get(id_, None)
+        # Thread lock following block so we do not fall victim to
+        # race condition across threads trying to instantiate multiple
+        # instances. In principle we better have a lock per id_ but that mean we
+        # might race at getting "name specific lock" (Yarik did not research much),
+        # so keeping it KISS -- just lock instantiation altogether, but could be
+        # made smarter later on.
+        with cls._lock:
+            instance = cls._unique_instances.get(id_, None)
 
-        if instance is None or instance._flyweight_invalid():
-            # we have no such instance yet or the existing one is invalidated,
-            # so we instantiate:
-            instance = type.__call__(cls, *new_args, **new_kwargs)
-            cls._unique_instances[id_] = instance
-        else:
-            # we have an instance already that is not invalid itself; check
-            # whether there is a conflict, otherwise return existing one:
-            # TODO
-            # Note, that this might (and probably should) go away, when we
-            # decide how to deal with currently possible invalid constructor
-            # calls for the repo classes. In particular this is about calling
-            # it with different options than before, that might lead to
-            # fundamental changes in the repository (like annex repo version
-            # change or re-init of git)
+            if instance is None or instance._flyweight_invalid():
+                # we have no such instance yet or the existing one is invalidated,
+                # so we instantiate:
+                instance = type.__call__(cls, *new_args, **new_kwargs)
+                cls._unique_instances[id_] = instance
+            else:
+                # we have an instance already that is not invalid itself; check
+                # whether there is a conflict, otherwise return existing one:
+                # TODO
+                # Note, that this might (and probably should) go away, when we
+                # decide how to deal with currently possible invalid constructor
+                # calls for the repo classes. In particular this is about calling
+                # it with different options than before, that might lead to
+                # fundamental changes in the repository (like annex repo version
+                # change or re-init of git)
 
-            # force? may not mean the same thing
-            msg = cls._flyweight_reject(id_, *new_args, **new_kwargs)
-            if msg is not None:
-                raise InvalidInstanceRequestError(id_, msg)
-
+                # force? may not mean the same thing
+                msg = cls._flyweight_reject(id_, *new_args, **new_kwargs)
+                if msg is not None:
+                    raise InvalidInstanceRequestError(id_, msg)
         return instance
 
 

--- a/datalad/support/tests/test_parallel.py
+++ b/datalad/support/tests/test_parallel.py
@@ -268,7 +268,7 @@ def test_stalling(kill=False):
 
 
 @with_tempfile(mkdir=True)
-def test_parallel_singletons(topd=None):
+def test_parallel_flyweights(topd=None):
     from datalad.support.gitrepo import GitRepo
 
     # ProducerConsumer relies on unique args to consumer so we will provide 2nd different arg


### PR DESCRIPTION
As commented added to the comment says we might want (eventually) make locking smarter and per "id" since in principle we should be able to instantiate multiple separate instances in parallel.  Might be useful or even critical for parallel "create" and alike.  But I think such use-cases are rare so decided to KISS.  test added, so disable locking to see how things could go wrong (hint: there is more than 1 way ;) ).

Fixes #6598 