### PR TITLE
Fix test failure with old annex

### DIFF
--- a/changelog.d/pr-7159.md
+++ b/changelog.d/pr-7159.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Fix test failure with old annex.  Fixes [#7157](https://github.com/datalad/datalad/issues/7157) via [PR #7159](https://github.com/datalad/datalad/pull/7159) (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1117,7 +1117,7 @@ class RIARemote(SpecialRemote):
         self.remote_git_dir, self.remote_archive_dir, self.remote_obj_dir = \
             self.get_layout_locations(store_base_path, self.archive_id)
 
-        read_only_msg = "Treating remote as read-only in order to" \
+        read_only_msg = "Treating remote as read-only in order to " \
                         "prevent damage by putting things into an unknown " \
                         "version of the target layout. You can overrule this " \
                         "by setting 'annex.ora-remote.<name>.force-write=true'."

--- a/datalad/distributed/tests/test_ria_basics.py
+++ b/datalad/distributed/tests/test_ria_basics.py
@@ -31,7 +31,10 @@ from datalad.distributed.tests.ria_utils import (
     get_all_files,
     populate_dataset,
 )
-from datalad.support.exceptions import CommandError
+from datalad.support.exceptions import (
+    CommandError,
+    IncompleteResultsError,
+)
 from datalad.tests.utils_pytest import (
     SkipTest,
     assert_equal,
@@ -470,9 +473,7 @@ def _test_version_check(host, dspath, store):
         f.write("arbitrary addition")
     ds.save(message="Add a new_file")
 
-    # TODO: use self.annex.error in special remote and see whether we get an
-    #       actual error result
-    with assert_raises(CommandError):
+    with assert_raises((CommandError, IncompleteResultsError)):
         ds.push('new_file', to='store')
 
     # However, we can force it by configuration
@@ -486,6 +487,7 @@ def _test_version_check(host, dspath, store):
 def test_version_check_ssh():
     # TODO: Skipped due to gh-4436
     _test_version_check('datalad-test')
+
 
 def test_version_check():
     _test_version_check(None)


### PR DESCRIPTION
This test asserts that the push call will fail, because of read-only mode of the ORA remote. This is what happens, but with older annex we get an `IncompleteResultsError` rather than a `CommandError`. Not sure what changed for this to happen now, but in any case: `IncompleteResultsError` would be more desireable to begin with as we get an actual error result rather than a crash + if there's something to change to get this with all annex versions, it's in `push` or at a more generic layer when calling annex. The test, however, only is about testing that annex-copy and by extension datalad-push with the ORA remote fails under these circumstances.
Hence, accept both ways of failing from within this test. The difference warrants an investigation of `push`/`Runner` or whatever is causing the difference here, though.

Closes #7157