### PR TITLE
Various small fixups ran after looking post-release and trying to build Debian package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@
   [PR #7107](https://github.com/datalad/datalad/pull/7107)
   (by [@christian-monch](https://github.com/christian-monch))
 
+- Improved reporting when using `dry-run` with github-like
+  `create-sibling*` commands (`-gin`, `-gitea`, `-github`,
+  `-gogs`). The result messages will now display names of the
+  repositories which would be created (useful for recursive
+  operations).
+  [PR #7103](https://github.com/datalad/datalad/pull/7103)
+  (by [@mslw](https://github.com/mslw))
+
 <a id='changelog-0.17.7'></a>
 # 0.17.7 (2022-10-14)
 

--- a/changelog.d/pr-7103
+++ b/changelog.d/pr-7103
@@ -1,9 +1,0 @@
-### Bug Fixes
-
-- Improved reporting when using `dry-run` with github-like
-  `create-sibling*` commands (`-gin`, `-gitea`, `-github`,
-  `-gogs`). The result messages will now display names of the
-  repositories which would be created (useful for recursive
-  operations).
-  [PR #7103](https://github.com/datalad/datalad/pull/7103)
-  (by [@mslw](https://github.com/mslw))

--- a/changelog.d/pr-7112.md
+++ b/changelog.d/pr-7112.md
@@ -1,0 +1,3 @@
+### Bug Fixes
+
+- Various small fixups ran after looking post-release and trying to build Debian package.  [PR #7112](https://github.com/datalad/datalad/pull/7112) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -154,7 +154,7 @@ def test_help_np():
     assert re.search(r"Global options\W*-c ", stdout, flags=re.MULTILINE)
     # and -c should be listed only once - i.e. that we do not duplicate sections
     # and our USAGE summary has only [global-opts]
-    assert re.match("Usage: .*datalad.* \[global-opts\] command \[command-opts\]", stdout)
+    assert re.match(r"Usage: .*datalad.* \[global-opts\] command \[command-opts\]", stdout)
     assert stdout.count(' -c ') == 1
 
     assert_all_commands_present(stdout)

--- a/datalad/metadata/tests/test_metadata.py
+++ b/datalad/metadata/tests/test_metadata.py
@@ -1,6 +1,6 @@
 
 from datalad.distribution.dataset import Dataset
-from datalad.tests.utils import with_tempfile
+from datalad.tests.utils_pytest import with_tempfile
 
 
 @with_tempfile(mkdir=True)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,7 +21,8 @@ Bug Fixes
    results of ``run_procedure()``. Fixes
    `#7091 <https://github.com/datalad/datalad/issues/7091>`__ via `PR
    #7094 <https://github.com/datalad/datalad/pull/7094>`__ (by
-   `@mslw <https://github.com/mslw>`__ & `@mih <https://github.com/mih>`__)
+   `@mslw <https://github.com/mslw>`__ &
+   `@mih <https://github.com/mih>`__)
 
 -  Improve handling of ``--existing reconfigure`` in
    ``create-sibling-ria``: previously, the command would not make the
@@ -36,6 +37,14 @@ Bug Fixes
    `#7040 <https://github.com/datalad/datalad/issues/7040>`__ via `PR
    #7107 <https://github.com/datalad/datalad/pull/7107>`__ (by
    `@christian-monch <https://github.com/christian-monch>`__)
+
+-  Improved reporting when using ``dry-run`` with github-like
+   ``create-sibling*`` commands (``-gin``, ``-gitea``, ``-github``,
+   ``-gogs``). The result messages will now display names of the
+   repositories which would be created (useful for recursive
+   operations). `PR
+   #7103 <https://github.com/datalad/datalad/pull/7103>`__ (by
+   `@mslw <https://github.com/mslw>`__)
 
 .. _section-1:
 
@@ -2292,7 +2301,7 @@ Fixes
 -  ``save`` no longer saves unspecified subdatasets when called with an
    explicit path (list). The fix required a behavior change of
    ``GitRepo.get_content_info()`` in its interpretation of ``None``
-   vs. \ ``[]`` path argument values that now aligns the behavior of
+   vs. ``[]`` path argument values that now aligns the behavior of
    ``GitRepo.diff|status()`` with their respective documentation.
    (`#5693 <https://github.com/datalad/datalad/issues/5693>`__)
 
@@ -2988,7 +2997,7 @@ Enhancements and new features
    default, has been improved. A core piece of the new approach is
    registering the commit of the primary branch, not its checked out
    adjusted branch, in the superdataset. Note: This means that
-   ``git status`` will always consider a subdataset on an adjusted
+   ``git   status`` will always consider a subdataset on an adjusted
    branch as dirty while ``datalad status`` will look more closely and
    see if the tip of the primary branch matches the registered commit.
    (`#5241 <https://github.com/datalad/datalad/issues/5241>`__)
@@ -3117,10 +3126,10 @@ Enhancements and new features
 
 -  The ``ConfigManager`` methods ``get``, ``getbool``, ``getfloat``, and
    ``getint`` now return a single value (with same precedence as
-   ``git config --get``) when there are multiple values for the same key
-   (in the non-committed git configuration, if the key is present there,
-   or in the dataset configuration). For ``get``, the old behavior can
-   be restored by specifying ``get_all=True``.
+   ``git   config --get``) when there are multiple values for the same
+   key (in the non-committed git configuration, if the key is present
+   there, or in the dataset configuration). For ``get``, the old
+   behavior can be restored by specifying ``get_all=True``.
    (`#4924 <https://github.com/datalad/datalad/issues/4924>`__)
 
 -  Command-line scripts are now defined via the ``entry_points``
@@ -3588,7 +3597,7 @@ Enhancements and new features
 
 -  ``datalad push`` now avoids unnecessary ``git push`` dry runs and
    pushes all refspecs with a single ``git push`` call rather than
-   invoking ``git push`` for each one.
+   invoking ``git   push`` for each one.
    (`#4692 <https://github.com/datalad/datalad/issues/4692>`__)
    (`#4675 <https://github.com/datalad/datalad/issues/4675>`__)
 
@@ -3941,8 +3950,9 @@ Fixes
 -  A longstanding regression in argcomplete-based command-line
    completion for Bash has been fixed. You can enable completion by
    configuring a Bash startup file to run
-   ``eval "$(register-python-argcomplete datalad)"`` or source DataLad’s
-   ``tools/cmdline-completion``. The latter should work for Zsh as well.
+   ``eval   "$(register-python-argcomplete datalad)"`` or source
+   DataLad’s ``tools/cmdline-completion``. The latter should work for
+   Zsh as well.
    (`#4477 <https://github.com/datalad/datalad/issues/4477>`__)
 
 -  `publish <http://datalad.readthedocs.io/en/latest/generated/man/datalad-publish.html>`__
@@ -4023,12 +4033,13 @@ Fixes
 
 -  The default for the ``--jobs`` option, “auto”, instructed DataLad to
    pass a value to git-annex’s ``--jobs`` equal to
-   ``min(8, max(3, <number of CPUs>))``, which could lead to issues due
-   to the large number of child processes spawned and file descriptors
-   opened. To avoid this behavior, ``--jobs=auto`` now results in
-   git-annex being called with ``--jobs=1`` by default. Configure the
-   new option ``datalad.runtime.max-annex-jobs`` to control the maximum
-   value that will be considered when ``--jobs='auto'``.
+   ``min(8, max(3, <number   of CPUs>))``, which could lead to issues
+   due to the large number of child processes spawned and file
+   descriptors opened. To avoid this behavior, ``--jobs=auto`` now
+   results in git-annex being called with ``--jobs=1`` by default.
+   Configure the new option ``datalad.runtime.max-annex-jobs`` to
+   control the maximum value that will be considered when
+   ``--jobs='auto'``.
    (`#4409 <https://github.com/datalad/datalad/issues/4409>`__)
 
 -  Various commands have been adjusted to better handle the case where a
@@ -4812,7 +4823,7 @@ Enhancements and new features
    (`#3693 <https://github.com/datalad/datalad/issues/3693>`__)
 
 -  ``GitRepo`` now has a ``for_each_ref_`` method that wraps
-   ``git for-each-ref``, which is used in various spots that used to
+   ``git   for-each-ref``, which is used in various spots that used to
    rely on GitPython functionality.
    (`#3705 <https://github.com/datalad/datalad/issues/3705>`__)
 
@@ -5142,7 +5153,7 @@ Enhancements and new features
       (`#3334 <https://github.com/datalad/datalad/issues/3334>`__)
 
 -  Querying repository content is faster due to batching of
-   ``git cat-file`` calls.
+   ``git   cat-file`` calls.
    (`#3301 <https://github.com/datalad/datalad/issues/3301>`__)
 
 -  The dataset ID of a subdataset is now recorded in the superdataset.
@@ -5997,7 +6008,7 @@ Fixes
    command with a non-zero exit were incorrectly formatted.
    (`#2692 <https://github.com/datalad/datalad/issues/2692>`__)
 -  Decompression of zip files (e.g., through
-   ``datalad add-archive-content``) failed on Python 3.
+   ``datalad   add-archive-content``) failed on Python 3.
    (`#2702 <https://github.com/datalad/datalad/issues/2702>`__)
 -  Windows:
 
@@ -6099,15 +6110,15 @@ Enhancements and new features
    of each extension.
    (`#2741 <https://github.com/datalad/datalad/issues/2741>`__)
 -  The internal handling of gitattributes information has been improved.
-   A user-visible consequence is that ``datalad create --force`` no
+   A user-visible consequence is that ``datalad create   --force`` no
    longer duplicates existing attributes.
    (`#2744 <https://github.com/datalad/datalad/issues/2744>`__)
 -  The “annex” metadata extractor can now be used even when no content
    is present.
    (`#2724 <https://github.com/datalad/datalad/issues/2724>`__)
 -  The ``add_url_to_file`` method (called by commands like
-   ``datalad download-url`` and ``datalad add-archive-content``) learned
-   how to display a progress bar.
+   ``datalad   download-url`` and ``datalad add-archive-content``)
+   learned how to display a progress bar.
    (`#2738 <https://github.com/datalad/datalad/issues/2738>`__)
 
 0.10.2 (Jul 09, 2018) – Thesecuriestever
@@ -6213,7 +6224,7 @@ A number of fixes did not make it into the 0.9.x series:
 -  ``add`` now correctly saves staged subdataset additions.
 -  Running ``datalad save`` in a dataset no longer adds untracked
    content to the dataset. In order to add content a path has to be
-   given, e.g. \ ``datalad save .``
+   given, e.g. ``datalad save .``
 -  ``wtf`` now works reliably with a DataLad that wasn’t installed from
    Git (but, e.g., via pip)
 -  More robust URL handling in ``simple_with_archives`` crawler


### PR DESCRIPTION
Dear @datalad/developers and @datalad/contributors , please
- add .md to changelog snippets you might decide to produce/rename manually
- use `tests.utils_pytest` not `tests.utils` (old, nose version, we should look to remove it probably after some minor major release)
- (reminder to myself as well) - do not forget to `r""` raw strings with escapes (e.g. `r"\["`)