### PR TITLE
Fix ls import in benchmarks

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -71,7 +71,7 @@ class SuprocBenchmarks(object):
             # so fails correctly identify rc as pre .0
             if external_versions['datalad'] < '0.12.1':
                 from datalad import utils
-                from datalad.interface import ls
+                from datalad.api import ls
                 utils.is_interactive = is_interactive
                 ls.is_interactive = is_interactive
             SuprocBenchmarks._monkey_patched = True

--- a/changelog.d/pr-7154.md
+++ b/changelog.d/pr-7154.md
@@ -1,0 +1,6 @@
+### 🏠 Internal
+
+- Fix import of the `ls` command from datalad-deprecated for benchmarks.
+  Fixes [#7149](https://github.com/datalad/datalad/issues/7149) via
+  [PR #7154](https://github.com/datalad/datalad/pull/7154)
+  (by [@bpoldrack](https://github.com/bpoldrack))


### PR DESCRIPTION
ls command moved to datalad-deprecated. Import from api module, not from interface.

Closes #7149

