### PR TITLE
XFAIL a check on length of results in test_gracefull_death

### DIFF
--- a/changelog.d/pr-7126.md
+++ b/changelog.d/pr-7126.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- XFAIL a check on length of results in test_gracefull_death.  [PR #7126](https://github.com/datalad/datalad/pull/7126) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/support/tests/test_parallel.py
+++ b/datalad/support/tests/test_parallel.py
@@ -14,6 +14,8 @@ from time import (
     time,
 )
 
+import pytest
+
 # logging effects threading and causes some 'weak' tests to fail,
 # so we will just skip those (well, if happens again -- disable altogether)
 from datalad import lgr
@@ -192,7 +194,12 @@ def test_gracefull_death():
         ValueError)
     # we will get some results, seems around 4 and they should be "sequential"
     assert_equal(results, list(range(len(results))))
-    assert_greater_equal(len(results), 2)
+    try:
+        assert_greater_equal(len(results), 2)
+    except AssertionError:
+        # Possible TODO: if tests below would start failing too, move xfail to the level
+        # of the entire test
+        pytest.xfail(f"Rarely but happens. Got only {len(results)} instead of at least 2")
 
     # This test relies too much on threads scheduling to not hog up on handling
     # consumers, but if it happens so - they might actually consume all results


### PR DESCRIPTION
Still happens in some busy environments, like recently within https://app.travis-ci.com/github/datalad/datalad/jobs/586725682 of https://github.com/datalad/datalad/pull/7118

Attn @bpoldrack who was after all the flaky tests
