### PR TITLE
BF(TST): allow for "file" protocol

### DIFF
--- a/changelog.d/pr-7130.md
+++ b/changelog.d/pr-7130.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- BF(TST): allow for "file" protocol.  [PR #7130](https://github.com/datalad/datalad/pull/7130) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/changelog.d/pr-7130.md
+++ b/changelog.d/pr-7130.md
@@ -1,3 +1,3 @@
 ### 🧪 Tests
 
-- BF(TST): allow for "file" protocol.  [PR #7130](https://github.com/datalad/datalad/pull/7130) (by [@yarikoptic](https://github.com/yarikoptic))
+- Configure Git to allow for "file" protocol in tests.  [PR #7130](https://github.com/datalad/datalad/pull/7130) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/conftest.py
+++ b/datalad/conftest.py
@@ -89,6 +89,10 @@ def setup_package():
 	# allowed by default
 	allowed-url-schemes = http https file
 	allowed-http-addresses = all
+[protocol "file"]
+    # since git 2.38.1 cannot by default use local clones for submodules
+    # https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253
+    allow = always
 """ + os.environ.get('DATALAD_TESTS_GITCONFIG', '').replace('\\n', os.linesep)
             # TODO: split into a function + context manager
             with make_tempfile(mkdir=True) as new_home:


### PR DESCRIPTION
Similarly to git-annex disallowing it by default, now git started to disallow it for local clones. In our case it should be safe since we are cloning our own repos in the tests, thus should not be subject to the malicious attempts.

Closes #7116

Some runs in appveyor already carry new `git` so let's see if they all turn green now.