### PR TITLE
BF(TST): for older versions allow either replaced or not -

### DIFF
--- a/datalad/customremotes/tests/test_datalad.py
+++ b/datalad/customremotes/tests/test_datalad.py
@@ -48,13 +48,12 @@ def check_basic_scenario(url, d=None):
     filenames = glob.glob(op.join(d, '3versions[-_]allversioned.txt'))
     eq_(len(filenames), 1)
     filename = op.basename(filenames[0])
-    if external_versions['cmd:annex'] < '8.20200501':
-        assert_in('_', filename)
-    # Date after the fix in 8.20200501-53-gcabbc91b1
-    elif external_versions['cmd:annex'] >= '8.20200512':
+    # Date after the fix in 8.20200501-53-gcabbc91b1 - must have '-'
+    if external_versions['cmd:annex'] >= '8.20200512':
         assert_in('-', filename)
     else:
-        pass  # either of those is ok
+        # either one is ok
+        assert '_' in filename or '-' in filename
 
     whereis1 = annex.whereis(filename, output='full')
     eq_(len(whereis1), 2)  # here and datalad


### PR DESCRIPTION
Our cron tests against git annex 8.20200309 were failing due to wrong assumption that some prior old versions MUST had it wrong, which apparently was not the case.

Addressed 1/2 of #7157
