### PR TITLE
BF: Ensure that datalad urls are posix

### DIFF
--- a/changelog.d/pr-7183.md
+++ b/changelog.d/pr-7183.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Ensure that paths used in the datalad-url field of .gitmodules are posix. Fixes [#7182](https://github.com/datalad/datalad/issues/7182) via [PR #7183](https://github.com/datalad/datalad/pull/7183) (by [@adswa](https://github.com/adswa))

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -324,7 +324,7 @@ def test_clone_into_dataset(source_path=None, top_path=None):
     # source is recorded in .gitmodules:
     sds = ds.subdatasets("sub")
     assert_result_count(sds, 1, action='subdataset')
-    eq_(sds[0]['gitmodule_datalad-url'], source.path)
+    eq_(sds[0]['gitmodule_datalad-url'], source.pathobj.as_posix())
     # Clone produced one commit including the addition to .gitmodule:
     commits = list(ds.repo.get_branch_commits_(
         branch=DEFAULT_BRANCH,


### PR DESCRIPTION
Fixes #7182

If the source in a clone command is a windows path, the resulting ```datalad_url``` in the .gitmodules file of the superdataset contains it verbatim, including escaped backslashes. Ensuring that it is posix makes it functional, and compliant to git's url format.

