### PR TITLE
Report repository name in `create_sibling_ghlike` dry run

### DIFF
--- a/changelog.d/pr-7103
+++ b/changelog.d/pr-7103
@@ -1,0 +1,9 @@
+### Bug Fixes
+
+- Improved reporting when using `dry-run` with github-like
+  `create-sibling*` commands (`-gin`, `-gitea`, `-github`,
+  `-gogs`). The result messages will now display names of the
+  repositories which would be created (useful for recursive
+  operations).
+  [PR #7103](https://github.com/datalad/datalad/pull/7103)
+  (by [@mslw](https://github.com/mslw))

--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -467,7 +467,6 @@ class _GitHubLike(object):
         headers = self.request_headers
 
         if dry_run:
-            res_msg = "would create {} sibling and repository named {}"
             return dict(
                 status='ok',
                 request_url=endpoint,

--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -134,8 +134,8 @@ class _GitHubLike(object):
             args=("--dry-run",),
             action="store_true",
             doc="""if set, no repository will be created, only tests for
-            name collisions will be performed, and would-be repository names
-            are reported for all relevant datasets"""),
+            sibling name collisions will be performed, and would-be repository
+            names are reported for all relevant datasets"""),
     )
 
     def __init__(self, url, credential, require_token=True, token_info=None):

--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -391,10 +391,19 @@ class _GitHubLike(object):
                     reponame, self.api_url)
 
             if 'message' not in res:
-                res['message'] = (
-                    "sibling repository '%s' created at %s",
-                    siblingname, res.get('html_url')
-                )
+                if not dry_run:
+                    res['message'] = (
+                        "sibling repository '%s' created at %s",
+                        siblingname, res.get('html_url')
+                    )
+                else:
+                    # can't know url when request was not made
+                    res['message'] = (
+                        "would create sibling '%s' and repository '%s%s'",
+                        siblingname,
+                        organization + "/" if organization else "",
+                        reponame
+                    )
             # report to caller
             yield get_status_dict(**res)
 
@@ -458,6 +467,7 @@ class _GitHubLike(object):
         headers = self.request_headers
 
         if dry_run:
+            res_msg = "would create {} sibling and repository named {}"
             return dict(
                 status='ok',
                 request_url=endpoint,


### PR DESCRIPTION
This PR adds a different error message when `create_sibling_github` is used with `dry_run`. The new error message  actually gives repository names.

The docstring for `create_sibling_ghlike` `dry_run` option said:
```
if set, no repository will be created, only tests for
name collisions will be performed, and would-be repository names
are reported for all relevant datasets
```
However, it behaved like this (dataset with one subdataset):
```
❱ datalad create-sibling-gin --recursive --dry-run -d . ProjectX
create_sibling_gin [dry-run](ok): [sibling repository 'gin' created at None]
create_sibling_gin [dry-run](ok): [sibling repository 'gin' created at None]
action summary:
  create_sibling_gin [dry-run] (ok: 2)
```

Now it will behave like this:
```
❱ datalad create-sibling-gin --recursive --dry-run -d . ProjectX
create_sibling_gin [dry-run](ok): [would create sibling 'gin' and repository 'ProjectX']
create_sibling_gin [dry-run](ok): [would create sibling 'gin' and repository 'ProjectX-bar']
action summary:
  create_sibling_gin [dry-run] (ok: 2)
```

Moreover, the docstring wasn't clear on what name collision tests will be performed (sibling names vs repository names). The `dry_run` mode, in fact, does not make any requests to the hosting service, so it would only check for the former.

Because adding checks for repository names would be more complicated (need to process the response, and then adjust the message depending on what we chose to reconfigure), I assumed that the current behavior is intended and only adjusted the docstring.