### PR TITLE
MNT: Move eval_results() into interface.base

### DIFF
--- a/changelog.d/pr-7170.md
+++ b/changelog.d/pr-7170.md
@@ -1,3 +1,3 @@
 ### 🏠 Internal
 
-- MNT: Move eval_results() into interface.base.  Fixes [#6694](https://github.com/datalad/datalad/issues/6694) via [PR #7170](https://github.com/datalad/datalad/pull/7170) (by [@adswa](https://github.com/adswa))
+- Move eval_results() into interface.base to simplify imports for command implementations. Deprecate use from interface.utils accordingly. Fixes [#6694](https://github.com/datalad/datalad/issues/6694) via [PR #7170](https://github.com/datalad/datalad/pull/7170) (by [@adswa](https://github.com/adswa))

--- a/changelog.d/pr-7170.md
+++ b/changelog.d/pr-7170.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- MNT: Move eval_results() into interface.base.  Fixes [#6694](https://github.com/datalad/datalad/issues/6694) via [PR #7170](https://github.com/datalad/datalad/pull/7170) (by [@adswa](https://github.com/adswa))

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -25,13 +25,13 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results
 )
 from datalad.interface.common_opts import (
     location_description,
     reckless_opt,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureKeyChoice,

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -20,16 +20,14 @@ import re
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     jobs_opt,
     recursion_limit,
     recursion_flag,
 )
-from datalad.interface.utils import (
-    eval_results,
-    render_action_summary,
-)
+from datalad.interface.utils import render_action_summary
 from datalad.interface.results import annexjson2result
 from datalad.log import log_progress
 from datalad.support.annexrepo import (

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -25,8 +25,10 @@ import os.path as op
 from datalad import cfg
 from datalad import _seed
 from datalad.interface.base import Interface
-from datalad.interface.utils import eval_results
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    build_doc,
+    eval_results,
+)
 from datalad.interface.common_opts import (
     location_description,
 )

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -22,8 +22,8 @@ from datalad.utils import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
-from datalad.interface.utils import eval_results
 
 from datalad.distribution.dataset import (
     Dataset,

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -36,16 +36,14 @@ from datalad.distribution.install import Install
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     jobs_opt,
     save_message_opt,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import (
-    eval_results,
-    generic_result_renderer,
-)
+from datalad.interface.utils import generic_result_renderer
 from datalad.local.unlock import Unlock
 from datalad.support.constraints import (
     EnsureBool,

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -19,6 +19,7 @@ from functools import partial
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     jobs_opt,
@@ -27,7 +28,6 @@ from datalad.interface.common_opts import (
     save_message_opt,
 )
 from datalad.interface.utils import (
-    eval_results,
     get_tree_roots,
     discover_dataset_trace_to_targets,
 )

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -26,15 +26,13 @@ from datalad.utils import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     recursion_limit,
     recursion_flag,
 )
-from datalad.interface.utils import (
-    eval_results,
-    generic_result_renderer,
-)
+from datalad.interface.utils import generic_result_renderer
 import datalad.support.ansi_colors as ac
 from datalad.support.param import Parameter
 from datalad.support.constraints import (

--- a/datalad/distributed/create_sibling_gin.py
+++ b/datalad/distributed/create_sibling_gin.py
@@ -20,8 +20,8 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
-from datalad.interface.utils import eval_results
 from datalad.support.annexrepo import AnnexRepo
 
 

--- a/datalad/distributed/create_sibling_gitea.py
+++ b/datalad/distributed/create_sibling_gitea.py
@@ -19,8 +19,8 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
-from datalad.interface.utils import eval_results
 
 lgr = logging.getLogger('datalad.distributed.create_sibling_gitea')
 

--- a/datalad/distributed/create_sibling_github.py
+++ b/datalad/distributed/create_sibling_github.py
@@ -26,8 +26,8 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
-from datalad.interface.utils import eval_results
 from datalad.support.constraints import (
     EnsureChoice,
     EnsureNone,

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -29,13 +29,13 @@ from ..dochelpers import exc_str
 from ..interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from ..interface.common_opts import (
     publish_depends,
     recursion_flag,
     recursion_limit,
 )
-from ..interface.utils import eval_results
 from ..local.subdatasets import Subdatasets
 from ..support.constraints import (
     EnsureChoice,

--- a/datalad/distributed/create_sibling_gogs.py
+++ b/datalad/distributed/create_sibling_gogs.py
@@ -20,8 +20,8 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
-from datalad.interface.utils import eval_results
 
 lgr = logging.getLogger('datalad.distributed.create_sibling_gogs')
 

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -36,13 +36,13 @@ from datalad.distribution.utils import _yield_ds_w_matching_siblings
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.log import log_progress
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (

--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -26,6 +26,7 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     jobs_opt,
@@ -37,7 +38,6 @@ from datalad.interface.results import (
     results_from_annex_noinfo,
     success_status_map,
 )
-from datalad.interface.utils import eval_results
 from datalad.runner.exception import CommandError
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (

--- a/datalad/distributed/export_archive_ora.py
+++ b/datalad/distributed/export_archive_ora.py
@@ -25,11 +25,11 @@ from datalad.utils import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.results import (
     get_status_dict,
 )
-from datalad.interface.utils import eval_results
 from datalad.support.param import Parameter
 from datalad.support.constraints import (
     EnsureChoice,

--- a/datalad/distributed/export_to_figshare.py
+++ b/datalad/distributed/export_to_figshare.py
@@ -190,7 +190,7 @@ class ExportToFigshare(Interface):
 
     from datalad.support.param import Parameter
     from datalad.distribution.dataset import datasetmethod
-    from datalad.interface.utils import eval_results
+    from datalad.interface.base import eval_results
     from datalad.distribution.dataset import EnsureDataset
     from datalad.support.constraints import (
         EnsureChoice,

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -48,6 +48,7 @@ from datalad.distribution.siblings import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     annex_group_opt,
@@ -60,7 +61,6 @@ from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
 )
-from datalad.interface.utils import eval_results
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureBool,

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -16,8 +16,10 @@ import re
 import os.path as op
 
 from datalad.config import ConfigManager
-from datalad.interface.base import Interface
-from datalad.interface.utils import eval_results
+from datalad.interface.base import (
+    Interface,
+    eval_results,
+)
 from datalad.interface.base import build_doc
 from datalad.interface.results import (
     get_status_dict,

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -26,8 +26,10 @@ from datalad.interface.results import (
     YieldDatasets,
     is_result_matching_pathsource_argument,
 )
-from datalad.interface.utils import eval_results
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    build_doc,
+    eval_results,
+)
 from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -26,6 +26,7 @@ from datalad.downloaders.credentials import UserPassword
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     annex_group_opt,
@@ -41,10 +42,7 @@ from datalad.interface.common_opts import (
     recursion_limit,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import (
-    generic_result_renderer,
-    eval_results,
-)
+from datalad.interface.utils import generic_result_renderer
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureBool,

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -30,12 +30,12 @@ from datalad.interface.common_opts import (
     if_dirty_opt,
     recursion_flag,
 )
-from datalad.interface.utils import (
-    eval_results,
-    handle_dirty_dataset,
-)
+from datalad.interface.utils import handle_dirty_dataset
 from datalad.interface.results import get_status_dict
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    build_doc,
+    eval_results,
+)
 from datalad.utils import (
     ensure_list,
 )

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -18,8 +18,10 @@ from os.path import lexists
 import itertools
 
 from datalad.interface.base import Interface
-from datalad.interface.utils import eval_results
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    build_doc,
+    eval_results,
+)
 from datalad.interface.results import (
     get_status_dict,
     YieldDatasets

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -12,6 +12,7 @@
 
 __docformat__ = 'restructuredtext'
 
+import inspect
 import logging
 
 lgr = logging.getLogger('datalad.interface.base')
@@ -25,15 +26,41 @@ from abc import (
     abstractmethod,
 )
 from collections import OrderedDict
+from functools import wraps
 from importlib import import_module
+from typing import (
+    Callable,
+    Dict,
+    Generator,
+    TypeVar,
+    TYPE_CHECKING,
+)
 
 import datalad
+from datalad import cfg as dlcfg
+from datalad.core.local.resulthooks import (
+    get_jsonhooks_from_config,
+    match_jsonhook2result,
+    run_jsonhook,
+)
 from datalad.distribution.dataset import (
     Dataset,
     resolve_path,
 )
 from datalad.interface.common_opts import eval_params
-from datalad.support.exceptions import CapturedException
+from datalad.interface.results import known_result_xfms
+from datalad.interface.utils import (
+    get_result_filter,
+    keep_result,
+    render_action_summary,
+    xfm_result,
+    _process_results
+)
+from datalad.support.exceptions import (
+    CapturedException,
+    IncompleteResultsError,
+)
+from datalad.utils import get_wrapped_class
 
 default_logchannels = {
     '': 'debug',
@@ -42,6 +69,10 @@ default_logchannels = {
     'impossible': 'warning',
     'error': 'error',
 }
+if TYPE_CHECKING:
+    from .base import Interface
+
+anInterface = TypeVar('anInterface', bound='Interface')
 
 
 def get_api_name(intfspec):
@@ -640,3 +671,289 @@ def _has_eval_results_call(cls):
     """Return True if cls has a __call__ decorated with @eval_results
     """
     return getattr(getattr(cls, '__call__', None), '_eval_results', False)
+
+
+def eval_results(wrapped):
+    """Decorator for return value evaluation of datalad commands.
+
+    Note, this decorator is only compatible with commands that return
+    status dict sequences!
+
+    Two basic modes of operation are supported: 1) "generator mode" that
+    `yields` individual results, and 2) "list mode" that returns a sequence of
+    results. The behavior can be selected via the kwarg `return_type`.
+    Default is "list mode".
+
+    This decorator implements common functionality for result rendering/output,
+    error detection/handling, and logging.
+
+    Result rendering/output configured via the `result_renderer` keyword
+    argument of each decorated command. Supported modes are: 'generic' (a
+    generic renderer producing one line per result with key info like action,
+    status, path, and an optional message); 'json' (a complete JSON line
+    serialization of the full result record), 'json_pp' (like 'json', but
+    pretty-printed spanning multiple lines), 'tailored' custom output
+    formatting provided by each command class (if any), or 'disabled' for
+    no result rendering.
+
+    Error detection works by inspecting the `status` item of all result
+    dictionaries. Any occurrence of a status other than 'ok' or 'notneeded'
+    will cause an IncompleteResultsError exception to be raised that carries
+    the failed actions' status dictionaries in its `failed` attribute.
+
+    Status messages will be logged automatically, by default the following
+    association of result status and log channel will be used: 'ok' (debug),
+    'notneeded' (debug), 'impossible' (warning), 'error' (error).  Logger
+    instances included in the results are used to capture the origin of a
+    status report.
+
+    Parameters
+    ----------
+    func: function
+      __call__ method of a subclass of Interface,
+      i.e. a datalad command definition
+    """
+
+    @wraps(wrapped)
+    def eval_func(*args, **kwargs):
+        lgr.log(2, "Entered eval_func for %s", wrapped)
+        # determine the command class associated with `wrapped`
+        wrapped_class = get_wrapped_class(wrapped)
+
+        # retrieve common options from kwargs, and fall back on the command
+        # class attributes, or general defaults if needed
+        kwargs = kwargs.copy()  # we will pop, which might cause side-effect
+        common_params = {
+            p_name: kwargs.pop(
+                # go with any explicitly given default
+                p_name,
+                # otherwise determine the command class and pull any
+                # default set in that class
+                getattr(wrapped_class, p_name))
+            for p_name in eval_params}
+
+        # short cuts and configured setup for common options
+        return_type = common_params['return_type']
+
+        if return_type == 'generator':
+            # hand over the generator
+            lgr.log(2,
+                    "Returning generator_func from eval_func for %s",
+                    wrapped_class)
+            return _execute_command_(
+                interface=wrapped_class,
+                cmd=wrapped,
+                cmd_args=args,
+                cmd_kwargs=kwargs,
+                exec_kwargs=common_params,
+            )
+        else:
+            @wraps(_execute_command_)
+            def return_func(*args_, **kwargs_):
+                results = _execute_command_(
+                    interface=wrapped_class,
+                    cmd=wrapped,
+                    cmd_args=args,
+                    cmd_kwargs=kwargs,
+                    exec_kwargs=common_params,
+                )
+                if inspect.isgenerator(results):
+                    # unwind generator if there is one, this actually runs
+                    # any processing
+                    results = list(results)
+                if return_type == 'item-or-list' and \
+                        len(results) < 2:
+                    return results[0] if results else None
+                else:
+                    return results
+
+            lgr.log(2,
+                    "Returning return_func from eval_func for %s",
+                    wrapped_class)
+            return return_func(*args, **kwargs)
+
+    ret = eval_func
+    ret._eval_results = True
+    return ret
+
+
+def _execute_command_(
+    *,
+    interface: anInterface,
+    cmd: Callable[..., Generator[Dict, None, None]],
+    cmd_args: tuple,
+    cmd_kwargs: Dict,
+    exec_kwargs: Dict,
+) -> Generator[Dict, None, None]:
+    """Internal helper to drive a command execution generator-style
+
+    Parameters
+    ----------
+    interface:
+      Interface class of associated with the `cmd` callable
+    cmd:
+      A DataLad command implementation. Typically the `__call__()` of
+      the given `interface`.
+    cmd_args:
+      Positional arguments for `cmd`.
+    cmd_kwargs:
+      Keyword arguments for `cmd`.
+    exec_kwargs:
+      Keyword argument affecting the result handling.
+      See `datalad.interface.common_opts.eval_params`.
+    """
+    # for result filters and validation
+    # we need to produce a dict with argname/argvalue pairs for all args
+    # incl. defaults and args given as positionals
+    allkwargs = get_allargs_as_kwargs(
+        cmd,
+        cmd_args,
+        {**cmd_kwargs, **exec_kwargs},
+    )
+
+    # validate the complete parameterization
+    _validate_cmd_call(interface, allkwargs)
+
+    # look for potential override of logging behavior
+    result_log_level = dlcfg.get('datalad.log.result-level', 'debug')
+    # resolve string labels for transformers too
+    result_xfm = known_result_xfms.get(
+        allkwargs['result_xfm'],
+        # use verbatim, if not a known label
+        allkwargs['result_xfm'])
+    result_filter = get_result_filter(allkwargs['result_filter'])
+    result_renderer = allkwargs['result_renderer']
+    if result_renderer == 'tailored' and not hasattr(interface,
+                                                     'custom_result_renderer'):
+        # a tailored result renderer is requested, but the class
+        # does not provide any, fall back to the generic one
+        result_renderer = 'generic'
+    if result_renderer == 'default':
+        # standardize on the new name 'generic' to avoid more complex
+        # checking below
+        result_renderer = 'generic'
+
+    # figure out which hooks are relevant for this command execution
+    # query cfg for defaults
+    # .is_installed and .config can be costly, so ensure we do
+    # it only once. See https://github.com/datalad/datalad/issues/3575
+    dataset_arg = allkwargs.get('dataset', None)
+    ds = None
+    if dataset_arg is not None:
+        from datalad.distribution.dataset import Dataset
+        if isinstance(dataset_arg, Dataset):
+            ds = dataset_arg
+        else:
+            try:
+                ds = Dataset(dataset_arg)
+            except ValueError:
+                pass
+    # look for hooks
+    hooks = get_jsonhooks_from_config(ds.config if ds else dlcfg)
+    # end of hooks discovery
+
+    # flag whether to raise an exception
+    incomplete_results = []
+    # track what actions were performed how many times
+    action_summary = {}
+
+    # if a custom summary is to be provided, collect the results
+    # of the command execution
+    results = []
+    do_custom_result_summary = result_renderer in (
+        'tailored', 'generic', 'default') and hasattr(
+            interface,
+            'custom_result_summary_renderer')
+    pass_summary = do_custom_result_summary \
+        and getattr(interface,
+                    'custom_result_summary_renderer_pass_summary',
+                    None)
+
+    # process main results
+    for r in _process_results(
+            # execution
+            cmd(*cmd_args, **cmd_kwargs),
+            interface,
+            allkwargs['on_failure'],
+            # bookkeeping
+            action_summary,
+            incomplete_results,
+            # communication
+            result_renderer,
+            result_log_level,
+            # let renderers get to see how a command was called
+            allkwargs):
+        for hook, spec in hooks.items():
+            # run the hooks before we yield the result
+            # this ensures that they are executed before
+            # a potentially wrapper command gets to act
+            # on them
+            if match_jsonhook2result(hook, r, spec['match']):
+                lgr.debug('Result %s matches hook %s', r, hook)
+                # a hook is also a command that yields results
+                # so yield them outside too
+                # users need to pay attention to void infinite
+                # loops, i.e. when a hook yields a result that
+                # triggers that same hook again
+                for hr in run_jsonhook(hook, spec, r, dataset_arg):
+                    # apply same logic as for main results, otherwise
+                    # any filters would only tackle the primary results
+                    # and a mixture of return values could happen
+                    if not keep_result(hr, result_filter, **allkwargs):
+                        continue
+                    hr = xfm_result(hr, result_xfm)
+                    # rationale for conditional is a few lines down
+                    if hr:
+                        yield hr
+        if not keep_result(r, result_filter, **allkwargs):
+            continue
+        r = xfm_result(r, result_xfm)
+        # in case the result_xfm decided to not give us anything
+        # exclude it from the results. There is no particular reason
+        # to do so other than that it was established behavior when
+        # this comment was written. This will not affect any real
+        # result record
+        if r:
+            yield r
+
+        # collect if summary is desired
+        if do_custom_result_summary:
+            results.append(r)
+
+    # result summary before a potential exception
+    # custom first
+    if do_custom_result_summary:
+        if pass_summary:
+            summary_args = (results, action_summary)
+        else:
+            summary_args = (results,)
+        interface.custom_result_summary_renderer(*summary_args)
+    elif result_renderer in ('generic', 'default') \
+            and action_summary \
+            and sum(sum(s.values())
+                    for s in action_summary.values()) > 1:
+        # give a summary in generic mode, when there was more than one
+        # action performed
+        render_action_summary(action_summary)
+
+    if incomplete_results:
+        raise IncompleteResultsError(
+            failed=incomplete_results,
+            msg="Command did not complete successfully")
+
+
+def _validate_cmd_call(interface: anInterface, kwargs: Dict) -> None:
+    """Validate a parameterization of a command call
+
+    This is called by `_execute_command_()` before a command call, with
+    the respective Interface sub-type of the command, and all its
+    arguments in keyword argument dict style. This dict also includes
+    the default values for any parameter that was not explicitly included
+    in the command call.
+
+    This expected behavior is to raise an exception whenever an invalid
+    parameterization is encountered.
+
+    This default implementation performs no validation.
+    """
+    pass

--- a/datalad/interface/shell_completion.py
+++ b/datalad/interface/shell_completion.py
@@ -14,8 +14,10 @@ __docformat__ = 'restructuredtext'
 
 from .base import Interface
 
-from datalad.interface.base import build_doc
-from datalad.interface.utils import eval_results
+from datalad.interface.base import (
+    build_doc,
+    eval_results,
+)
 from datalad.interface.results import get_status_dict
 from datalad.support.exceptions import CapturedException
 

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -22,7 +22,10 @@ from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
 )
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    build_doc,
+    eval_results,
+)
 from datalad.support.constraints import (
     EnsureKeyChoice,
     EnsureNone,
@@ -54,7 +57,6 @@ from ..base import Interface
 from ..results import get_status_dict
 from ..utils import (
     discover_dataset_trace_to_targets,
-    eval_results,
     handle_dirty_dataset,
 )
 

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -270,7 +270,6 @@ def render_action_summary(action_summary):
                     for act in sorted(action_summary))))
 
 
-
 def _display_suppressed_message(nsimilar, ndisplayed, last_ts, final=False):
     # +1 because there was the original result + nsimilar displayed.
     n_suppressed = nsimilar - ndisplayed + 1

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -219,11 +219,11 @@ def get_result_filter(fx):
 
 def eval_results(wrapped):
     import warnings
-    from datalad.interface.base import eval_results as f
+    from datalad.interface.base import eval_results as eval_results_moved
     warnings.warn("datalad.interface.utils.eval_results is obsolete. "
                   "Use datalad.interface.base.eval_results instead",
                   DeprecationWarning)
-    return f(wrapped)
+    return eval_results_moved(wrapped)
 
 
 def generic_result_renderer(res):

--- a/datalad/local/add_archive_content.py
+++ b/datalad/local/add_archive_content.py
@@ -37,10 +37,10 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import allow_dirty
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.log import (
     log_progress,
     logging,

--- a/datalad/local/add_readme.py
+++ b/datalad/local/add_readme.py
@@ -31,7 +31,7 @@ class AddReadme(Interface):
     """
     from datalad.support.param import Parameter
     from datalad.distribution.dataset import datasetmethod
-    from datalad.interface.utils import eval_results
+    from datalad.interface.base import eval_results
     from datalad.distribution.dataset import EnsureDataset
     from datalad.support.constraints import (
         EnsureChoice,

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -1169,7 +1169,7 @@ class Addurls(Interface):
         EnsureDataset,
         datasetmethod,
     )
-    from datalad.interface.utils import eval_results
+    from datalad.interface.base import eval_results
     from datalad.support.constraints import (
         EnsureChoice,
         EnsureNone,

--- a/datalad/local/check_dates.py
+++ b/datalad/local/check_dates.py
@@ -66,7 +66,7 @@ class CheckDates(Interface):
     timestamps within files of the "git-annex" branch, and (3) the timestamps
     of annotated tags.
     """
-    from datalad.interface.utils import eval_results
+    from datalad.interface.base import eval_results
     import datalad.support.ansi_colors as ac
     from datalad.support.constraints import EnsureChoice, EnsureNone, EnsureStr
     from datalad.support.param import Parameter

--- a/datalad/local/clean.py
+++ b/datalad/local/clean.py
@@ -26,13 +26,13 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
 from datalad.utils import (

--- a/datalad/local/configuration.py
+++ b/datalad/local/configuration.py
@@ -25,6 +25,7 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_cfg import definitions as cfg_defs
 from datalad.interface.common_opts import (
@@ -32,10 +33,7 @@ from datalad.interface.common_opts import (
     recursion_limit,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import (
-    default_result_renderer,
-    eval_results,
-)
+from datalad.interface.utils import default_result_renderer
 from datalad.support.constraints import (
     EnsureChoice,
     EnsureNone,

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -17,8 +17,10 @@ from shutil import copyfile
 import sys
 
 from datalad.interface.base import Interface
-from datalad.interface.utils import eval_results
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    build_doc,
+    eval_results,
+)
 from datalad.support.constraints import (
     EnsureStr,
     EnsureNone,

--- a/datalad/local/download_url.py
+++ b/datalad/local/download_url.py
@@ -27,13 +27,13 @@ from datalad.downloaders.providers import Provider
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     nosave_opt,
     save_message_opt,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureNone,

--- a/datalad/local/export_archive.py
+++ b/datalad/local/export_archive.py
@@ -20,7 +20,7 @@ class ExportArchive(Interface):
     """
     from datalad.support.param import Parameter
     from datalad.distribution.dataset import datasetmethod
-    from datalad.interface.utils import eval_results
+    from datalad.interface.base import eval_results
     from datalad.distribution.dataset import EnsureDataset
     from datalad.support.constraints import (
         EnsureChoice,

--- a/datalad/local/foreach_dataset.py
+++ b/datalad/local/foreach_dataset.py
@@ -33,6 +33,7 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     contains,
@@ -42,7 +43,6 @@ from datalad.interface.common_opts import (
     recursion_limit,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.support.constraints import (
     EnsureBool,
     EnsureChoice,

--- a/datalad/local/no_annex.py
+++ b/datalad/local/no_annex.py
@@ -38,7 +38,7 @@ class NoAnnex(Interface):
     """
     from datalad.support.param import Parameter
     from datalad.distribution.dataset import datasetmethod
-    from datalad.interface.utils import eval_results
+    from datalad.interface.base import eval_results
     from datalad.distribution.dataset import EnsureDataset
     from datalad.support.constraints import EnsureNone
 

--- a/datalad/local/remove.py
+++ b/datalad/local/remove.py
@@ -27,12 +27,12 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     jobs_opt,
     save_message_opt,
 )
-from datalad.interface.utils import eval_results
 from datalad.support.constraints import (
     EnsureChoice,
     EnsureNone,

--- a/datalad/local/rerun.py
+++ b/datalad/local/rerun.py
@@ -35,9 +35,9 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.interface.common_opts import jobs_opt
 
 from datalad.support.constraints import (

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -31,9 +31,9 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.support.constraints import EnsureNone
 from datalad.support.exceptions import (
     InsufficientArgumentsError,

--- a/datalad/local/subdatasets.py
+++ b/datalad/local/subdatasets.py
@@ -16,10 +16,12 @@ import re
 import os
 import warnings
 
-from datalad.interface.base import Interface
 from datalad.interface.utils import generic_result_renderer
-from datalad.interface.utils import eval_results
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
 from datalad.interface.results import get_status_dict
 from datalad.support.constraints import (
     EnsureStr,

--- a/datalad/local/unlock.py
+++ b/datalad/local/unlock.py
@@ -27,13 +27,13 @@ from datalad.distribution.dataset import (
 from datalad.interface.base import (
     Interface,
     build_doc,
+    eval_results,
 )
 from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
 from datalad.log import log_progress
 from datalad.support.constraints import (
     EnsureNone,

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -19,8 +19,10 @@ from functools import partial
 from collections import OrderedDict
 
 
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
 from datalad.utils import (
     ensure_unicode,
     getpwd,
@@ -363,7 +365,7 @@ class WTF(Interface):
 
     from datalad.support.param import Parameter
     from datalad.distribution.dataset import datasetmethod
-    from datalad.interface.utils import eval_results
+    from datalad.interface.base import eval_results
     from datalad.distribution.dataset import EnsureDataset
     from datalad.support.constraints import EnsureNone, EnsureChoice
 


### PR DESCRIPTION
If done right, this PR fixes #6694. It moves ``eval_results()`` from ``interface.utils`` into ``interface.base``.  It replaces it with a shim ``eval_results()`` in ``interface.utils`` which issues a deprecation warning and imports the moved function back from ``interface.base``, such that this hopefully doesn't break things left and right.

I moved two helper functions, ``_execute_command_`` and ``_validate_cmd_call`` together with ``eval_results``. I found it cleaner than importing underscore functions from ``utils`` into ``base``, and got entangled in a few circular imports when I left it in `utils`. 

Tests were ok locally, I hope the extensions manage, too :crossed_fingers: 