### PR TITLE
Improve `datalad.support.tests.test_parallel.py::test_stalling`

### DIFF
--- a/changelog.d/pr-7119.md
+++ b/changelog.d/pr-7119.md
@@ -1,0 +1,7 @@
+### 🧪 Tests
+
+- Increase the upper time limit after which we assume that a process is stalling. 
+  That should reduce false positives from `datalad.support.tests.test_parallel.py::test_stalling`,
+  without impacting the runtime of passing tests.
+  [PR #7119](https://github.com/datalad/datalad/pull/7119)
+  (by [@christian-monch](https://github.com/christian-monch))


### PR DESCRIPTION
 This PR extends the time after which we believe to witness a stalling thread to at least 5 seconds. This time-span will only be exhausted if the test is failing, i.e. an executing worker is stalling (or very very slow). The duration of a passing test is usually in the range of a few dozen milliseconds.

The commit adds output processing in order to actually start of few runner-related threads and performs thread-based asynchronous data processing.
    
The large time limit will hopefully reduce the number of false positives greatly, though it cannot *guarantee* the absence of false positives, it just makes them unlikely, i.e. less than 1 false positive per 10e5 executions.
