### PR TITLE
Stop rendering subdatasets results

### DIFF
--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -141,7 +141,8 @@ def _get_procedure_implementation(name='*', ds=None):
                 yield (m, n,) + _get_proc_config(n, ds=ds)
         # 2.1. check subdatasets recursively
         for subds in ds.subdatasets(return_type='generator',
-                                    result_xfm='datasets'):
+                                    result_xfm='datasets',
+                                    result_renderer='disabled'):
             for m, n, f, h in _get_procedure_implementation(name=name, ds=subds):
                 yield m, n, f, h
 


### PR DESCRIPTION
Disables `subdataset` result renderer inside `run_procedure`. 
The `subdataset` call was internal, and its results do not need to be rendered.
Fixes #7091.

I applied a patch proposed by @mih in #7091.
Fixes #7091 

### PR checklist

- [ ] Provide an overview of the changes you're making and explain why you're proposing them, ideally in the form of a changelog (template below)
- [x] Include `Fixes #NNN` somewhere in the description if this PR addresses an existing issue.
- [x] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
  Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
- [x] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
- [ ] **Delete these instructions**. :-)

Thanks for contributing!

### Changelog
#### 🐛 Bug Fixes
- Description... Fixes #issue
#### 💫 Enhancements and new features
-
#### 🪓 Deprecations and removals
-
#### 📝 Documentation
-
#### 🏠 Internal
-
#### 🛡 Tests
-
