### PR TITLE
DOC: Add design document on Tests and CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,24 +284,6 @@ release of Debian or Ubuntu) with all dependencies listed in README.md pre-insta
 [datalad/tests/utils.py]() defines many useful decorators. Some of those just to annotate tests
 for various aspects to allow for easy sub-selection.
 
-#### Migration from `nose` to `pytest` in downstream code
-
-`datalad.tests.utils` remains providing `nose`-based utils and `datalad.__init__` provides `nose`-based
-fixtures to not break extensions which still use `nose` for testing. For a typical migration of a DataLad
-extension to use `pytest` instead of `nose`:
-
-- keep all the `assert_*` and `ok_` helpers but import them from `datalad.tests.utils_pytest`
-  instead
-- for `@with_*` and other decorators populating positional arguments, convert corresponding
-  posarg to kwarg by adding `=None`
-- convert all generator-based parametric tests into direct invocation or, preferably,
-  `@pytest.mark.parametrized` tests
-- address DeprecationWarnings in the code. Only where desired to test deprecation,
-  add `@pytest.mark.filterwarnings("ignore: BEGINNING OF WARNING")` decorator to the test.
-
-For an example, see a "migrate to pytest" PR against datalad-deprecated:
-https://github.com/datalad/datalad-deprecated/pull/51 .
-
 ##### Speed
 
 Please annotate with following decorators

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,8 @@ rules before submitting a pull request:
 
 - New code should be accompanied by tests.
 
+The documentation contains a [Design Document specifically on running and writing tests](http://docs.datalad.org/en/stable/design/testing.html) that we encourage you to read beforehand.
+Further hands-on advice is detailed below.
 
 ### Tests
 
@@ -279,56 +281,11 @@ Additionally, [tools/testing/test_README_in_docker](tools/testing/test_README_in
 be used to establish a clean docker environment (based on any NtesteuroDebian-supported
 release of Debian or Ubuntu) with all dependencies listed in README.md pre-installed.
 
-#### Test attributes
-
-[datalad/tests/utils.py]() defines many useful decorators. Some of those just to annotate tests
-for various aspects to allow for easy sub-selection.
-
-##### Speed
-
-Please annotate with following decorators
-- `@slow` if test runs over 10 seconds
-- `@turtle` if test runs over 120 seconds (those would not typically be ran on CIs)
-
-##### Purpose
-
-As those tests also usually tend to be slower, use in conjunction with `@slow` or `@turtle` when slow
-- `@integration` - tests verifying correct operation with external tools/services beyond git/git-annex
-- `@usecase` - represents some (user) use-case, and not necessarily a "unit-test" of functionality
-
 ### CI setup
 
-We are using Travis-CI and have [buildbot setup](https://github.com/datalad/buildbot) which also
-exercises our tests battery for every PR and on the master.  Note that buildbot runs tests only submitted
-by datalad developers, or if a PR acquires 'buildbot' label.
-
-In case if you want to enter buildbot's environment
-
-1. Login to our development server (`smaug`)
-
-2. Find container ID associated with the environment you are interested in, e.g.
-
-        docker ps | grep nd16.04
-
-3. Enter that docker container environment using
-
-        docker exec -it <CONTAINER ID> /bin/bash
-
-4. Become buildbot user
-
-        su - buildbot
-
-5. Activate corresponding virtualenv using
-
-        source <VENV/bin/activate>
-
-   e.g. `source /home/buildbot/datalad-pr-docker-dl-nd15_04/build/venv-ci/bin/activate`
-
-And now you should be in the same environment as the very last tested PR.
-Note that the same path/venv is reused for all the PRs, so you might want
-first to check using `git show` under the `build/` directory if it corresponds
-to the commit you are interested to troubleshoot.
-
+We are using several continuous integration services to run our tests battery for every PR and on the default branch.
+Please note that new a contributor's first PR needs workflow approval from a team member to start the CI runs, but we will hurry to start the CI runs on your PR.
+As the full CI suite takes a while to complete, we recommend to run at least tests directly related to your contributions locally beforehand.
 For developing on Windows you can use free [Windows VMs](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/).
 
 ### Coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,9 +284,10 @@ release of Debian or Ubuntu) with all dependencies listed in README.md pre-insta
 ### CI setup
 
 We are using several continuous integration services to run our tests battery for every PR and on the default branch.
-Please note that new a contributor's first PR needs workflow approval from a team member to start the CI runs, but we will hurry to start the CI runs on your PR.
+Please note that new a contributor's first PR needs workflow approval from a team member to start the CI runs, but we promise to promptly review and start the CI runs on your PR.
 As the full CI suite takes a while to complete, we recommend to run at least tests directly related to your contributions locally beforehand.
 For developing on Windows you can use free [Windows VMs](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/).
+If you would like to propose patch against `git-annex` itself, submit them against [datalad/git-annex](https://github.com/datalad/git-annex/#submitting-patches) repository which builds and tests `git-annex`.
 
 ### Coverage
 

--- a/changelog.d/pr-7195.md
+++ b/changelog.d/pr-7195.md
@@ -1,0 +1,3 @@
+### 📝 Documentation
+
+- DOC: Add design document on Tests and CI.  [PR #7195](https://github.com/datalad/datalad/pull/7195) (by [@adswa](https://github.com/adswa))

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -33,3 +33,4 @@ subsystems in DataLad.
    docstrings
    progress_reporting
    github_actions
+   testing

--- a/docs/source/design/testing.rst
+++ b/docs/source/design/testing.rst
@@ -1,19 +1,93 @@
 .. -*- mode: rst -*-
 .. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
 
-.. _chap_design_pytest_migration:
+.. _chap_design_testing:
 
-*********************************************
-Migrating downstream code from nose to pytest
-*********************************************
+**********************************
+Continuous integration and testing
+**********************************
 
 .. topic:: Specification scope and status
 
    This specification describes the current implementation.
 
-DataLad's test suite has been migrated from `nose <https://nose.readthedocs.io/en/latest/>`_ to `pytest <https://docs.pytest.org/en/latest/contents.html>`_ in the `0.17.0 release <https://github.com/datalad/datalad/releases/tag/0.17.0>`_.
+DataLad is tested using a pytest-based testsuite that is run locally and via continuous integrations setups.
+Code development should ensure that old and new functionality is appropriately tested.
+The project aims for good unittest coverage (at least 80%).
 
-For the time being, ``datalad.tests.utils`` keeps providing ``nose``-based ``utils``, and ``datalad.__init__`` keeps providing nose-based fixtures to not break extensions that still use nose for testing.
+Running tests
+=============
+
+``datalad/tests`` contains tests for the core portion of the project.
+More tests are provided under corresponding submodules in ``tests/`` subdirectories to simplify re-running the tests concerning that portion of the codebase.
+The test suite is run using
+
+.. code-block:: bash
+
+   pytest datalad
+   # or, with coverage reports
+   pip install pytest coverage
+   pytest --cov=datalad datalad
+
+Individual tests can be run using a path to the test file, followed by two colons and the test name:
+
+.. code-block:: bash
+
+    pytest datalad/core/local/tests/test_save.py::test_save_message_file
+
+The set of to-be-run tests can be further sub-selected with environment variable based configurations that enable tests based on their :ref:`decorators`, or pytest-specific parameters.
+Invoking a test run using ``DATALAD_TESTS_KNOWNFAILURES_PROBE=True pytest datalad``, for example, will run tests marked as known failures whether or not they still fail.
+See section :ref:`configuration` for all available configurations.
+Invoking a test run using ``DATALAD_TESTS_SSH=1 pytest -m xfail -c tox.ini datalad`` will run only those tests marked as `xfail <https://docs.pytest.org/en/latest/how-to/skipping.html>`_.
+
+Local setup
+-----------
+Local test execution usually requires a local installation with all development requirements. It is recommended to either use a `virtualenv <https://virtualenv.pypa.io/en/latest/>`_, or `tox <https://tox.wiki/en/latest/>`_ via a ``tox.ini`` file in the code base.
+
+CI setup
+--------
+At the moment, Travis-CI, Appveyor, and GitHub Workflows exercise the tests battery for every PR and on the default branch, covering different operating systems, Python versions, and file systems.
+Tests should be ran on the oldest, latest, and current stable Python release.
+The projects uses https://codecov.io for an overview of code coverage.
+
+
+Writing tests
+=============
+
+Additional functionality is tested by extending existing similar tests with new test cases, or adding new tests to the respective test script of the module.
+Test helper functions assisting various general and DataLad specific assertions as well the construction of test directories and files can be found in ``datalad/tests/utils_pytest.py`` and ``datalad/tests/utils.py``.
+
+.. _decorators:
+
+Test annotations
+----------------
+
+``datalad/tests/utils.py`` and ``datalad/tests/utils_pytest.py`` also define test decorators.
+Some of those are used to annotate tests for various aspects to allow for easy sub-selection via environment variables.
+
+**Speed**: Please annotate tests that take a while to complete with following decorators
+
+* ``@slow`` if test runs over 10 seconds
+* ``@turtle`` if test runs over 120 seconds (those would not typically be ran on CIs)
+
+**Purpose**: Please further annotate tests with a special purpose specifically. As those tests also usually tend to be slower, use in conjunction with ``@slow`` or ``@turtle`` when slow.
+
+* ``@integration`` - tests verifying correct operation with external tools/services beyond git/git-annex
+* ``@usecase`` - represents some (user) use-case, and not necessarily a "unit-test" of functionality
+
+**Dysfunction**: If tests are not meant to be run on certain platforms or under certain conditions, ``@known_failure`` or ``@skip`` annotations can be used. Examples include:
+
+* ``@skip``, ``@skip_if_on_windows``, ``@skip_ssh``, ``@skip_wo_symlink_capability``, ``@skip_if_adjusted_branch``, ``@skip_if_no_network``, ``@skip_if_root``
+* ``@knownfailure``, ``@known_failure_windows``, ``known_failure_githubci_win`` or ``known_failure_githubci_osx``
+
+
+Migrating tests from nose to pytest
+===================================
+
+DataLad's test suite has been migrated from `nose <https://nose.readthedocs.io/en/latest/>`_ to `pytest <https://docs.pytest.org/en/latest/contents.html>`_ in the `0.17.0 release <https://github.com/datalad/datalad/releases/tag/0.17.0>`_.
+This might be relevant for DataLad extensions that still use nose.
+
+For the time being, ``datalad.tests.utils`` keeps providing ``nose``-based utils, and ``datalad.__init__`` keeps providing nose-based fixtures to not break extensions that still use nose for testing.
 A migration to ``pytest`` is recommended, though.
 To perform a typical migration of a DataLad extension to use pytest instead of nose, go through the following list:
 

--- a/docs/source/design/testing.rst
+++ b/docs/source/design/testing.rst
@@ -1,0 +1,25 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_design_pytest_migration:
+
+*********************************************
+Migrating downstream code from nose to pytest
+*********************************************
+
+.. topic:: Specification scope and status
+
+   This specification describes the current implementation.
+
+DataLad's test suite has been migrated from `nose <https://nose.readthedocs.io/en/latest/>`_ to `pytest <https://docs.pytest.org/en/latest/contents.html>`_ in the `0.17.0 release <https://github.com/datalad/datalad/releases/tag/0.17.0>`_.
+
+For the time being, ``datalad.tests.utils`` keeps providing ``nose``-based ``utils``, and ``datalad.__init__`` keeps providing nose-based fixtures to not break extensions that still use nose for testing.
+A migration to ``pytest`` is recommended, though.
+To perform a typical migration of a DataLad extension to use pytest instead of nose, go through the following list:
+
+* keep all the ``assert_*`` and ``ok_`` helpers, but import them from ``datalad.tests.utils_pytest`` instead
+* for ``@with_*`` and other decorators populating positional arguments, convert corresponding posarg to kwarg by adding ``=None``
+* convert all generator-based parametric tests into direct invocations or, preferably, ``@pytest.mark.parametrized`` tests
+* address ``DeprecationWarnings`` in the code. Only where desired to test deprecation, add ``@pytest.mark.filterwarnings("ignore: BEGINNING OF WARNING")`` decorator to the test.
+
+For an example, see a "migrate to pytest" PR against ``datalad-deprecated``: `datalad/datalad-deprecated#51 <https://github.com/datalad/datalad-deprecated/pull/51>`_ .

--- a/docs/source/design/testing.rst
+++ b/docs/source/design/testing.rst
@@ -18,8 +18,8 @@ The project aims for good unittest coverage (at least 80%).
 Running tests
 =============
 
-``datalad/tests`` contains tests for the core portion of the project.
-More tests are provided under corresponding submodules in ``tests/`` subdirectories to simplify re-running the tests concerning that portion of the codebase.
+
+Starting at the top level with ``datalad/tests``, every module in the package comes with a subdirectory ``tests/``, containing the tests for that portion of the codebase. This structure is meant to simplify (re-)running the tests for a particular module.
 The test suite is run using
 
 .. code-block:: bash
@@ -54,15 +54,15 @@ The projects uses https://codecov.io for an overview of code coverage.
 Writing tests
 =============
 
-Additional functionality is tested by extending existing similar tests with new test cases, or adding new tests to the respective test script of the module.
-Test helper functions assisting various general and DataLad specific assertions as well the construction of test directories and files can be found in ``datalad/tests/utils_pytest.py`` and ``datalad/tests/utils.py``.
+Additional functionality is tested by extending existing similar tests with new test cases, or adding new tests to the respective test script of the module. Generally, every file `example.py `with datalad code comes with a corresponding `tests/test_example.py`.
+Test helper functions assisting various general and DataLad specific assertions as well the construction of test directories and files can be found in ``datalad/tests/utils_pytest.py``.
 
 .. _decorators:
 
 Test annotations
 ----------------
 
-``datalad/tests/utils.py`` and ``datalad/tests/utils_pytest.py`` also define test decorators.
+``datalad/tests/utils_pytest.py`` also defines test decorators.
 Some of those are used to annotate tests for various aspects to allow for easy sub-selection via environment variables.
 
 **Speed**: Please annotate tests that take a while to complete with following decorators

--- a/docs/source/design/testing.rst
+++ b/docs/source/design/testing.rst
@@ -24,16 +24,16 @@ The test suite is run using
 
 .. code-block:: bash
 
-   pytest datalad
+   pip install -e .[tests]
+   python -m pytest -c tox.ini datalad
    # or, with coverage reports
-   pip install pytest coverage
-   pytest --cov=datalad datalad
+   python -m pytest  -c tox.ini --cov=datalad datalad
 
 Individual tests can be run using a path to the test file, followed by two colons and the test name:
 
 .. code-block:: bash
 
-    pytest datalad/core/local/tests/test_save.py::test_save_message_file
+    python -m pytest datalad/core/local/tests/test_save.py::test_save_message_file
 
 The set of to-be-run tests can be further sub-selected with environment variable based configurations that enable tests based on their :ref:`decorators`, or pytest-specific parameters.
 Invoking a test run using ``DATALAD_TESTS_KNOWNFAILURES_PROBE=True pytest datalad``, for example, will run tests marked as known failures whether or not they still fail.


### PR DESCRIPTION
This fixes #6679 by moving the CONTRIBUTING section on migrating downstream code from nose to pytest into a dedicated Design document in the docs.

I just moved this section because there was an explicit issue about it, but if deemed useful, this new design document could contain more test-related information from contributing, and become a more general Design doc on tests and CI - what do you think?

[skip ci]
- closes #6679 