### PR TITLE
BF: Prevent doomed annex calls on files we already know are untracked

### DIFF
--- a/changelog.d/pr-7166.md
+++ b/changelog.d/pr-7166.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: Prevent doomed annex calls on files we already know are untracked.  Fixes [#7032](https://github.com/datalad/datalad/issues/7032) via [PR #7166](https://github.com/datalad/datalad/pull/7166) (by [@adswa](https://github.com/adswa))

--- a/changelog.d/pr-7166.md
+++ b/changelog.d/pr-7166.md
@@ -1,3 +1,3 @@
 ### 🐛 Bug Fixes
 
-- BF: Prevent doomed annex calls on files we already know are untracked.  Fixes [#7032](https://github.com/datalad/datalad/issues/7032) via [PR #7166](https://github.com/datalad/datalad/pull/7166) (by [@adswa](https://github.com/adswa))
+- Prevent doomed annex calls on files we already know are untracked.  Fixes [#7032](https://github.com/datalad/datalad/issues/7032) via [PR #7166](https://github.com/datalad/datalad/pull/7166) (by [@adswa](https://github.com/adswa))

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -168,6 +168,15 @@ def yield_dataset_status(ds, paths, annexinfo, untracked, recursion_limit,
         eval_submodule_state=eval_submodule_state,
         _cache=cache)
     if annexinfo and hasattr(repo, 'get_content_annexinfo'):
+        if paths:
+            # when an annex query has been requested for specific paths,
+            # exclude untracked files from the annex query (else gh-7032)
+            untracked = [k for k, v in status.items() if
+                         v['state'] == 'untracked']
+            lgr.debug(
+                'Skipping %s.get_content_annexinfo() for untracked paths: %s',
+                repo, paths)
+            [paths.remove(p) for p in untracked]
         lgr.debug('Querying %s.get_content_annexinfo() for paths: %s', repo, paths)
         # this will amend `status`
         repo.get_content_annexinfo(

--- a/datalad/core/local/tests/test_status.py
+++ b/datalad/core/local/tests/test_status.py
@@ -26,6 +26,7 @@ from datalad.tests.utils_pytest import (
     assert_dict_equal,
     assert_in,
     assert_in_results,
+    assert_not_in_results,
     assert_raises,
     assert_repo_status,
     assert_result_count,
@@ -222,6 +223,17 @@ def test_status(_path=None, linkpath=None):
             assert res['type'] == 'symlink', res
         else:
             assert res['type'] != 'symlink', res
+
+@with_tempfile(mkdir=True)
+def test_untracked_annex_query(path=None):
+    # test for #7032
+    ds = Dataset(path).create()
+    (ds.pathobj / 'untracked_file.txt').write_text(u'dummy')
+    res = ds.status(annex='basic', path='untracked_file.txt')
+    assert_not_in_results(
+        res,
+        error_message='File unknown to git',
+        )
 
 
 # https://github.com/datalad/datalad-revolution/issues/64


### PR DESCRIPTION
Fixes #7032 


This change adds a short check if any file in a list of paths given to a ``datalad status --annex `` call is untracked. If it is, it is removed from the list of paths given to the annex query, as we already know that this annex call would fail. 
It does not prevent the status report of being untracked:

```
❱ datalad status --annex basic my some moreuntracked 
untracked: moreuntracked (file)
untracked: my (file)
1 annex'd file (7.0 B recorded total size)
```

If untracked paths are excluded from this query, a trace of it is left in the debug log. 

This PR also adds a small test.