### PR TITLE
Let EnsureDataset handle Path instances

### DIFF
--- a/changelog.d/pr-7133.md
+++ b/changelog.d/pr-7133.md
@@ -1,0 +1,6 @@
+### Internal
+
+- Allow EnsureDataset constraint to handle Path instances.
+  Fixes [#7069](https://github.com/datalad/datalad/issues/7069) via
+  [PR #7133](https://github.com/datalad/datalad/pull/7133)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -522,7 +522,7 @@ class EnsureDataset(Constraint):
     def __call__(self, value):
         if isinstance(value, Dataset):
             return value
-        elif isinstance(value, str):
+        elif isinstance(value, (str, PurePath)):
             # we cannot convert to a Dataset class right here
             # - duplicates require_dataset() later on
             # - we need to be able to distinguish between a bound

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -81,9 +81,9 @@ def test_EnsureDataset():
     assert_raises(ValueError, c, {"what": "ever"})
 
     # let's a Dataset instance pass, but leaves a path untouched
-    test_path = opj("some", "path")
-    ok_(isinstance(c(test_path), type(test_path)))
-    ok_(isinstance(Dataset(test_path), Dataset))
+    for test_path in [opj("some", "path"), Path("some") / "path"]:
+        ok_(isinstance(c(test_path), type(test_path)))
+        ok_(isinstance(Dataset(test_path), Dataset))
 
     # Note: Ensuring that string is valid path is not
     # part of the constraint itself, so not explicitly tested here.


### PR DESCRIPTION
Previously this constraint allowed for strings only.

Closes #7069
