### PR TITLE
BF (regression fix): Do not yield "impossible" records by default while querying metadata

### DIFF
--- a/datalad/metadata/tests/test_search.py
+++ b/datalad/metadata/tests/test_search.py
@@ -602,8 +602,19 @@ def test_gen4_query_aggregated_metadata():
             )
             if metadata_result['status'] == 'impossible'
         ]
-        assert_equal(len(result), 2)
+        assert_equal(len(result), 0)
 
+        result = [
+            metadata_result
+            for metadata_result in query_aggregated_metadata(
+                reporton='all',
+                ds=DatasetMock('ds'),
+                aps=mocked_annotated_paths,
+                yield_impossible=True,
+            )
+            if metadata_result['status'] == 'impossible'
+        ]
+        assert_equal(len(result), 2)
 
 @with_tempfile(mkdir=True)
 def test_metadata_source_handling(temp_dir=None):


### PR DESCRIPTION
.... eh -- might not be needed/suboptimal since there is WiP https://github.com/datalad/datalad/pull/7001 but that one doesn't address neuroimaging fails since operates at "metadata" command level.  With this one i think neuroimaging would be "clean". But may be #7001 logic could/should be moved into `query_aggregated_metadata` instead @christian-monch ?