### PR TITLE
RF: Specify parameter choices uniformly

### DIFF
--- a/changelog.d/pr-7161.md
+++ b/changelog.d/pr-7161.md
@@ -1,0 +1,6 @@
+### 🏠 Internal
+
+- Unify definition of parameter choices with `datalad clean`.
+  Fixes [#7026](https://github.com/datalad/datalad/issues/7026) via
+  [PR #7161](https://github.com/datalad/datalad/pull/7161)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/local/clean.py
+++ b/datalad/local/clean.py
@@ -33,7 +33,10 @@ from datalad.interface.common_opts import (
 )
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
-from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import (
+    EnsureChoice,
+    EnsureNone,
+)
 from datalad.support.param import Parameter
 from datalad.utils import (
     Path,
@@ -92,11 +95,11 @@ class Clean(Interface):
         what=Parameter(
             args=("--what",),
             dest='what',
-            choices=('cached-archives', 'annex-tmp', 'annex-transfer',
-                     'search-index'),
             nargs="*",
             doc="""What to clean. If none specified -- all known
-            targets are considered."""),
+            targets are considered.""",
+            constraints=EnsureChoice('cached-archives', 'annex-tmp',
+                'annex-transfer', 'search-index') | EnsureNone()),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
     )


### PR DESCRIPTION
`clean` was an outlier in that regard.

Closes #7026
