### PR TITLE
Use regular dicts instead of OrderedDicts for speedier operations

### DIFF
--- a/changelog.d/pr-7174.md
+++ b/changelog.d/pr-7174.md
@@ -1,0 +1,3 @@
+### 🏎 Performance
+
+- Use regular dicts instead of OrderedDicts for speedier operations.  Fixes [#6566](https://github.com/datalad/datalad/issues/6566) via [PR #7174](https://github.com/datalad/datalad/pull/7174) (by [@adswa](https://github.com/adswa))

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -12,7 +12,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from collections import OrderedDict
 from itertools import chain
 import logging
 import re
@@ -868,13 +867,13 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
     # input has type=dataset, but now it is about files
     res_kwargs.pop('type', None)
 
-    # A set and an OrderedDict is used to track files pointing to the
+    # A set and a dict is used to track files pointing to the
     # same key.  The set could be dropped, using a single dictionary
     # that has an entry for every seen key and a (likely empty) list
     # of redundant files, but that would mean looping over potentially
     # many keys to yield likely few if any notneeded results.
     seen_keys = set()
-    repkey_paths = OrderedDict()
+    repkey_paths = dict()
 
     # produce final path list. use knowledge that annex command will
     # run in the root of the dataset and compact paths to be relative

--- a/datalad/core/local/diff.py
+++ b/datalad/core/local/diff.py
@@ -13,7 +13,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import os.path as op
-from collections import OrderedDict
 from datalad.utils import (
     ensure_list,
     ensure_unicode,
@@ -283,7 +282,7 @@ def diff_dataset(
             if recursion_limit is not None and recursive
             else -1 if recursive else 0,
             # TODO recode paths to repo path reference
-            origpaths=None if not path else OrderedDict(path),
+            origpaths=None if not path else dict(path),
             untracked=untracked,
             annexinfo=annex,
             cache=content_info_cache,
@@ -309,7 +308,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
     repo_path = repo.pathobj
     if datasets_only:
         assert not origpaths  # protected above with NotImplementedError
-        paths = OrderedDict(
+        paths = dict(
             (sds.pathobj.relative_to(ds.pathobj), False)
             for sds in ds.subdatasets(
                 recursive=False,
@@ -325,7 +324,7 @@ def _diff_ds(ds, fr, to, constant_refs, recursion_level, origpaths, untracked,
         # filter and normalize paths that match this dataset before passing them
         # onto the low-level query method
         paths = None if origpaths is None \
-            else OrderedDict(
+            else dict(
                 (repo_path / p.relative_to(ds.pathobj), goinside)
                 for p, goinside in origpaths.items()
                 if ds.pathobj in p.parents or (p == ds.pathobj and goinside)

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -522,7 +522,7 @@ def get_paths_by_ds(refds, dataset_arg, paths, subdsroot_mode='rsync'):
       that are not located underneath the reference dataset.
     """
     ds_path = refds.path
-    paths_by_ds = OrderedDict()
+    paths_by_ds = dict()
     errors = []
 
     if not paths:
@@ -629,7 +629,12 @@ def _yield_paths_by_ds(refds, dataset_arg, paths):
             logger=lgr)
 
     while paths_by_ds:
-        qdspath, qpaths = paths_by_ds.popitem(last=False)
+        # gh-6566 advised replacement of OrderedDicts with dicts for performance
+        # The previous qdspath, qpaths = paths_by_ds.popitem(last=False) used an
+        # OrderedDict specific function (returns k, v in FIFO order). Below is a
+        # less pretty replacement for this functionality with a pure dict
+        qdspath = next(iter(paths_by_ds.keys()))
+        qpaths = paths_by_ds.pop(qdspath)
         if qpaths and qdspath in qpaths:
             # this is supposed to be a full status query, save some
             # cycles sifting through the actual path arguments

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -14,7 +14,6 @@ import logging
 import os
 import os.path as op
 import shutil
-from collections import OrderedDict
 from operator import itemgetter
 from pathlib import Path
 from urllib.parse import urlparse
@@ -141,7 +140,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
                     "Provide archive_file or archive_key - not both")
             archive_key = self.repo.get_file_annexinfo(archive_file)['key']
         assert(archive_key is not None)
-        attrs = OrderedDict()  # looking forward for more
+        attrs = dict()  # looking forward for more
         if file:
             attrs['path'] = file.lstrip('/')
         if size is not None:

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -22,8 +22,6 @@ https://github.com/omab/python-social-auth
 
 import time
 
-from collections import OrderedDict
-
 from ..support.exceptions import (
     AccessDeniedError,
     CapturedException,
@@ -52,7 +50,7 @@ class Credential(object):
     assume `user` and `password` to be valid keys.
     """
 
-    # Should be defined in a subclass as an OrderedDict of fields
+    # Should be defined in a subclass as a dict of fields
     # name -> dict(attributes)
     _FIELDS = None
     _KNOWN_ATTRS = {
@@ -273,8 +271,8 @@ class Credential(object):
 class UserPassword(Credential):
     """Simple type of a credential which consists of user/password pair"""
 
-    _FIELDS = OrderedDict([('user', {}),
-                           ('password', {'hidden': True})])
+    _FIELDS = dict([('user', {}),
+                    ('password', {'hidden': True})])
 
     is_expired = False  # no expiration provisioned
 
@@ -282,7 +280,7 @@ class UserPassword(Credential):
 class Token(Credential):
     """Simple type of a credential which provides a single token"""
 
-    _FIELDS = OrderedDict([('token', {'hidden': True, 'repeat': False})])
+    _FIELDS = dict([('token', {'hidden': True, 'repeat': False})])
 
     is_expired = False  # no expiration provisioned
 
@@ -290,11 +288,11 @@ class Token(Credential):
 class AWS_S3(Credential):
     """Credential for AWS S3 service"""
 
-    _FIELDS = OrderedDict([('key_id', {'repeat': False}),
-                           ('secret_id', {'hidden': True, 'repeat': False}),
-                           ('session', {'optional': True}),
-                           ('expiration', {'optional': True}),
-                           ])
+    _FIELDS = dict([('key_id', {'repeat': False}),
+                    ('secret_id', {'hidden': True, 'repeat': False}),
+                    ('session', {'optional': True}),
+                    ('expiration', {'optional': True}),
+                   ])
 
     @property
     def is_expired(self):
@@ -455,8 +453,8 @@ class GitCredential(Credential):
     """
 
 
-    _FIELDS = OrderedDict([('user', {}),
-                           ('password', {'hidden': True})])
+    _FIELDS = dict([('user', {}),
+                    ('password', {'hidden': True})])
 
     # substitute keys used within datalad by the ones used by git-credential
     _FIELDS_GIT = {'user': 'username',

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -15,7 +15,6 @@ from logging import getLogger
 import re
 from os.path import dirname, abspath, join as pathjoin
 from urllib.parse import urlparse
-from collections import OrderedDict
 
 from .base import NoneAuthenticator, NotImplementedAuthenticator
 
@@ -206,7 +205,7 @@ type = {credential_type}
         Is implemented as a function to ease mock testing depending on dirs.
         values
         """
-        paths = OrderedDict()
+        paths = dict()
         paths['dist'] = pathjoin(dirname(abspath(__file__)), 'configs')
         if dsroot is not None:
             paths['ds'] = pathjoin(dsroot, '.datalad', 'providers')
@@ -254,7 +253,7 @@ type = {credential_type}
         # there's a conflict between configuration files declared
         # at different precedence levels (ie. dataset vs system)
         # the appropriate precedence config wins.
-        providers = OrderedDict()
+        providers = dict()
         credentials = {}
 
         for section in config.sections():

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -24,7 +24,6 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from collections import OrderedDict
 from importlib import import_module
 
 import datalad
@@ -620,7 +619,7 @@ def get_allargs_as_kwargs(call, args, kwargs):
     assert (nargs >= len(defaults))
     # map any args to their name
     argmap = list(zip(argspec.args[:len(args)], args))
-    kwargs_ = OrderedDict(argmap)
+    kwargs_ = dict(argmap)
     # map defaults of kwargs to their names (update below)
     for k, v in zip(argspec.args[-len(defaults):], defaults):
         if k not in kwargs_:

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -16,7 +16,6 @@ import os.path as op
 import sys
 import tempfile
 from functools import partial
-from collections import OrderedDict
 
 
 from datalad.interface.base import Interface
@@ -447,7 +446,7 @@ class WTF(Interface):
         from datalad.ui import ui
         from datalad.support.external_versions import external_versions
 
-        infos = OrderedDict()
+        infos = dict()
         res = get_status_dict(
             action='wtf',
             path=ds.path if ds else ensure_unicode(op.abspath(op.curdir)),

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -17,7 +17,6 @@ import logging
 import os
 import re
 import warnings
-from collections import OrderedDict
 from itertools import chain
 from multiprocessing import cpu_count
 from os import linesep
@@ -3355,7 +3354,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             is available (with `eval_availability`)
         """
         if init is None:
-            info = OrderedDict()
+            info = dict()
         elif init == 'git':
             info = super(AnnexRepo, self).get_content_info(
                 paths=paths, ref=ref, **kwargs)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -16,7 +16,6 @@ import os.path as op
 import posixpath
 import re
 import warnings
-from collections import OrderedDict
 from collections.abc import Mapping
 from functools import wraps
 from itertools import chain
@@ -144,7 +143,7 @@ def to_options(split_single_char_options=True, **kwargs):
         return []
 
     args = []
-    kwargs = OrderedDict(sorted(kwargs.items(), key=lambda x: x[0]))
+    kwargs = dict(sorted(kwargs.items(), key=lambda x: x[0]))
     for k, v in kwargs.items():
         if isinstance(v, (list, tuple)):
             for value in v:
@@ -2704,7 +2703,7 @@ class GitRepo(CoreGitRepo):
         """
         lgr.debug('%s.get_content_info(...)', self)
         # TODO limit by file type to replace code in subdatasets command
-        info = OrderedDict()
+        info = dict()
 
         if paths:  # is not None separate after
             # path matching will happen against what Git reports
@@ -3000,7 +2999,7 @@ class GitRepo(CoreGitRepo):
                 from_state = {}
             _cache[key] = from_state
 
-        status = OrderedDict()
+        status = dict()
         for f, to_state_r in to_state.items():
             props = self._diffstatus_get_state_props(
                 f,

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -19,7 +19,6 @@ import pickle
 import re
 import sys
 import time
-from collections import OrderedDict
 from hashlib import md5
 from ntpath import splitdrive as win_splitdrive
 from os.path import dirname
@@ -469,7 +468,7 @@ class RI(object):
 
     @classmethod
     def _get_blank_fields(cls, **fields):
-        return OrderedDict(((f, fields.get(f, '')) for f in cls._FIELDS))
+        return dict(((f, fields.get(f, '')) for f in cls._FIELDS))
 
     @property
     def fields(self):
@@ -679,7 +678,7 @@ class URL(RI):
         """Helper around parse_qs to strip unneeded 'list'ing etc and return a dict of key=values"""
         if not s:
             return {}
-        out = map_items(ensure_unicode, OrderedDict(parse_qsl(s, 1)))
+        out = map_items(ensure_unicode, dict(parse_qsl(s, 1)))
         if not auto_delist:
             return out
         for k in out:

--- a/datalad/support/strings.py
+++ b/datalad/support/strings.py
@@ -10,7 +10,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from collections import OrderedDict
 import re
 
 
@@ -20,7 +19,7 @@ def get_replacement_dict(rules):
     if isinstance(rules, (bytes, str)):
         rules = [rules]
 
-    pairs = OrderedDict()
+    pairs = dict()
     for rule in rules:
         if isinstance(rule, (list, tuple)):
             if len(rule) == 2:

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -10,7 +10,6 @@
 import logging
 import os
 import sys
-from collections import OrderedDict
 from os.path import isabs
 from os.path import join as opj
 
@@ -399,19 +398,19 @@ def test_url_quote_path(cls, clskwargs, target_url):
 
 def test_url_compose_archive_one():
     url = URL(scheme='dl+archive', path='KEY',
-              fragment=OrderedDict((('path', 'f/p/ s+'), ('size', 30))))
+              fragment=dict((('path', 'f/p/ s+'), ('size', 30))))
     # funny - space is encoded as + but + is %2B
     eq_(str(url), 'dl+archive:KEY#path=f/p/+s%2B&size=30')
     eq_(url.fragment_dict, {'path': 'f/p/ s+', 'size': '30'})
 
 
 def test_url_fragments_and_query():
-    url = URL(hostname="host", query=OrderedDict((('a', 'x/b'), ('b', 'y'))))
+    url = URL(hostname="host", query=dict((('a', 'x/b'), ('b', 'y'))))
     eq_(str(url), '//host?a=x%2Fb&b=y')
     eq_(url.query, 'a=x%2Fb&b=y')
     eq_(url.query_dict, {'a': 'x/b', 'b': 'y'})
 
-    url = URL(hostname="host", fragment=OrderedDict((('b', 'x/b'), ('a', 'y'))))
+    url = URL(hostname="host", fragment=dict((('b', 'x/b'), ('a', 'y'))))
     eq_(str(url), '//host#b=x/b&a=y')
     eq_(url.fragment, 'b=x/b&a=y')
     eq_(url.fragment_dict, {'a': 'y', 'b': 'x/b'})

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -19,7 +19,6 @@ import shutil
 import stat
 import sys
 import time
-from collections import OrderedDict
 from functools import wraps
 from operator import itemgetter
 from os.path import (
@@ -372,10 +371,10 @@ def test_updated():
     eq_(d, {'a': 'b'})
 
     # and that it would maintain the type
-    d = OrderedDict(((99, 0), ('z', 0), ('a', 0)))
+    d = dict(((99, 0), ('z', 0), ('a', 0)))
     d_ = updated(d, {0: 1})
-    ok_(isinstance(d_, OrderedDict))
-    eq_(d_, OrderedDict(((99, 0), ('z', 0), ('a', 0), (0, 1))))
+    ok_(isinstance(d_, dict))
+    eq_(d_, dict(((99, 0), ('z', 0), ('a', 0), (0, 1))))
 
 
 def test_get_local_file_url_windows():
@@ -1236,9 +1235,9 @@ def test_CMD_MAX_ARG():
 @with_tempfile(mkdir=True)
 def test_create_tree(path=None):
     content = u"мама мыла раму"
-    create_tree(path, OrderedDict([
+    create_tree(path, dict([
         ('1', content),
-        ('sd', OrderedDict(
+        ('sd', dict(
             [
             # right away an obscure case where we have both 1 and 1.gz
                 ('1', content*2),

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2311,8 +2311,7 @@ def get_encoding_info():
     """Return a dictionary with various encoding/locale information"""
     import locale
     import sys
-    from collections import OrderedDict
-    return OrderedDict([
+    return dict([
         ('default', sys.getdefaultencoding()),
         ('filesystem', sys.getfilesystemencoding()),
         ('locale.prefered', locale.getpreferredencoding()),
@@ -2320,7 +2319,6 @@ def get_encoding_info():
 
 
 def get_envvars_info():
-    from collections import OrderedDict
     envs = []
     for var, val in os.environ.items():
         if (
@@ -2330,7 +2328,7 @@ def get_envvars_info():
                 var in ('LANG', 'LANGUAGE', 'PATH')
         ):
             envs.append((var, val))
-    return OrderedDict(envs)
+    return dict(envs)
 
 
 # This class is modified from Snakemake (v5.1.4)


### PR DESCRIPTION
This is an attempt to fix #6566, which calls for a replacement of OrderedDicts with regular dicts to increase performance/speed. There was only one instance in ``status()`` where OrderedDict-specific functionality was used; I used a patch cooked up by @yarikoptic in #6566 as an alternative. 
Let's check if the CI is happy with this change or if it breaks something.