### PR TITLE
TST: Re-Enable now-passing diff test on Windows

### DIFF
--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -332,8 +332,6 @@ def test_diff_recursive(path=None):
         action='diff', state='modified', path=sub.path, type='dataset')
 
 
-# https://github.com/datalad/datalad/issues/3725
-@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 @with_tempfile()
 def test_path_diff(_path=None, linkpath=None):


### PR DESCRIPTION
``test_path_diff`` only failed on windows CI, not real machines, 3 years ago. I'm curious if this is still the case. Will cancel all tests but a shrunk appveyor suite