### PR TITLE
Reenable now passing test_path_diff test on Windows

### DIFF
--- a/changelog.d/pr-7194.md
+++ b/changelog.d/pr-7194.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Reenable now passing test_path_diff test on Windows.  Fixes [#3725](https://github.com/datalad/datalad/issues/3725) via [PR #7194](https://github.com/datalad/datalad/pull/7194) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -332,8 +332,6 @@ def test_diff_recursive(path=None):
         action='diff', state='modified', path=sub.path, type='dataset')
 
 
-# https://github.com/datalad/datalad/issues/3725
-@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 @with_tempfile()
 def test_path_diff(_path=None, linkpath=None):


### PR DESCRIPTION
Closes #3725

It is https://github.com/datalad/datalad/pull/7191 but against maint since IMHO it is worth there