### PR TITLE
Comply to Posix-like clone URL formats on Windows

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -741,6 +741,19 @@ def test_relative_submodule_url(path=None):
         '../../origin')
 
 
+def test_mushy_windows_submodule_url(tmp_path):
+    """Test that subdataset clones from relative urls
+    do not include backslashes (gh-7180)"""
+    Dataset(tmp_path / 'origin').create()
+    ds = Dataset(tmp_path / 'ds').create()
+    with chpwd(ds.path):
+        ds_cloned = ds.clone(
+            source=op.join(op.pardir, 'origin'),
+            path='sources')
+        assert '\\' not in ds_cloned.config.get('remote.dl-test-remote.url')
+
+
+
 @with_tree(tree={"subdir": {}})
 @with_tempfile(mkdir=True)
 def test_local_url_with_fetch(path=None, path_other=None):


### PR DESCRIPTION
Fixes #7180.

Git clone's url format does not include backslashes.   Therefore, this commits ensures that paths provided to clone on  Windows are compliying to posix. When platform specific windows paths were passed on by clone as git urls, cloning succeeded, but resulting remote urls can became disfunctional. Specifically, in the case of cloning a subdataset from a local relative path, git will append the relative Windows path to an otherwise Posix-confirming absolute path in the remote url in the subdatasets .git/config. (see #7180). This patch should fix this, and add a test.