### PR TITLE
BF: Fix add-archive-contents try-finally statement by defining variable earlier

### DIFF
--- a/changelog.d/pr-7117.md
+++ b/changelog.d/pr-7117.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: Fix add-archive-contents try-finally statement by defining variable earlier.  [PR #7117](https://github.com/datalad/datalad/pull/7117) (by [@adswa](https://github.com/adswa))

--- a/datalad/local/add_archive_content.py
+++ b/datalad/local/add_archive_content.py
@@ -423,13 +423,13 @@ class AddArchiveContent(Interface):
         outside_stats = stats
         stats = ActivityStats()
 
+        # start a progress bar for extraction
+        pbar_id = f'add-archive-{archive_path}'
         try:
             # keep track of extracted files for progress bar logging
             file_counter = 0
             # iterative over all files in the archive
             extracted_files = list(earchive.get_extracted_files())
-            # start a progress bar for extraction
-            pbar_id = f'add-archive-{archive_path}'
             log_progress(
                 lgr.info, pbar_id, 'Extracting archive',
                 label="Extracting archive",


### PR DESCRIPTION
Committed by Adina but taken from the patch provided by @mih in https://github.com/datalad/datalad/issues/7113
