### PR TITLE
[BF] Prevent double yielding of impossible get result

### DIFF
--- a/changelog.d/pr-7093.md
+++ b/changelog.d/pr-7093.md
@@ -1,5 +1,6 @@
 ### Bug Fixes
 
-- [BF] Prevent double yielding of impossible get result.  [PR
-  #7093](https://github.com/datalad/datalad/pull/7093) (by
+- [BF] Prevent double yielding of impossible get result 
+  Fixes [#5537](https://github.com/datalad/datalad/issues/5537).
+  [PR #7093](https://github.com/datalad/datalad/pull/7093) (by
   [@jsheunis](https://github.com/jsheunis))

--- a/changelog.d/pr-7093.md
+++ b/changelog.d/pr-7093.md
@@ -1,0 +1,5 @@
+### Bug Fixes
+
+- [BF] Prevent double yielding of impossible get result.  [PR
+  #7093](https://github.com/datalad/datalad/pull/7093) (by
+  [@jsheunis](https://github.com/jsheunis))

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -890,9 +890,8 @@ class Get(Interface):
                 # maintain path argument semantics and pass in dataset arg
                 # as is
                 dataset=dataset,
-                # from the bottom prevents duplicate yielding of results
-                # for a dataset where subdatasets are not installed yet
-                bottomup=True,
+                # always come from the top to get sensible generator behavior
+                bottomup=False,
                 # when paths are given, they will constrain the recursion
                 # automatically, and we need to enable recursion so we can
                 # location path in subdatasets several levels down

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -705,7 +705,7 @@ def _get_targetpaths(ds, content, refds_path, source, jobs):
         yield r
 
 
-def _check_error_reported(res: dict, error_dict: dict):
+def _check_error_reported_before(res: dict, error_dict: dict):
     # Helper to check if an impossible result for a path that does
     # not exist has already been yielded before. If not, add path
     # to the error_dict.
@@ -890,7 +890,8 @@ class Get(Interface):
                 # maintain path argument semantics and pass in dataset arg
                 # as is
                 dataset=dataset,
-                # always come from the top to get sensible generator behavior
+                # from the bottom prevents duplicate yielding of results
+                # for a dataset where subdatasets are not installed yet
                 bottomup=True,
                 # when paths are given, they will constrain the recursion
                 # automatically, and we need to enable recursion so we can
@@ -942,7 +943,7 @@ class Get(Interface):
                             # are a bit pointless
                             # "notneeded" for annex get comes below
                             # prevent double yielding of impossible result
-                            if _check_error_reported(res, error_reported):
+                            if _check_error_reported_before(res, error_reported):
                                 continue
                             yield res
                 else:
@@ -982,7 +983,7 @@ class Get(Interface):
                     # paths, prior in this loop
                     if res.get('status', None) != 'notneeded' or not known_ds:
                         # prevent double yielding of impossible result
-                        if _check_error_reported(res, error_reported):
+                        if _check_error_reported_before(res, error_reported):
                             continue
                         yield res
 

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -788,3 +788,26 @@ def test_source_candidate_subdataset(store1=None, store2=None, intermediate=None
     # This would fail if source candidates weren't right, since cloneds only
     # knows the second store so far (which doesn't have the subdatasets).
     cloneds.get("intermediate", recursive=True)
+
+
+@with_tempfile
+@with_tempfile
+def test_get_non_existing(origin_path=None, clone_path=None):
+
+    # test for gh-5537
+    _make_dataset_hierarchy(origin_path)
+    super_ds = clone(source=origin_path, path=clone_path)
+    res = super_ds.get(opj("sub1", "sub2", "sub3",
+                           "file_in_annex.wrong.extension"),
+                       result_renderer="disabled", on_failure='ignore')
+    # report failure only once:
+    assert_result_count(res, 1, status="impossible",
+                        message="path does not exist")
+
+    # same after intermediates are installed:
+    res = super_ds.get(opj("sub1", "sub2", "sub3",
+                           "file_in_annex.wrong.extension"),
+                       result_renderer="disabled", on_failure='ignore')
+
+    assert_result_count(res, 1, status="impossible",
+                        message="path does not exist")


### PR DESCRIPTION
Fixes #5537.

This PR prevents double yielding of an impossible get result on a path that does not exist by keeping track of impossible get results and skipping additional yields inside `_install_targetpath()`.

The issue reported this problem occurring twice:
- when called from a superdataset _without_ interim subdatasets in the problematic path installed: this is addressed by changing the `bottomup` flag to `True` in the `Subdatasets.__call__()`.
- when called from a superdataset _with_ interim subdatasets in the problematic path already installed: this addressed by tracking the paths for which `_install_targetpath()` has already been called, using the new helper function `_check_error_reported()` and the tracking dict `error_reported`

These changes were rerun locally using the example provided in the issue, and succeeded to give single impossible results in both cases. Tests all succeeded locally with `python -m pytest -s -v --pyargs datalad/core/distributed datalad/distribution datalad/distributed`

### Changelog
#### 🐛 Bug Fixes
- Prevent double yielding of `impossible` `get` result for a path that does not exist. Fixes #5537
