### PR TITLE
Make sure to re-initialise git repo

### DIFF
--- a/changelog.d/pr-7095.md
+++ b/changelog.d/pr-7095.md
@@ -1,0 +1,8 @@
+### Bug Fixes
+
+- Improve handling of `--existing reconfigure` in
+  `create-sibling-ria`: previously, the command would not make the
+  underlying `git init` call for existing local repositories, leading
+  to some configuration updates not being applied. Partially addresses
+  https://github.com/datalad/datalad/issues/6967 via
+  https://github.com/datalad/datalad/pull/7095 (by @mslw)

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -684,10 +684,7 @@ def _create_sibling_ria(
             # skip & error have been handled at this point
             gr.init(
                 sanity_checks=False,
-                init_options=[
-                    "--bare",
-                    "--shared={}".format(shared) if shared else "",
-                ]
+                init_options=["--bare"] + ([f"--shared={shared}"] if shared else []),
             )
         if storage_sibling:
             # write special remote's uuid into git-config, so clone can

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -518,7 +518,8 @@ def _create_sibling_ria(
             use_remote_annex_bundle=False)
         ssh.open()
 
-    if existing in ['skip', 'error']:
+    exists = False
+    if existing in ['skip', 'error', 'reconfigure']:
         config_path = repo_path / 'config'
         # No .git -- if it's an existing repo in a RIA store it should be a
         # bare repo.
@@ -545,7 +546,7 @@ def _create_sibling_ria(
                     **res_kwargs
                 )
                 return
-            else:  # existing == 'error'
+            elif existing == 'error':
                 yield get_status_dict(
                     status='error',
                     message="remote directory {} already "
@@ -553,6 +554,9 @@ def _create_sibling_ria(
                     **res_kwargs
                 )
                 return
+            else:
+                # reconfigure will be handled later in the code
+                pass
 
     if storage_sibling == 'only':
         lgr.info("create storage sibling '{}' ...".format(name))
@@ -674,6 +678,17 @@ def _create_sibling_ria(
     else:
         gr = GitRepo(repo_path, create=True, bare=True,
                      shared=shared if shared else None)
+        if exists and existing == 'reconfigure':
+            # if the repo exists at the given path, the GitRepo would not
+            # (re)-run git init, and just return an instance of GitRepo;
+            # skip & error have been handled at this point
+            gr.init(
+                sanity_checks=False,
+                init_options=[
+                    "--bare",
+                    "--shared={}".format(shared) if shared else "",
+                ]
+            )
         if storage_sibling:
             # write special remote's uuid into git-config, so clone can
             # which one it is supposed to be and enable it even with


### PR DESCRIPTION
The `create_sibling_ria` command used `GitRepo(repo_path, create=True)` constructor to initialise bare repositories locally, also when `existing=reconfigure` was requested. But for existing repositories, `GitRepo` does not execute `git init`, it just returns a `GitRepo` instance, so `reconfigure` was not actually handled. This commit introduces an aditional check, to make sure that `git init` is called when reconfiguring.

Partially addresses #6967 (`--existing reconfigure --shared` not working). However, another problem remains: although we now do handle the reconfiguration, calling `git annex init --bare --shared` sets the config variable `core.sharedRepository` (which would presumably affect future commits), but does not change the permissions for the already existing files in the bare git repo.