### PR TITLE
Switch to test against 3.11 instead of 3.10 as the latest python to test against (travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       - PYTEST_SELECTION=
       - PYTEST_SELECTION_OP=not
       - DATALAD_REPO_VERSION=10
-      - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex -m conda"
+      - _DL_ANNEX_INSTALL_SCENARIO="miniconda --channel conda-forge --python-match minor --batch git-annex -m conda"
       - DATALAD_TESTS_GITCONFIG="\n[annex]\n stalldetection = 1KB/120s\n"
   - python: '3.11'
     dist: focal
@@ -71,7 +71,7 @@ matrix:
       - PYTEST_SELECTION=
       - PYTEST_SELECTION_OP=
       - DATALAD_REPO_VERSION=10
-      - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex -m conda"
+      - _DL_ANNEX_INSTALL_SCENARIO="miniconda --channel conda-forge --python-match minor --batch git-annex -m conda"
       - DATALAD_TESTS_GITCONFIG="\n[annex]\n stalldetection = 1KB/120s\n"
   - if: type = cron
     python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
     - PYTEST_SELECTION_OP=not
   # Two matrix runs for "recent python and git-annex with the recent supported by git annex
   # new version of repo" and various extra options/features enabled for git-annex
-  - python: '3.10'
+  - python: '3.11'
     dist: focal
     env:
       - PYTEST_SELECTION=
@@ -65,7 +65,7 @@ matrix:
       - DATALAD_REPO_VERSION=10
       - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex -m conda"
       - DATALAD_TESTS_GITCONFIG="\n[annex]\n stalldetection = 1KB/120s\n"
-  - python: '3.10'
+  - python: '3.11'
     dist: focal
     env:
       - PYTEST_SELECTION=

--- a/datalad/tests/test_utils.py
+++ b/datalad/tests/test_utils.py
@@ -177,11 +177,13 @@ def test_getargspec():
         # so we know that our expected is correct
         if not has_kwonlyargs:
             # if False - we test function with kwonlys - inspect.getargspec would barf
-            eq_(inspect.getargspec(f), expected)
+            if sys.version_info < (3, 11):
+                eq_(inspect.getargspec(f), expected)
             # and getfullargspec[:4] wouldn't provide a full picture
             eq_(inspect.getfullargspec(f)[:4], expected)
         else:
-            assert_raises(ValueError, inspect.getargspec, f)
+            if sys.version_info < (3, 11):
+                assert_raises(ValueError, inspect.getargspec, f)
             inspect.getfullargspec(f)  # doesn't barf
         eq_(getargspec(f, include_kwonlyargs=has_kwonlyargs), expected)
 


### PR DESCRIPTION
brought up by @christian-monch , see #7177 

ATM fails in datalad-installer to install 3.11 in conda -- filed https://github.com/datalad/datalad-installer/issues/133