### PR TITLE
release template etc fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,35 +13,36 @@
   [PR #7028](https://github.com/datalad/datalad/pull/7028)
   (by [@yarikoptic](https://github.com/yarikoptic))
 
-- Let `create` touch the dataset root, if not saving in parent dataset.  [PR
-  #7036](https://github.com/datalad/datalad/pull/7036) (by
+- Let `create` touch the dataset root, if not saving in parent dataset.
+  [PR #7036](https://github.com/datalad/datalad/pull/7036) (by
   [@mih](https://github.com/mih))
 
-- Let get_status_dict() use exception message if none is passed.  [PR
-  #7037](https://github.com/datalad/datalad/pull/7037) (by
+- Let `get_status_dict()` use exception message if none is passed.
+  [PR #7037](https://github.com/datalad/datalad/pull/7037) (by
   [@mih](https://github.com/mih))
 
-- Make choices for `status|diff --annex` and `status|diff --untracked` visible.  [PR
-  #7039](https://github.com/datalad/datalad/pull/7039) (by
+- Make choices for `status|diff --annex` and `status|diff --untracked` visible.
+  [PR #7039](https://github.com/datalad/datalad/pull/7039) (by
   [@mih](https://github.com/mih))
 
-- push: Assume 0 bytes pushed if git-annex does not provide bytesize.  [PR
-  #7049](https://github.com/datalad/datalad/pull/7049) (by
+- push: Assume 0 bytes pushed if git-annex does not provide bytesize.
+  [PR #7049](https://github.com/datalad/datalad/pull/7049) (by
   [@yarikoptic](https://github.com/yarikoptic))
 
 ## Internal
 
-- Use scriv for CHANGELOG generation in release workflow.  [PR
-  #7009](https://github.com/datalad/datalad/pull/7009) (by
+- Use scriv for CHANGELOG generation in release workflow.
+  [PR #7009](https://github.com/datalad/datalad/pull/7009) (by
   [@jwodder](https://github.com/jwodder))
 
-- Stop using auto.  [PR #7024](https://github.com/datalad/datalad/pull/7024)
+- Stop using auto.
+  [PR #7024](https://github.com/datalad/datalad/pull/7024)
   (by [@jwodder](https://github.com/jwodder))
 
 ## Tests
 
-- Allow for any 2 from first 3 to be consumed in test_gracefull_death.  [PR
-  #7041](https://github.com/datalad/datalad/pull/7041) (by
+- Allow for any 2 from first 3 to be consumed in test_gracefull_death.
+  [PR #7041](https://github.com/datalad/datalad/pull/7041) (by
   [@yarikoptic](https://github.com/yarikoptic))
 
 ---

--- a/changelog.d/templates/new_fragment.md.j2
+++ b/changelog.d/templates/new_fragment.md.j2
@@ -4,7 +4,8 @@
 ### {{ cat }}
 
 - Describe change, possibly reference closed/related issue/PR.
-  Fixes https://github.com/datalad/datalad-next/issues/XXX via
-  https://github.com/datalad/datalad-next/pull/XXX (by @GITHUBHANDLE)
+  Fixes [#XXX](https://github.com/datalad/datalad-next/issues/XXX) via
+  [PR #YYY](https://github.com/datalad/datalad-next/pull/YYY)
+  (by [@GITHUBHANDLE](https://github.com/GITHUBHANDLE))
 -->
 {% endfor -%}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,8 +22,8 @@ Bug Fixes
    dataset. `PR #7036 <https://github.com/datalad/datalad/pull/7036>`__
    (by `@mih <https://github.com/mih>`__)
 
--  Let get_status_dict() use exception message if none is passed. `PR
-   #7037 <https://github.com/datalad/datalad/pull/7037>`__ (by
+-  Let ``get_status_dict()`` use exception message if none is passed.
+   `PR #7037 <https://github.com/datalad/datalad/pull/7037>`__ (by
    `@mih <https://github.com/mih>`__)
 
 -  Make choices for ``status|diff --annex`` and

--- a/tools/ci/mkchlog-snippet.py
+++ b/tools/ci/mkchlog-snippet.py
@@ -89,14 +89,6 @@ class PullRequest:
                 + " via "
             )
         item += f"{self.as_link()} (by {self.author.as_link()})"
-        item = textwrap.fill(
-            item,
-            width=79,
-            initial_indent="- ",
-            subsequent_indent="  ",
-            break_long_words=False,
-            break_on_hyphens=False,
-        )
         return f"### {self.category}\n\n{item}\n"
 
 

--- a/tools/ci/mkchlog-snippet.py
+++ b/tools/ci/mkchlog-snippet.py
@@ -89,7 +89,7 @@ class PullRequest:
                 + " via "
             )
         item += f"{self.as_link()} (by {self.author.as_link()})"
-        return f"### {self.category}\n\n{item}\n"
+        return f"### {self.category}\n\n- {item}\n"
 
 
 def main():


### PR DESCRIPTION
- adjust template to use markdown for links and make them thus more concise in rendering
- remove warping (TODO: file issue within WiP action to format similarly to template)
- fix up wrapping in prior changelog

[ci skip]
[appveyor skip]