### PR TITLE
Fix broken submodule URLs generated from relative paths

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -722,7 +722,6 @@ def test_cfg_originorigin(path=None):
 
 
 # test fix for gh-2601/gh-3538
-@known_failure
 @with_tempfile()
 def test_relative_submodule_url(path=None):
     Dataset(op.join(path, 'origin')).create()

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -740,19 +740,6 @@ def test_relative_submodule_url(path=None):
         '../../origin')
 
 
-def test_mushy_windows_submodule_url(tmp_path):
-    """Test that subdataset clones from relative urls
-    do not include backslashes (gh-7180)"""
-    Dataset(tmp_path / 'origin').create()
-    ds = Dataset(tmp_path / 'ds').create()
-    with chpwd(ds.path):
-        ds_cloned = ds.clone(
-            source=op.join(op.pardir, 'origin'),
-            path='sources')
-        assert '\\' not in ds_cloned.config.get(f'remote.{DEFAULT_REMOTE}.url')
-
-
-
 @with_tree(tree={"subdir": {}})
 @with_tempfile(mkdir=True)
 def test_local_url_with_fetch(path=None, path_other=None):


### PR DESCRIPTION
This change reincarnates parts of a changeset originally proposed in #4026, which did not make it in due to Windows errors I never saw (CI logs weren't preserved), but that I suspect to originate in https://github.com/datalad/datalad/issues/7180 (Git stitching together posix and windows paths into a non-functional URL). Thus, this change sits on top of https://github.com/datalad/datalad/pull/7181, which fixes
these URLs to be fully posix. Based on those fixes, this change wrangles absolute URLs originating from relative paths back into relative paths, to keep them functional.
This change also enables an old test for this problem, marked as a known
failure.

Fixes https://github.com/datalad/datalad/issues/3538