### PR TITLE
Fix `PWD` environment entry if `cwd` provided to `Runner()` or `Runner.run()` is  a `Path`-object

### DIFF
--- a/changelog.d/pr-7107.md
+++ b/changelog.d/pr-7107.md
@@ -1,0 +1,8 @@
+### Bug Fixes
+
+- Ensure subprocess environments have a valid path in `os.environ['PWD']`,
+  even if a Path-like object was given to the runner on subprocess creation
+  or invocation.
+  Fixes [#7040](https://github.com/datalad/datalad/issues/7040) via
+  [PR #7107](https://github.com/datalad/datalad/pull/7107)
+  (by [@christian-monch](https://github.com/christian-monch))

--- a/datalad/runner/runner.py
+++ b/datalad/runner/runner.py
@@ -37,7 +37,7 @@ class WitlessRunner(object):
         """
         Parameters
         ----------
-        cwd : path-like, optional
+        cwd : str or path-like, optional
           If given, commands are executed with this path as PWD,
           the PWD of the parent process is used otherwise.
         env : dict, optional
@@ -48,7 +48,7 @@ class WitlessRunner(object):
         """
         self.env = env
         # stringify to support Path instances on PY35
-        self.cwd = str(cwd) if cwd is not None else None
+        self.cwd = cwd
 
         self.threaded_runner = None
 
@@ -61,9 +61,9 @@ class WitlessRunner(object):
         if copy:
             env = env.copy() if env else None
         if cwd and env is not None:
-            # if CWD was provided, we must not make it conflict with
+            # if `cwd` was provided, we must not make it conflict with
             # a potential PWD setting
-            env['PWD'] = cwd
+            env['PWD'] = str(cwd)
         return env
 
     def run(self,
@@ -96,7 +96,7 @@ class WitlessRunner(object):
           If stdin is a Queue, all elements (bytes) put into the Queue will
           be passed to stdin until None is read from the queue. If None is read,
           stdin of the subprocess is closed.
-        cwd : path-like, optional
+        cwd : str or path-like, optional
           If given, commands are executed with this path as PWD,
           the PWD of the parent process is used otherwise. Overrides
           any `cwd` given to the constructor.

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -329,10 +329,10 @@ def test_path_to_str_conversion():
 def test_environment(temp_dir_path=None):
     # Ensure that the subprocess sees a string in `$PWD`, even if a Path-object
     # is provided to `cwd`.
-    cmd = py2cmd('import os; print(os.environ["PWD"])')
+    cmd = py2cmd("import os; print(os.environ['PWD'])")
     test_kwargs = {
         'cwd': Path(temp_dir_path),
-        'env': dict(TEST='test_value')
+        'env': dict(SYSTEMROOT=os.environ.get('SYSTEMROOT', ''))
     }
     runner = Runner()
     results = runner.run(cmd=cmd, protocol=StdOutCapture, **test_kwargs)

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -317,11 +317,12 @@ def test_path_to_str_conversion():
     # Regression test to ensure that Path-objects are converted into strings
     # before they are put into the environment variable `$PWD`
     runner = Runner()
+    test_path = Path("a/b/c")
     adjusted_env = runner._get_adjusted_env(
-        cwd=Path("/a/b/c"),
+        cwd=test_path,
         env=dict(some_key="value")
     )
-    assert "/a/b/c" == adjusted_env['PWD']
+    assert str(test_path) == adjusted_env['PWD']
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
Fixes #7040 

This PR fixes #7040. It ensures that an environment that is provided to the subprocess contains a proper entry for `PWD`. That means, the entry contains a string that describes the path of the working directory, and not a python-representation of a Path object.
