### PR TITLE
Prevent adding duplicate entries to .gitmodules

### DIFF
--- a/changelog.d/pr-7088.md
+++ b/changelog.d/pr-7088.md
@@ -1,0 +1,3 @@
+### Bug Fixes
+
+- Prevent adding duplicate entries to .gitmodules.  [PR #7088](https://github.com/datalad/datalad/pull/7088) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -225,6 +225,25 @@ def test_subdataset_save(path=None):
     sub.save('new2')
     assert_repo_status(parent.path, untracked=['untracked'], modified=['sub'])
 
+    # https://github.com/datalad/datalad/issues/6843
+    # saving subds within super must not add 2nd copy of the submodule within .gitmodules
+    with chpwd(sub.path):
+        # op.sep is critical to trigger saving within (although should not
+        # be relevant sice no changes within sub)
+        res = save(dataset="^", path=sub.path + op.sep)
+    assert_repo_status(parent.path, untracked=['untracked'])
+    git_modules = (parent.pathobj / ".gitmodules")
+    # there was nothing to do for .gitmodules
+    # TODO: enable assert_result_count(res, 0, path=str(git_modules))
+    # more thorough test that it also was not modified.
+    # ensure that .gitmodules does not have duplicate entries
+    submodules = [
+        l.strip()
+        for l in git_modules.read_text().splitlines()
+        if l.strip().split(' ', 1)[0] == '[submodule'
+    ]
+    assert len(submodules) == 1
+
 
 @with_tempfile(mkdir=True)
 def test_subsuperdataset_save(path=None):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3426,11 +3426,7 @@ class GitRepo(CoreGitRepo):
                     untracked='all').items()
                 if sm_props.get('type', None) == 'directory']
             to_add_submodules = _prune_deeper_repos(to_add_submodules)
-            if to_add_submodules:
-                for r in self._save_add_submodules(to_add_submodules):
-                    if r.get('status', None) == 'ok':
-                        submodule_change = True
-                    yield r
+
         to_stage_submodules = {
             f: props
             for f, props in status_state['modified_or_untracked'].items()
@@ -3441,7 +3437,10 @@ class GitRepo(CoreGitRepo):
                 len(to_stage_submodules), self,
                 to_stage_submodules
                 if len(to_stage_submodules) < 10 else '')
-            for r in self._save_add_submodules(to_stage_submodules):
+            to_add_submodules += list(to_stage_submodules)
+
+        if to_add_submodules:
+            for r in self._save_add_submodules(to_add_submodules):
                 if r.get('status', None) == 'ok':
                     submodule_change = True
                 yield r


### PR DESCRIPTION
fixes #6843 in a crude fashion by not bothering to add 2nd entry if one already exists.

Also contains separate commit for test (was created before this fix) and OPT to avoid double call of the same _save_add_submodules.

This is really a band-aid and not fixing underlying issue which I believe is somewhere else which leads to marking an existing and known `sub/` to be 'untracked` instead of `modified` -- an issue which I believe I observed before and then it was closed since immediate effect of taking too long was addressed.  I might find it eventually again. For now want to see if this fix works and not breaks anything.