### PR TITLE
Fix RIA file URL reporting in exception handling

### DIFF
--- a/changelog.d/pr-7123.md
+++ b/changelog.d/pr-7123.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Fix RIA file URL reporting in exception handling.  [PR #7123](https://github.com/datalad/datalad/pull/7123) (by [@adswa](https://github.com/adswa))

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1058,8 +1058,9 @@ class RIARemote(SpecialRemote):
         """ Get version and config flags from remote file
         """
         if self.ria_store_url:
-            # construct path to ria_layout_version file in store for reporting
-            target_ri = self.ria_store_url[4:] + '/' + path.name
+            # construct path to ria_layout_version file for reporting
+            target_ri = self.ria_store_url[4:] +\
+                        path.relative_to(Path(self.store_base_path)).as_posix()
         elif self.storage_host:
             target_ri = "ssh://{}{}".format(self.storage_host, path.as_posix())
         else:

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1057,9 +1057,9 @@ class RIARemote(SpecialRemote):
     def _get_version_config(self, path):
         """ Get version and config flags from remote file
         """
-
         if self.ria_store_url:
-            target_ri = self.ria_store_url[4:] + path.as_posix()
+            # construct path to ria_layout_version file in store for reporting
+            target_ri = self.ria_store_url[4:] + '/' + path.name
         elif self.storage_host:
             target_ri = "ssh://{}{}".format(self.storage_host, path.as_posix())
         else:


### PR DESCRIPTION
Probing for the existence of a ria_layout_version file internally misconstructs a ``target_ri`` variable only used for reporting the path to the file. We noticed recently that this reporting was off, duplicating paths, e.g.:

```
[INFO   ] RIA store unavailable. 
-caused by- 
file:///tmp/myriastore/tmp/myriastore/ria-layout-version not found. 
-caused by- 
[Errno 2] No such file or directory: '/tmp/myriastore/ria-layout-version'
```
This duplication should be fixed with this small change. It extracts the file name (``ria_layout_version``) and appends it to the ria store location, instead of appending the entire path to it.


