### PR TITLE
Unrestrict pytest and pytest-cov versions

### DIFF
--- a/changelog.d/pr-7125.md
+++ b/changelog.d/pr-7125.md
@@ -1,0 +1,3 @@
+### 🔩 Dependencies
+
+- Unrestrict pytest and pytest-cov versions.  [PR #7125](https://github.com/datalad/datalad/pull/7125) (by [@jwodder](https://github.com/jwodder))

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ requires = {
         'BeautifulSoup4',  # VERY weak requirement, still used in one of the tests
         'httpretty>=0.9.4',  # Introduced py 3.6 support
         'mypy~=0.900',
-        'pytest~=7.0',
-        'pytest-cov~=3.0',
+        'pytest',
+        'pytest-cov',
         'pytest-fail-slow~=0.2',
         'types-python-dateutil',
         'types-requests',


### PR DESCRIPTION
pytest-cov was being restricted to an old version that produces warnings when combined with the latest version of pytest.  At the same time, it's doubtful that restricting the maximum version of pytest will ever help.