### PR TITLE
PR template: remove Changelog entries, refer to scriv

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,10 @@
 ### PR checklist
 
-- [ ] Provide an overview of the changes you're making and explain why you're proposing them, ideally in the form of a changelog (template below)
-- [ ] Include `Fixes #NNN` somewhere in the description if this PR addresses an existing issue.
+- [ ] Provide an overview of the changes you're making and explain why you're proposing them, ideally in the form of a changelog (use `scriv create` or add `CHANGELOG-missing` label to generate one from title).
+- [ ] Include `Fixes #NNN` somewhere in the description and `scriv` changelog entry if this PR addresses an existing issue.
 - [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
   Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
 - [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
 - [ ] **Delete these instructions**. :-)
 
 Thanks for contributing!
-
-### Changelog
-#### 🐛 Bug Fixes
-- Description... Fixes #issue
-#### 💫 Enhancements and new features
--
-#### 🪓 Deprecations and removals
--
-#### 📝 Documentation
--
-#### 🏠 Internal
--
-#### 🛡 Tests
--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 ### PR checklist
 
-- [ ] Provide an overview of the changes you're making and explain why you're proposing them, ideally in the form of a changelog (use `scriv create` or add `CHANGELOG-missing` label to generate one from title).
+- [ ] Provide an overview of the changes you're making and explain why you're proposing them.
+- [ ] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title;
+  or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).
 - [ ] Include `Fixes #NNN` somewhere in the description and `scriv` changelog entry if this PR addresses an existing issue.
 - [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
   Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.


### PR DESCRIPTION
Since we are migrating to an automation for changelog management with scriv, suggesting to describe changelog entry in description is suboptimal

- adds yet another way to specify changelog entries (thus - confusion)
- those entries would not be used and would get forgotten
- unlike scriv entries in a file included in the diff they cannot be easily provided "suggestions" to
- duplicate listing of agreed upon sections for the 3rd time (in addition to scriv.ini and action to add changelog entries)

thus, following our discussion at meetup, this PR removes changelog template from the PR template.