### PR TITLE
Bandaids for export-to-figshare to restore functionality

### DIFF
--- a/changelog.d/pr-7188.md
+++ b/changelog.d/pr-7188.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Bandaids for export-to-figshare to restore functionality.  [PR #7188](https://github.com/datalad/datalad/pull/7188) (by [@adswa](https://github.com/adswa))

--- a/datalad/distributed/export_to_figshare.py
+++ b/datalad/distributed/export_to_figshare.py
@@ -300,7 +300,7 @@ class ExportToFigshare(Interface):
             )
         )
         assert archive_out['status'] == 'ok'
-        fname = archive_out['path']
+        fname = str(archive_out['path'])
 
         lgr.info("Uploading %s to figshare", fname)
         figshare = FigshareRESTLaison()

--- a/datalad/distributed/export_to_figshare.py
+++ b/datalad/distributed/export_to_figshare.py
@@ -354,7 +354,7 @@ class ExportToFigshare(Interface):
             lgr.info("Registering links back for the content of the archive")
             add_archive_content(
                 fname,
-                annex=dataset.repo,
+                dataset=dataset,
                 delete_after=True,  # just remove extracted into a temp dir
                 allow_dirty=True,  # since we have a tarball
                 commit=False  # we do not want to commit anything we have done here


### PR DESCRIPTION
I checked whether [this export-to-figshare bug](https://github.com/datalad/datalad/issues/4137) still reproduces. But in its current state, the command is dysfunctional, failing first in an attempt to initialize a progressbar with a pathobject as a label, and then further by giving a path object to ``repo.add()`` (which can't handle pathobjects). The command also still relied on calling ``add_archive_content`` with a deprecated ``annex`` parameter, which would eventually crash in the patch the next extension provides for ``get_allargs_as_kwargs``. This PR adds some very patchy bandaids to make it functional again. But I guess the future should bring slightly more sweeping refurbishments. It would probably also help to have proper tests for this command.