### PR TITLE
BF: read RIA config from stdin instead of temporary file

### DIFF
--- a/changelog.d/pr-7147.md
+++ b/changelog.d/pr-7147.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: read RIA config from stdin instead of temporary file.  Fixes [#6514](https://github.com/datalad/datalad/issues/6514) via [PR #7147](https://github.com/datalad/datalad/pull/7147) (by [@adswa](https://github.com/adswa))


### PR DESCRIPTION
A RIA postclone config hook tried to read a special remote UUID from a stores config file by writing the config files contents to a temporary config file, and subsequently running ``git config -f <thatfile>``. As outlined in a comment by @bpoldrack in the code, ``git config -f -`` can read from stdin:

```
echo '[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = true\n' | git config -f - core.filemode
true
```

A quick chat in the Git IRC channel hinted that this is supported by git as its a unix convention. Trial and error confirms that this patch also runs successfully in a Windows CMD. I'll rely on the tests on MacOS to check if it runs there successfully, too. By switching to a git config call with stdin as the input file, we spare the need to write a temporary RIA config file. This fix could thus fix #6514, where a user error lead to a non-existent TMP path and a subsequent failure to create the temporary config file.