### PR TITLE
Update GitHub Actions action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[gh-actions]"
+      include: scope
+    target-branch: maint
+    labels:
+      - semver-internal

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,9 +23,9 @@ jobs:
         # See also the GIT_ASKPASS env var below
         git config --global core.askPass ""
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,6 +24,8 @@ jobs:
         git config --global core.askPass ""
 
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.7
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -12,9 +12,9 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,11 @@ jobs:
 
     steps:
     - name: Set up environment
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:  # no need for the history
         fetch-depth: 1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7'
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
           git config --global user.email "bot@datalad.org"
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '^3.8'
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,7 +13,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install shellcheck
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Run shellcheck
       run: |
         # I: running only on a subset of scripts which are shellcheck clean ATM

--- a/.github/workflows/test-nose.yml
+++ b/.github/workflows/test-nose.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -48,7 +48,7 @@ jobs:
         working-directory: __testhome__
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           directory: __testhome__
           fail_ci_if_error: false

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -28,6 +28,8 @@ jobs:
         git config --global user.name "GitHub Almighty"
 
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.7
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -27,9 +27,9 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -35,10 +35,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -36,6 +36,8 @@ jobs:
         git config --global user.name "GitHub Almighty"
 
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v4

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -22,6 +22,8 @@ jobs:
 
 
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v4

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -21,13 +21,13 @@ jobs:
         git config --global user.name "GitHub Almighty"
 
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
-    
+
     - name: Install git-annex
       run: |
         pip install datalad-installer
@@ -52,6 +52,6 @@ jobs:
         python -m pytest -c ../tox.ini -s -v --cov=datalad --cov-report=xml --pyargs datalad.core datalad.support
 
     - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: __testhome__/coverage.xml

--- a/.github/workflows/test_win2019_disabled
+++ b/.github/workflows/test_win2019_disabled
@@ -29,9 +29,9 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Set up git-annex

--- a/.github/workflows/test_win2019_disabled
+++ b/.github/workflows/test_win2019_disabled
@@ -30,6 +30,9 @@ jobs:
         git config --global user.name "GitHub Almighty"
 
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: Set up Python 3.7
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.7'
 

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -12,13 +12,13 @@ jobs:
     if: contains(github.repository, 'datalad/datalad')
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Tributors Update      
+      - name: Tributors Update
         uses: con/tributors@0.0.19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:        
+        with:
 
           # Single text list (space separated) of parsers, leave unset to auto-detect
           parsers: unset

--- a/changelog.d/pr-7082.md
+++ b/changelog.d/pr-7082.md
@@ -1,0 +1,5 @@
+### Internal
+
+- Update GitHub Actions action versions.  [PR
+  #7082](https://github.com/datalad/datalad/pull/7082) (by
+  [@jwodder](https://github.com/jwodder))

--- a/changelog.d/pr-7082.md
+++ b/changelog.d/pr-7082.md
@@ -1,5 +1,5 @@
 ### Internal
 
-- Update GitHub Actions action versions.  [PR
-  #7082](https://github.com/datalad/datalad/pull/7082) (by
+- Update GitHub Actions action versions.
+  [PR #7082](https://github.com/datalad/datalad/pull/7082) (by
   [@jwodder](https://github.com/jwodder))


### PR DESCRIPTION
We are currently using older versions of the updated GitHub Actions actions, and these older versions still use Node 12, [which is deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

This PR also configures Dependabot to create PRs updating workflows whenever a new version of a used action is released, as discussed in https://github.com/datalad/datalad-extensions/pull/105.