### PR TITLE
Fix all logging to use %-interpolation and not .format, sort imports in touched files, add pylint-ing for % formatting in log messages to `tox -e lint`

### DIFF
--- a/changelog.d/pr-7118.md
+++ b/changelog.d/pr-7118.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Fix all logging to use %-interpolation and not .format, sort imports in touched files, add pylint-ing for % formatting in log messages to `tox -e lint`.  [PR #7118](https://github.com/datalad/datalad/pull/7118) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -17,12 +17,13 @@
 __docformat__ = 'restructuredtext'
 
 import logging
+
 lgr = logging.getLogger('datalad.cli')
 
 lgr.log(5, "Importing cli.main")
 
-import sys
 import os
+import sys
 
 import datalad
 
@@ -65,6 +66,7 @@ def main(args=sys.argv):
     completing = "_ARGCOMPLETE" in os.environ
     if completing and 'COMP_LINE' in os.environ:
         import shlex
+
         # TODO support posix=False too?
         args = shlex.split(os.environ['COMP_LINE']) or args
 
@@ -74,6 +76,7 @@ def main(args=sys.argv):
         args = [_fix_datalad_ri(s) for s in args]
 
     from datalad.support.entrypoints import load_extensions
+
     # load extensions requested by configuration
     # analog to what coreapi is doing for a Python session
     # importantly, load them prior to parser construction, such
@@ -97,9 +100,9 @@ def main(args=sys.argv):
     has_func = hasattr(cmdlineargs, 'func') and cmdlineargs.func is not None
     if unparsed_args:
         if has_func:
-            lgr.error('unknown argument{}: {}'.format(
+            lgr.error('unknown argument%s: %s',
                 's' if len(unparsed_args) > 1 else '',
-                unparsed_args if len(unparsed_args) > 1 else unparsed_args[0])
+                unparsed_args if len(unparsed_args) > 1 else unparsed_args[0],
             )
             cmdlineargs.subparser.print_usage()
             sys.exit(1)
@@ -172,6 +175,7 @@ def _run(namespace):
 def _run_with_debugger(cmdlineargs):
     """Execute the command and drop into debugger if it crashes"""
     from .utils import setup_exceptionhook
+
     # so we could see/stop clearly at the point of failure
     setup_exceptionhook(ipython=cmdlineargs.common_idebug)
     return cmdlineargs.func(cmdlineargs)
@@ -188,9 +192,9 @@ def _run_with_exception_handler(cmdlineargs):
     except BaseException as exc:
         from datalad.support.exceptions import (
             CapturedException,
-            InsufficientArgumentsError,
-            IncompleteResultsError,
             CommandError,
+            IncompleteResultsError,
+            InsufficientArgumentsError,
         )
         ce = CapturedException(exc)
         # we crashed, it has got to be non-zero for starters

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -22,6 +22,8 @@ from urllib.parse import urlparse
 from annexremote import UnsupportedRequest
 
 from datalad.consts import ARCHIVES_SPECIAL_REMOTE
+from datalad.customremotes import RemoteError
+from datalad.customremotes.main import main as super_main
 from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.archives import ArchivesCache
@@ -31,14 +33,12 @@ from datalad.support.locking import lock_if_check_fails
 from datalad.support.network import URL
 from datalad.utils import (
     ensure_bytes,
-    getpwd,
     get_dataset_root,
+    getpwd,
     unique,
     unlink,
 )
 
-from datalad.customremotes import RemoteError
-from datalad.customremotes.main import main as super_main
 from .base import AnnexCustomRemote
 
 lgr = logging.getLogger('datalad.customremotes.archive')
@@ -405,8 +405,8 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                 # so
                 pwd = getpwd()
                 lgr.debug(
-                    "Getting file {afile} from {akey_path} "
-                    "while PWD={pwd}".format(**locals()))
+                    "Getting file %s from %s while PWD=%s",
+                    afile, akey_path, pwd)
                 was_extracted = self.cache[akey_path].is_extracted
                 apath = self.cache[akey_path].get_extracted_file(afile)
                 link_file_load(apath, file)

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -11,20 +11,17 @@
 
 __docformat__ = 'restructuredtext'
 
-from distutils.version import LooseVersion
 import logging
 import os
+from distutils.version import LooseVersion
+from os.path import curdir
+from os.path import join as opj
 from os.path import (
-    curdir,
-    join as opj,
     normpath,
     relpath,
 )
 
 from datalad import ssh_manager
-
-from datalad.ui import ui
-
 from datalad.cmd import (
     CommandError,
     StdOutErrCapture,
@@ -32,24 +29,24 @@ from datalad.cmd import (
 )
 from datalad.consts import (
     TIMESTAMP_FMT,
-    WEB_META_LOG
+    WEB_META_LOG,
 )
-from datalad.distribution.siblings import (
-    _DelayedSuper,
-    Siblings,
-)
+from datalad.core.local.diff import diff_dataset
 from datalad.distribution.dataset import (
     Dataset,
-    datasetmethod,
     EnsureDataset,
-    resolve_path,
+    datasetmethod,
     require_dataset,
+    resolve_path,
+)
+from datalad.distribution.siblings import (
+    Siblings,
+    _DelayedSuper,
 )
 from datalad.interface.base import (
-    build_doc,
     Interface,
+    build_doc,
 )
-from datalad.interface.utils import eval_results
 from datalad.interface.common_opts import (
     annex_group_opt,
     annex_groupwanted_opt,
@@ -61,6 +58,7 @@ from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
 )
+from datalad.interface.utils import eval_results
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureBool,
@@ -75,21 +73,20 @@ from datalad.support.exceptions import (
 )
 from datalad.support.external_versions import external_versions
 from datalad.support.network import (
-    is_ssh,
-    PathRI,
     RI,
+    PathRI,
+    is_ssh,
+)
+from datalad.support.param import Parameter
+from datalad.ui import ui
+from datalad.utils import (
+    _path_,
+    ensure_list,
+    make_tempfile,
+    on_windows,
 )
 from datalad.utils import quote_cmdlinearg as sh_quote
-from datalad.support.param import Parameter
-from datalad.utils import (
-    make_tempfile,
-    _path_,
-    slash_join,
-    ensure_list,
-)
-from datalad.core.local.diff import diff_dataset
-
-from datalad.utils import on_windows
+from datalad.utils import slash_join
 
 lgr = logging.getLogger('datalad.distribution.create_sibling')
 # Window's own mkdir command creates intermediate directories by default
@@ -188,9 +185,9 @@ def _create_dataset_sibling(
         ds_target_pushurl = target_pushurl.replace('%RELNAME', ds_name) \
             if target_pushurl else ds_url
 
-    lgr.info("Considering to create a target dataset {0} at {1} of {2}".format(
+    lgr.info("Considering to create a target dataset %s at %s of %s",
         localds_path, remoteds_path,
-        "localhost" if isinstance(ri, PathRI) else ri.hostname))
+        "localhost" if isinstance(ri, PathRI) else ri.hostname)
     # Must be set to True only if exists and existing='reconfigure'
     # otherwise we might skip actions if we say existing='reconfigure'
     # but it did not even exist before
@@ -579,8 +576,9 @@ class CreateSibling(Interface):
         if ui:
             # the webui has been moved to the deprecated extension
             try:
-                from datalad_deprecated.sibling_webui \
-                    import upload_web_interface
+                from datalad_deprecated.sibling_webui import (
+                    upload_web_interface,
+                )
             except Exception as e:
                 # we could just test for ModuleNotFoundError (which should be
                 # all that would happen with PY3.6+, but be a little more robust
@@ -826,7 +824,9 @@ class CreateSibling(Interface):
 
             # publish web-interface to root dataset on publication server
             if current_ds.path == refds_path and ui:
-                from datalad_deprecated.sibling_webui import upload_web_interface
+                from datalad_deprecated.sibling_webui import (
+                    upload_web_interface,
+                )
                 lgr.info("Uploading web interface to %s", path)
                 try:
                     upload_web_interface(path, shell, shared, ui)

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -13,27 +13,27 @@
 __docformat__ = 'restructuredtext'
 
 import logging
+
 lgr = logging.getLogger('datalad.interface.base')
 
+import os
+import re
+import textwrap
+import warnings
 from abc import (
     ABC,
     abstractmethod,
 )
-import os
-import re
-import textwrap
+from collections import OrderedDict
 from importlib import import_module
-from collections import (
-    OrderedDict,
-)
-import warnings
 
 import datalad
+from datalad.distribution.dataset import (
+    Dataset,
+    resolve_path,
+)
 from datalad.interface.common_opts import eval_params
-from datalad.distribution.dataset import Dataset
-from datalad.distribution.dataset import resolve_path
 from datalad.support.exceptions import CapturedException
-
 
 default_logchannels = {
     '': 'debug',
@@ -240,6 +240,7 @@ def update_docstring_with_parameters(func, params, prefix=None, suffix=None,
     the number and names of the callables arguments.
     """
     from datalad.utils import getargspec
+
     # get the signature
     args, varargs, varkw, defaults = getargspec(func, include_kwonlyargs=True)
     defaults = defaults or tuple()
@@ -394,7 +395,7 @@ def build_doc(cls, **kwargs):
     # would need to actually call the command once in order to build this
     # docstring.
 
-    lgr.debug("Building doc for {}".format(cls))
+    lgr.debug("Building doc for %s", cls)
 
     cls_doc = cls.__doc__
     if hasattr(cls, '_docs_'):

--- a/datalad/local/add_archive_content.py
+++ b/datalad/local/add_archive_content.py
@@ -504,8 +504,8 @@ class AddArchiveContent(Interface):
                         for regexp in exclude:
                             if re.search(regexp, extracted_file):
                                 lgr.debug(
-                                    "Skipping {extracted_file} since contains "
-                                    "{regexp} pattern".format(**locals()))
+                                    "Skipping %s since contains %s pattern",
+                                    extracted_file, regexp)
                                 stats.skipped += 1
                                 raise StopIteration
                     except StopIteration:
@@ -624,8 +624,8 @@ class AddArchiveContent(Interface):
                         stats.dropped += 1
                     stats.add_annex += 1
                 else:
-                    lgr.debug("File {} was added to git, not adding url".format(
-                        target_file_path))
+                    lgr.debug("File %s was added to git, not adding url",
+                        target_file_path)
                     stats.add_git += 1
 
                 if delete_after:
@@ -638,7 +638,7 @@ class AddArchiveContent(Interface):
                 del target_file
 
             if delete and archive and origin != 'key':
-                lgr.debug("Removing the original archive {}".format(archive))
+                lgr.debug("Removing the original archive %s", archive)
                 # force=True since some times might still be staged and fail
                 annex.remove(str(archive_path), force=True)
 

--- a/datalad/metadata/metadata.py
+++ b/datalad/metadata/metadata.py
@@ -13,12 +13,10 @@ __docformat__ = 'restructuredtext'
 
 import glob
 import logging
-import re
 import os
 import os.path as op
-from collections import (
-    OrderedDict,
-)
+import re
+from collections import OrderedDict
 from pathlib import Path
 from typing import (
     Dict,
@@ -26,55 +24,58 @@ from typing import (
     Optional,
 )
 
-from datalad import cfg
-from datalad.interface.annotate_paths import _minimal_annotate_paths
-from datalad.interface.base import Interface
-from datalad.interface.results import get_status_dict
-from datalad.interface.utils import (
-    eval_results,
-    generic_result_renderer,
-)
-from datalad.interface.base import build_doc
-from datalad.metadata.definitions import version as vocabulary_version
-from datalad.support.collections import ReadOnlyDict, _val2hashable
-from datalad.support.constraints import (
-    EnsureNone,
-    EnsureBool,
-    EnsureStr,
-)
-from datalad.support.gitrepo import GitRepo
-from datalad.support.annexrepo import AnnexRepo
-from datalad.support.exceptions import CapturedException
-from datalad.support.param import Parameter
 import datalad.support.ansi_colors as ac
-from datalad.support.json_py import (
-    load as jsonload,
-    load_xzstream,
+from datalad import cfg
+from datalad.consts import (
+    OLDMETADATA_DIR,
+    OLDMETADATA_FILENAME,
 )
-from datalad.interface.common_opts import (
-    recursion_flag,
-    reporton_opt,
-)
+from datalad.core.local.status import get_paths_by_ds
 from datalad.distribution.dataset import (
     Dataset,
     EnsureDataset,
     datasetmethod,
     require_dataset,
 )
+from datalad.dochelpers import single_or_plural
+from datalad.interface.annotate_paths import _minimal_annotate_paths
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.common_opts import (
+    recursion_flag,
+    reporton_opt,
+)
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import (
+    eval_results,
+    generic_result_renderer,
+)
+from datalad.log import log_progress
+from datalad.metadata.definitions import version as vocabulary_version
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.collections import (
+    ReadOnlyDict,
+    _val2hashable,
+)
+from datalad.support.constraints import (
+    EnsureBool,
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.exceptions import CapturedException
+from datalad.support.gitrepo import GitRepo
+from datalad.support.json_py import load as jsonload
+from datalad.support.json_py import load_xzstream
+from datalad.support.param import Parameter
+from datalad.ui import ui
 from datalad.utils import (
+    as_unicode,
     ensure_list,
     path_is_subpath,
     path_startswith,
-    as_unicode,
 )
-from datalad.ui import ui
-from datalad.dochelpers import single_or_plural
-from datalad.consts import (
-    OLDMETADATA_DIR,
-    OLDMETADATA_FILENAME,
-)
-from datalad.log import log_progress
-from datalad.core.local.status import get_paths_by_ds
 
 # Check availability of new-generation metadata
 try:
@@ -225,6 +226,7 @@ def legacy_query_aggregated_metadata(reporton, ds, aps, recursive=False,
       Of result dictionaries.
     """
     from datalad.coreapi import get
+
     # look for and load the aggregation info for the base dataset
     agginfos, agg_base_path = load_ds_aggregate_db(ds)
 
@@ -480,11 +482,11 @@ def _get_metadata(ds, types, global_meta=None, content_meta=None, paths=None):
         if nocontent:
             # TODO better fail, or support incremental and label this file as no present
             lgr.warning(
-                '{} files have no content present, '
-                'some extractors will not operate on {}'.format(
+                '%s files have no content present, '
+                'some extractors will not operate on %s',
                     nocontent,
                     'them' if nocontent > 10
-                           else [p for p, c, a in content_info if not c and a])
+                           else [p for p, c, a in content_info if not c and a]
             )
 
     # pull out potential metadata field blacklist config settings

--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -12,24 +12,29 @@
 __docformat__ = 'restructuredtext'
 
 import logging
+
 from datalad.log import log_progress
+
 lgr = logging.getLogger('datalad.metadata.search')
 
 import os
 import re
-from functools import partial
-from os.path import join as opj, exists
-from os.path import relpath
-from os.path import normpath
 import sys
+from functools import partial
+from os.path import exists
+from os.path import join as opj
+from os.path import (
+    normpath,
+    relpath,
+)
 from time import time
 
 from datalad import cfg
 from datalad.consts import SEARCH_INDEX_DOTGITDIR
-from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import (
-    datasetmethod,
+    Dataset,
     EnsureDataset,
+    datasetmethod,
     require_dataset,
 )
 from datalad.dochelpers import single_or_plural
@@ -38,6 +43,7 @@ from datalad.interface.base import (
     build_doc,
 )
 from datalad.interface.utils import eval_results
+from datalad.metadata.metadata import query_aggregated_metadata
 from datalad.support.constraints import (
     EnsureInt,
     EnsureNone,
@@ -56,7 +62,6 @@ from datalad.utils import (
     shortened_repr,
     unicode_srctypes,
 )
-from datalad.metadata.metadata import query_aggregated_metadata
 
 # TODO: consider using plain as_unicode, without restricting
 # the types?
@@ -180,7 +185,10 @@ def _meta2autofield_dict(meta, val2str=True, schema=None, consider_ucn=True):
                 yield key, v
 
     def get_indexer(metadata_format_name: str) -> callable:
-        from pkg_resources import EntryPoint, iter_entry_points
+        from pkg_resources import (
+            EntryPoint,
+            iter_entry_points,
+        )
 
         all_indexers = tuple(iter_entry_points('datalad.metadata.indexers', metadata_format_name))
         if all_indexers:
@@ -406,6 +414,7 @@ class _WhooshSearch(_Search):
         `meta2doc` - must return dict for index document from result input
         """
         from whoosh import index as widx
+
         from .metadata import get_ds_aggregate_db_locations
         dbloc, db_base_path = get_ds_aggregate_db_locations(self.ds)
         # what is the latest state of aggregated metadata
@@ -465,8 +474,8 @@ class _WhooshSearch(_Search):
                 else:
                     raise
 
-        lgr.info('{} search index'.format(
-            'Rebuilding' if exists(index_dir) else 'Building'))
+        lgr.info('%s search index',
+            'Rebuilding' if exists(index_dir) else 'Building')
 
         if not exists(index_dir):
             os.makedirs(index_dir)
@@ -541,7 +550,7 @@ class _WhooshSearch(_Search):
                 admin['id'] = res.get('dsid', None)
 
             doc.update({k: ensure_unicode(v) for k, v in admin.items()})
-            lgr.debug("Adding document to search index: {}".format(doc))
+            lgr.debug("Adding document to search index: %s", doc)
             # inject into index
             idx.add_document(**doc)
             idx_size += 1
@@ -586,7 +595,7 @@ class _WhooshSearch(_Search):
                 max_nresults,
                 single_or_plural('match', 'matches', max_nresults)
             )
-            lgr.info('Query completed in {} sec.{}'.format(
+            lgr.info('Query completed in %s sec.%s',
                 hits.runtime,
                 ' Reporting {}.'.format(
                     ('up to ' + topstr)
@@ -595,7 +604,7 @@ class _WhooshSearch(_Search):
                 )
                 if not hits.is_empty()
                 else ' No matches.'
-            ))
+            )
 
             if not hits:
                 return
@@ -642,8 +651,8 @@ class _WhooshSearch(_Search):
 
             if max_nresults and nhits == max_nresults:
                 lgr.info(
-                    "Reached the limit of {}, there could be more which "
-                    "were not reported.".format(topstr)
+                    "Reached the limit of %s, there could be more which "
+                    "were not reported.", topstr
                 )
 
 
@@ -841,8 +850,8 @@ class _EGrepCSSearch(_Search):
                         single_or_plural('match', 'matches', max_nresults)
                     )
                     lgr.info(
-                        "Reached the limit of {}, there could be more which "
-                        "were not reported.".format(topstr)
+                        "Reached the limit of %s, there could be more which "
+                        "were not reported.", topstr
                     )
                     break
 

--- a/datalad/support/archives.py
+++ b/datalad/support/archives.py
@@ -11,56 +11,55 @@
 """
 
 import hashlib
-import os
-import tempfile
-import string
-import random
 import logging
+import os
+import random
+import string
+import tempfile
 
-from datalad.support.path import (
-    join as opj,
-    exists,
-    abspath,
-    isabs,
-    normpath,
-    relpath,
-    pardir,
-    isdir,
-    sep as opsep,
-)
-
-from datalad.support.locking import lock_if_check_fails
-from datalad.support.external_versions import external_versions
+from datalad import cfg
+from datalad.config import anything2bool
 from datalad.consts import ARCHIVES_TEMP_DIR
+from datalad.support.external_versions import external_versions
+from datalad.support.locking import lock_if_check_fails
+from datalad.support.path import (
+    abspath,
+    exists,
+    isabs,
+    isdir,
+)
+from datalad.support.path import join as opj
+from datalad.support.path import (
+    normpath,
+    pardir,
+    relpath,
+)
+from datalad.support.path import sep as opsep
 from datalad.utils import (
+    Path,
     any_re_search,
     ensure_bytes,
     ensure_unicode,
-    unlink,
-    rmtemp,
-    rmtree,
     get_tempfile_kwargs,
     on_windows,
-    Path,
+    rmtemp,
+    rmtree,
+    unlink,
 )
-from datalad import cfg
-from datalad.config import anything2bool
 
 # fall back on patool, if requested, or 7z is not found
 if (cfg.obtain('datalad.runtime.use-patool', default=False,
                valtype=anything2bool)
         or not external_versions['cmd:7z']):
-    from datalad.support.archive_utils_patool import (
-        decompress_file as _decompress_file,
-        # other code expects this to be here
-        compress_files
-    )
+    from datalad.support.archive_utils_patool import compress_files
+    from datalad.support.archive_utils_patool import \
+        decompress_file as \
+        _decompress_file  # other code expects this to be here
 else:
-    from datalad.support.archive_utils_7z import (
-        decompress_file as _decompress_file,
-        # other code expects this to be here
-        compress_files
-    )
+    from datalad.support.archive_utils_7z import compress_files
+    from datalad.support.archive_utils_7z import \
+        decompress_file as \
+        _decompress_file  # other code expects this to be here
 
 lgr = logging.getLogger('datalad.support.archives')
 
@@ -323,7 +322,7 @@ class ExtractedArchive(object):
         # we need to extract the archive
         # TODO: extract to _tmp and then move in a single command so we
         # don't end up picking up broken pieces
-        lgr.debug(u"Extracting {self._archive} under {path}".format(**locals()))
+        lgr.debug("Extracting %s under %s", self._archive, path)
         if exists(path):
             lgr.debug(
                 "Previous extracted (but probably not fully) cached archive "
@@ -416,7 +415,7 @@ class ExtractedArchive(object):
         return leading if leading is None else opj(*leading)
 
     def get_extracted_file(self, afile):
-        lgr.debug(u"Requested file {afile} from archive {self._archive}".format(**locals()))
+        lgr.debug("Requested file %s from archive %s", afile, self._archive)
         # TODO: That could be a good place to provide "compatibility" layer if
         # filenames within archive are too obscure for local file system.
         # We could somehow adjust them while extracting and here channel back

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1003,7 +1003,7 @@ class GitRepo(CoreGitRepo):
         ntries = 5  # 3 is not enough for robust workaround
         for trial in range(ntries):
             try:
-                lgr.debug("Git clone from {0} to {1}".format(url, path))
+                lgr.debug("Git clone from %s to %s", url, path)
 
                 res = GitWitlessRunner().run(cmd, protocol=GitProgress)
                 # fish out non-critical warnings by git-clone
@@ -1727,7 +1727,7 @@ class GitRepo(CoreGitRepo):
                                 read_only=True)
         except CommandError as e:
             if 'HEAD is not a symbolic ref' in e.stderr:
-                lgr.debug("detached HEAD in {0}".format(self))
+                lgr.debug("detached HEAD in %s", self)
                 return None
             else:
                 raise e

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -8,6 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import logging
+
 lgr = logging.getLogger('datalad.network')
 
 lgr.log(5, "Importing support.network")
@@ -18,44 +19,48 @@ import pickle
 import re
 import sys
 import time
-import iso8601
-
-from hashlib import md5
 from collections import OrderedDict
-from os.path import (
-    dirname,
-    join as opj,
-)
+from hashlib import md5
 from ntpath import splitdrive as win_splitdrive
-
-from urllib.request import Request
+from os.path import dirname
+from os.path import join as opj
+from urllib.error import URLError
 from urllib.parse import (
-    parse_qsl,
     ParseResult,
-    unquote as urlunquote,
+    parse_qsl,
+)
+from urllib.parse import quote as urlquote
+from urllib.parse import unquote as urlunquote
+from urllib.parse import (
     urlencode,
     urljoin,
     urlparse,
     urlsplit,
     urlunparse,
 )
-from urllib.error import URLError
+from urllib.request import Request
 
-from datalad.utils import (
-    on_windows,
-    PurePath,
-    Path,
+import iso8601
+
+from datalad import (
+    cfg,
+    consts,
 )
-from datalad.utils import ensure_dir, ensure_bytes, ensure_unicode, map_items
-from datalad import consts
-from datalad import cfg
 from datalad.support.cache import lru_cache
 from datalad.support.exceptions import CapturedException
+from datalad.utils import (
+    Path,
+    PurePath,
+    ensure_bytes,
+    ensure_dir,
+    ensure_unicode,
+    map_items,
+    on_windows,
+)
 
 # !!! Lazily import requests where needed -- needs 30ms or so
 # import requests
 
-from urllib.parse import quote as urlquote
 
 
 def is_windows_path(path):
@@ -178,7 +183,10 @@ def get_tld(url):
     return rec.netloc
 
 
-from email.utils import parsedate_tz, mktime_tz
+from email.utils import (
+    mktime_tz,
+    parsedate_tz,
+)
 
 
 def rfc2822_to_epoch(datestr):
@@ -1021,7 +1029,7 @@ def get_cached_url_content(url, name=None, fetcher=None, maxage=None):
         ensure_dir(dirname(doc_fname))
         # use pickle to store the entire request result dict
         pickle.dump(doc, open(doc_fname, 'wb'))
-        lgr.debug("stored result of request to '{}' in {}".format(url, doc_fname))
+        lgr.debug("stored result of request to '%s' in %s", url, doc_fname)
     return doc
 
 

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -156,7 +156,10 @@ def setup_package():
         plugintest,
     )
 
-    from datalad import consts, lgr
+    from datalad import (
+        consts,
+        lgr,
+    )
     from datalad.support.annexrepo import AnnexRepo
     from datalad.support.external_versions import external_versions
     from datalad.tests.utils import (
@@ -1764,8 +1767,8 @@ def ignore_nose_capturing_stdout(func):
     """
     lgr.warning(
         "@ignore_nose_capturing_stdout no longer does anything - nose should "
-        "just be monkey patched in setup_package. {} still has it"
-        .format(func.__name__)
+        "just be monkey patched in setup_package. %s still has it",
+        func.__name__
     )
     return func
 

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1601,8 +1601,8 @@ def ignore_nose_capturing_stdout(func):
     """
     lgr.warning(
         "@ignore_nose_capturing_stdout no longer does anything - nose should "
-        "just be monkey patched in setup_package. {} still has it"
-        .format(func.__name__)
+        "just be monkey patched in setup_package. %s still has it",
+        func.__name__
     )
     return func
 

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -1834,7 +1834,7 @@ def knows_annex(path):
     """
     from os.path import exists
     if not exists(path):
-        lgr.debug("No annex: test path {0} doesn't exist".format(path))
+        lgr.debug("No annex: test path %s doesn't exist", path)
         return False
     from datalad.support.gitrepo import GitRepo
     return GitRepo(path, init=False, create=False).is_with_annex()

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ deps =
     codespell~=2.0
 commands =
     codespell -x .codespell-ignorelines -D- -I .codespell-ignorewords --skip "_version.py,*.pem" datalad setup.py _datalad_build_support
+    # pylinting limited set of known obvious issues only
+    pylint -d all -e W1202 datalad setup.py
 
 [testenv:flake8]
 commands = flake8 {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ setenv=
 skip_install = true
 deps =
     codespell~=2.0
+    pylint~=2.15
 commands =
     codespell -x .codespell-ignorelines -D- -I .codespell-ignorewords --skip "_version.py,*.pem" datalad setup.py _datalad_build_support
     # pylinting limited set of known obvious issues only


### PR DESCRIPTION
#7117 made me look into tightening our automated linting.  Adding pylinting for a single warning/error to start with:

    W1202: Use lazy % or % formatting in logging functions (logging-format-interpolation)

which I believe nobody would doubt to be a good thing to do.
- [ ] any objections?
- [x] fix the code
- later (other PRs): enable more checks while at it or may be postpone to follow up dedicated PRs, but worth listing here may be (I was looking for the one in #7117 like *use of undefined variable* but `pylint` didn't warn about that :-/ )

[appveyor skip]
[travis skip]

edit: had to cancel appveyor manually -- for some reason it ignored the annotation I gave
