### PR TITLE
RF `datalad.interface.utils.eval_results()`

### DIFF
--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -286,12 +286,6 @@ def eval_results(wrapped):
                 getattr(wrapped_class, p_name))
             for p_name in eval_params}
 
-        # for result filters
-        # we need to produce a dict with argname/argvalue pairs for all args
-        # incl. defaults and args given as positionals
-        allkwargs = get_allargs_as_kwargs(wrapped, args,
-                                          {**kwargs, **common_params})
-
         # short cuts and configured setup for common options
         return_type = common_params['return_type']
 
@@ -303,7 +297,7 @@ def eval_results(wrapped):
             return _execute_command_(
                 wrapped,
                 wrapped_class,
-                allkwargs,
+                common_params,
                 *args,
                 **kwargs
             )
@@ -313,7 +307,7 @@ def eval_results(wrapped):
                 results = _execute_command_(
                     wrapped,
                     wrapped_class,
-                    allkwargs,
+                    common_params,
                     *args,
                     **kwargs
                 )
@@ -340,13 +334,22 @@ def eval_results(wrapped):
 def _execute_command_(
         wrapped,
         wrapped_class,
-        allkwargs,
+        common_params,
         *_args,
         **_kwargs):
     """This internal helper function actually drives a command
     generator-style, it may generate an exception if desired,
     on incomplete results
     """
+    # for result filters and validation
+    # we need to produce a dict with argname/argvalue pairs for all args
+    # incl. defaults and args given as positionals
+    allkwargs = get_allargs_as_kwargs(
+        wrapped,
+        _args,
+        {**_kwargs, **common_params},
+    )
+
     # look for potential override of logging behavior
     result_log_level = dlcfg.get('datalad.log.result-level', 'debug')
     # resolve string labels for transformers too

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -311,8 +311,6 @@ def eval_results(wrapped):
             # standardize on the new name 'generic' to avoid more complex
             # checking below
             result_renderer = 'generic'
-        # look for potential override of logging behavior
-        result_log_level = dlcfg.get('datalad.log.result-level', 'debug')
 
         # query cfg for defaults
         # .is_installed and .config can be costly, so ensure we do
@@ -340,7 +338,6 @@ def eval_results(wrapped):
                 wrapped_class,
                 result_renderer,
                 common_params,
-                result_log_level,
                 allkwargs,
                 hooks,
                 dataset_arg,
@@ -357,7 +354,6 @@ def eval_results(wrapped):
                     wrapped_class,
                     result_renderer,
                     common_params,
-                    result_log_level,
                     allkwargs,
                     hooks,
                     dataset_arg,
@@ -389,7 +385,6 @@ def _execute_command_(
         wrapped_class,
         result_renderer,
         common_params,
-        result_log_level,
         allkwargs,
         hooks,
         dataset_arg,
@@ -401,6 +396,9 @@ def _execute_command_(
     generator-style, it may generate an exception if desired,
     on incomplete results
     """
+    # look for potential override of logging behavior
+    result_log_level = dlcfg.get('datalad.log.result-level', 'debug')
+
     # flag whether to raise an exception
     incomplete_results = []
     # track what actions were performed how many times

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -378,6 +378,9 @@ def _execute_command_(
         {**cmd_kwargs, **exec_kwargs},
     )
 
+    # validate the complete parameterization
+    _validate_cmd_call(interface, allkwargs)
+
     # look for potential override of logging behavior
     result_log_level = dlcfg.get('datalad.log.result-level', 'debug')
     # resolve string labels for transformers too
@@ -504,6 +507,23 @@ def _execute_command_(
         raise IncompleteResultsError(
             failed=incomplete_results,
             msg="Command did not complete successfully")
+
+
+def _validate_cmd_call(interface: anInterface, kwargs: Dict) -> None:
+    """Validate a parameterization of a command call
+
+    This is called by `_execute_command_()` before a command call, with
+    the respective Interface sub-type of the command, and all its
+    arguments in keyword argument dict style. This dict also includes
+    the default values for any parameter that was not explicitly included
+    in the command call.
+
+    This expected behavior is to raise an exception whenever an invalid
+    parameterization is encountered.
+
+    This default implementation performs no validation.
+    """
+    pass
 
 
 def generic_result_renderer(res):

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -297,7 +297,9 @@ def eval_results(wrapped):
 
         if return_type == 'generator':
             # hand over the generator
-            lgr.log(2, "Returning generator_func from eval_func for %s", wrapped_class)
+            lgr.log(2,
+                    "Returning generator_func from eval_func for %s",
+                    wrapped_class)
             return _execute_command_(
                 wrapped,
                 wrapped_class,
@@ -325,7 +327,9 @@ def eval_results(wrapped):
                 else:
                     return results
 
-            lgr.log(2, "Returning return_func from eval_func for %s", wrapped_class)
+            lgr.log(2,
+                    "Returning return_func from eval_func for %s",
+                    wrapped_class)
             return return_func(*args, **kwargs)
 
     ret = eval_func

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -337,7 +337,6 @@ def eval_results(wrapped):
                 wrapped,
                 wrapped_class,
                 result_renderer,
-                common_params,
                 allkwargs,
                 hooks,
                 dataset_arg,
@@ -353,7 +352,6 @@ def eval_results(wrapped):
                     wrapped,
                     wrapped_class,
                     result_renderer,
-                    common_params,
                     allkwargs,
                     hooks,
                     dataset_arg,
@@ -384,7 +382,6 @@ def _execute_command_(
         wrapped,
         wrapped_class,
         result_renderer,
-        common_params,
         allkwargs,
         hooks,
         dataset_arg,
@@ -421,7 +418,7 @@ def _execute_command_(
             # execution
             wrapped(*_args, **_kwargs),
             wrapped_class,
-            common_params['on_failure'],
+            allkwargs['on_failure'],
             # bookkeeping
             action_summary,
             incomplete_results,

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -298,8 +298,8 @@ def eval_results(wrapped):
                 wrapped,
                 wrapped_class,
                 common_params,
-                *args,
-                **kwargs
+                args,
+                kwargs
             )
         else:
             @wraps(_execute_command_)
@@ -308,8 +308,8 @@ def eval_results(wrapped):
                     wrapped,
                     wrapped_class,
                     common_params,
-                    *args,
-                    **kwargs
+                    args,
+                    kwargs
                 )
                 if inspect.isgenerator(results):
                     # unwind generator if there is one, this actually runs
@@ -335,8 +335,8 @@ def _execute_command_(
         wrapped,
         wrapped_class,
         common_params,
-        *_args,
-        **_kwargs):
+        cmd_args,
+        cmd_kwargs):
     """This internal helper function actually drives a command
     generator-style, it may generate an exception if desired,
     on incomplete results
@@ -346,8 +346,8 @@ def _execute_command_(
     # incl. defaults and args given as positionals
     allkwargs = get_allargs_as_kwargs(
         wrapped,
-        _args,
-        {**_kwargs, **common_params},
+        cmd_args,
+        {**cmd_kwargs, **common_params},
     )
 
     # look for potential override of logging behavior
@@ -408,7 +408,7 @@ def _execute_command_(
     # process main results
     for r in _process_results(
             # execution
-            wrapped(*_args, **_kwargs),
+            wrapped(*cmd_args, **cmd_kwargs),
             wrapped_class,
             allkwargs['on_failure'],
             # bookkeeping

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -294,23 +294,6 @@ def eval_results(wrapped):
 
         # short cuts and configured setup for common options
         return_type = common_params['return_type']
-        result_filter = get_result_filter(common_params['result_filter'])
-        # resolve string labels for transformers too
-        result_xfm = known_result_xfms.get(
-            common_params['result_xfm'],
-            # use verbatim, if not a known label
-            common_params['result_xfm'])
-        result_renderer = common_params['result_renderer']
-
-        if result_renderer == 'tailored' and not hasattr(wrapped_class,
-                                                         'custom_result_renderer'):
-            # a tailored result renderer is requested, but the class
-            # does not provide any, fall back to the generic one
-            result_renderer = 'generic'
-        if result_renderer == 'default':
-            # standardize on the new name 'generic' to avoid more complex
-            # checking below
-            result_renderer = 'generic'
 
         # query cfg for defaults
         # .is_installed and .config can be costly, so ensure we do
@@ -336,12 +319,9 @@ def eval_results(wrapped):
             return _execute_command_(
                 wrapped,
                 wrapped_class,
-                result_renderer,
                 allkwargs,
                 hooks,
                 dataset_arg,
-                result_filter,
-                result_xfm,
                 *args,
                 **kwargs
             )
@@ -351,12 +331,9 @@ def eval_results(wrapped):
                 results = _execute_command_(
                     wrapped,
                     wrapped_class,
-                    result_renderer,
                     allkwargs,
                     hooks,
                     dataset_arg,
-                    result_filter,
-                    result_xfm,
                     *args,
                     **kwargs
                 )
@@ -381,12 +358,9 @@ def eval_results(wrapped):
 def _execute_command_(
         wrapped,
         wrapped_class,
-        result_renderer,
         allkwargs,
         hooks,
         dataset_arg,
-        result_filter,
-        result_xfm,
         *_args,
         **_kwargs):
     """This internal helper function actually drives a command
@@ -395,6 +369,22 @@ def _execute_command_(
     """
     # look for potential override of logging behavior
     result_log_level = dlcfg.get('datalad.log.result-level', 'debug')
+    # resolve string labels for transformers too
+    result_xfm = known_result_xfms.get(
+        allkwargs['result_xfm'],
+        # use verbatim, if not a known label
+        allkwargs['result_xfm'])
+    result_filter = get_result_filter(allkwargs['result_filter'])
+    result_renderer = allkwargs['result_renderer']
+    if result_renderer == 'tailored' and not hasattr(wrapped_class,
+                                                     'custom_result_renderer'):
+        # a tailored result renderer is requested, but the class
+        # does not provide any, fall back to the generic one
+        result_renderer = 'generic'
+    if result_renderer == 'default':
+        # standardize on the new name 'generic' to avoid more complex
+        # checking below
+        result_renderer = 'generic'
 
     # flag whether to raise an exception
     incomplete_results = []


### PR DESCRIPTION
This is an essential function that any command execution goes through, which is responsible for result generation and handling. This change refactors the code by

- [x] Moving the internal `generator_func()` helper into a regular function with documentation and type annotation
- [x] Established a no-op call to a new `_validate_cmd_call()` function that can perform universal validation of a command parameterization before a command execution is attempted

This second aspect is the main motivation for this change. It lays the foundation for homogeneous validation of parameters beyond the CLI-specific (partial) validation and the custom, per-command validation that is done after a command execution has started.

The work on such a validation has started in https://github.com/datalad/datalad-next/pull/116