### PR TITLE
Fix runner hanging, fix an error in thread handling, and serialize concurrent generator-runner invocations

### DIFF
--- a/changelog.d/pr-7201.md
+++ b/changelog.d/pr-7201.md
@@ -2,7 +2,7 @@
 
 - Enhance concurrent invocation behavior of `ThreadedRunner.run()`. If possible invocations are serialized instead of raising *re-enter* runtime errors. Deadlock situations are detected and runtime errors are raised instead of deadlocking.
   Fixes [#7138](https://github.com/datalad/datalad/issues/7138) via
-  [PR #72ß1](https://github.com/datalad/datalad/pull/7201)
+  [PR #7201](https://github.com/datalad/datalad/pull/7201)
   (by [@christian-monch](https://github.com/christian-monch))
 
 ### 🐛 Bug Fixes

--- a/changelog.d/pr-7201.md
+++ b/changelog.d/pr-7201.md
@@ -1,0 +1,13 @@
+### 🚀 Enhancements and New Features
+
+- Enhance concurrent invocation behavior of `ThreadedRunner.run()`. If possible invocations are serialized instead of raising *re-enter* runtime errors. Deadlock situations are detected and runtime errors are raised instead of deadlocking.
+  Fixes [#7138](https://github.com/datalad/datalad/issues/7138) via
+  [PR #72ß1](https://github.com/datalad/datalad/pull/7201)
+  (by [@christian-monch](https://github.com/christian-monch))
+
+### 🐛 Bug Fixes
+
+- Fixes hanging threads when `close()` or `del` where called in `BatchedCommand` instances. That could lead to hanging tests if the tests used the `@serve_path_via_http()`-decorator
+  Fixes [#6804](https://github.com/datalad/datalad/issues/6804) via
+  [PR #72ß1](https://github.com/datalad/datalad/pull/7201)
+  (by [@christian-monch](https://github.com/christian-monch))

--- a/changelog.d/pr-7201.md
+++ b/changelog.d/pr-7201.md
@@ -9,5 +9,5 @@
 
 - Fixes hanging threads when `close()` or `del` where called in `BatchedCommand` instances. That could lead to hanging tests if the tests used the `@serve_path_via_http()`-decorator
   Fixes [#6804](https://github.com/datalad/datalad/issues/6804) via
-  [PR #72ß1](https://github.com/datalad/datalad/pull/7201)
+  [PR #7201](https://github.com/datalad/datalad/pull/7201)
   (by [@christian-monch](https://github.com/christian-monch))

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -540,16 +540,12 @@ class BatchedCommand(SafeDelCloseMixin):
                 self.return_code = self.generator.return_code
 
             except CommandError as command_error:
-                if command_error.code is None:
-                    lgr.debug("process lost, return value set to None")
-                else:
-                    lgr.error(
-                        "%s subprocess exited with %s (%s)",
-                        repr(command_error.code),
-                        self,
-                        repr(command_error.code),
-                        command_error
-                    )
+                lgr.error(
+                    "%s subprocess exited with %s (%s)",
+                    self,
+                    repr(command_error.code),
+                    command_error
+                )
                 self.return_code = command_error.code
 
             if remaining:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -538,7 +538,16 @@ class BatchedCommand(SafeDelCloseMixin):
                 self.return_code = self.generator.return_code
 
             except CommandError as command_error:
-                lgr.error("%s subprocess failed with %s", self, command_error)
+                if command_error.code is None:
+                    lgr.debug("process lost, return value set to None")
+                else:
+                    lgr.error(
+                        "%s subprocess exited with %s (%s)",
+                        repr(command_error.code),
+                        self,
+                        repr(command_error.code),
+                        command_error
+                    )
                 self.return_code = command_error.code
 
             if remaining:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -329,6 +329,8 @@ class BatchedCommand(SafeDelCloseMixin):
 
     def process_running(self) -> bool:
         if self.runner:
+            if self.generator.runner.process is None:
+                return False
             result = self.generator.runner.process.poll()
             if result is None:
                 return True
@@ -580,7 +582,7 @@ class BatchedCommand(SafeDelCloseMixin):
                 lgr.log(
                     5,
                     "stderr of %s had %d lines:",
-                    self.generator.runner.process.pid,
+                    self.generator.runner.process.pid if self.generator.runner.process else 'terminated',
                     len(stderr_lines))
                 for line in stderr_lines:
                     lgr.log(5, "| " + line)

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -206,6 +206,7 @@ class SafeDelCloseMixin(object):
         try:
             self.close()
         except (TypeError, ImportError):
+            # ImportError could be raised when the interpreter is shutting down.
             if os.fdopen is None or lgr.debug is None:
                 # if we are late in the game and things already gc'ed in py3,
                 # it is Ok

--- a/datalad/runner/exception.py
+++ b/datalad/runner/exception.py
@@ -35,17 +35,13 @@ class CommandError(RuntimeError):
         self.kwargs = kwargs
 
     def to_str(self, include_output=True):
-        from datalad.utils import (
-            ensure_unicode,
-            join_cmdline,
-        )
         to_str = "{}: ".format(self.__class__.__name__)
         cmd = self.cmd
         if cmd:
             to_str += "'{}'".format(
                 # go for a compact, normal looking, properly quoted
                 # command rendering if the command is in list form
-                join_cmdline(cmd) if isinstance(cmd, list) else cmd
+                " ".join(cmd) if isinstance(cmd, list) else cmd
             )
         if self.code:
             to_str += " failed with exitcode {}".format(self.code)

--- a/datalad/runner/exception.py
+++ b/datalad/runner/exception.py
@@ -35,6 +35,7 @@ class CommandError(RuntimeError):
         self.kwargs = kwargs
 
     def to_str(self, include_output=True):
+        from datalad.utils import ensure_unicode
         to_str = "{}: ".format(self.__class__.__name__)
         cmd = self.cmd
         if cmd:

--- a/datalad/runner/exception.py
+++ b/datalad/runner/exception.py
@@ -35,14 +35,17 @@ class CommandError(RuntimeError):
         self.kwargs = kwargs
 
     def to_str(self, include_output=True):
-        from datalad.utils import ensure_unicode
+        from datalad.utils import (
+            ensure_unicode,
+            join_cmdline,
+        )
         to_str = "{}: ".format(self.__class__.__name__)
         cmd = self.cmd
         if cmd:
             to_str += "'{}'".format(
                 # go for a compact, normal looking, properly quoted
                 # command rendering if the command is in list form
-                " ".join(cmd) if isinstance(cmd, list) else cmd
+                join_cmdline(cmd) if isinstance(cmd, list) else cmd
             )
         if self.code:
             to_str += " failed with exitcode {}".format(self.code)

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -104,8 +104,9 @@ class _ResultGenerator(Generator):
                 )
             self.state = self.GeneratorState.process_running
 
+        runner = self.runner
+
         if self.state == self.GeneratorState.process_running:
-            runner = self.runner
             # If we have elements in the result queue, return one
             while len(self.result_queue) == 0 and runner.should_continue():
                 runner.process_queue()
@@ -127,8 +128,6 @@ class _ResultGenerator(Generator):
             # callback. Those are returned here.
             if len(self.result_queue) > 0:
                 return self.result_queue.popleft()
-
-            runner = self.runner
             runner.ensure_stdin_stdout_stderr_closed()
             runner.protocol.connection_lost(None)   # TODO: check for exceptions
             runner.wait_for_threads()
@@ -140,7 +139,6 @@ class _ResultGenerator(Generator):
             # state: GeneratorState.process_exited.
             if len(self.result_queue) > 0:
                 return self.result_queue.popleft()
-            runner = self.runner
             runner.generator = None
             runner.owning_thread = None
             self.state = self.GeneratorState.exhausted

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -100,7 +100,7 @@ class _ResultGenerator(Generator):
         if self.state == self.GeneratorState.initialized:
             if message is not None:
                 raise RuntimeError(
-                    "sent non-None message to initialized generator "
+                    f"sent non-None message {message!r} to initialized generator "
                 )
             self.state = self.GeneratorState.process_running
 

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -566,7 +566,7 @@ class ThreadedRunner:
         # Continue with queue processing if there is still a process or
         # monitored files, or if there are still elements in the output queue.
         if self.is_stalled():
-            self.return_code = self.process.poll()
+            self.return_code = self.process.poll() if self.process else None
         return (
             len(self.active_file_numbers) > 0
             or not self.output_queue.empty()

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import enum
 import logging
 import subprocess
-import sys
 import threading
 import time
 from collections import deque
@@ -284,7 +283,7 @@ class ThreadedRunner:
 
     def _check_result(self):
         if self.exception_on_error is True:
-            if self.return_code != 0:
+            if self.return_code not in (0, None):
                 protocol = self.protocol
                 decoded_output = {
                     source: protocol.fd_infos[fileno][1].decode(protocol.encoding)
@@ -572,8 +571,6 @@ class ThreadedRunner:
     def should_continue(self) -> bool:
         # Continue with queue processing if there is still a process or
         # monitored files, or if there are still elements in the output queue.
-        if self.is_stalled():
-            self.return_code = self.process.poll() if self.process else None
         return (
             len(self.active_file_numbers) > 0
             or not self.output_queue.empty()

--- a/datalad/runner/runner.py
+++ b/datalad/runner/runner.py
@@ -11,8 +11,14 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
+from os import PathLike
+from queue import Queue
+from typing import (
+    IO,
+    cast,
+)
 
+from .protocol import WitlessProtocol
 from .coreprotocols import NoCapture
 from .exception import CommandError
 from .nonasyncrunner import (
@@ -67,13 +73,13 @@ class WitlessRunner(object):
         return env
 
     def run(self,
-            cmd,
-            protocol=None,
-            stdin=None,
-            cwd=None,
-            env=None,
-            timeout=None,
-            exception_on_error=True,
+            cmd: list | str,
+            protocol: type[WitlessProtocol] | None = None,
+            stdin: bytes | IO | Queue | None = None,
+            cwd: PathLike | str | None = None,
+            env: dict | None = None,
+            timeout: float | None = None,
+            exception_on_error: bool = True,
             **kwargs) -> dict | _ResultGenerator:
         """Execute a command and communicate with it.
 
@@ -106,7 +112,7 @@ class WitlessRunner(object):
           This must be a complete environment definition, no values
           from the current environment will be inherited. Overrides
           any `env` given to the constructor.
-        timeout:
+        timeout: float, optional
           None or the seconds after which a timeout callback is
           invoked, if no progress was made in communicating with
           the sub-process, or if waiting for the subprocess exit
@@ -214,6 +220,6 @@ class WitlessRunner(object):
                 cwd=self.cwd,
                 **results,
             )
-        # denoise, must be zero at this point
+        # Denoise result, the return code must be zero at this point.
         results.pop('code', None)
         return results

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -539,7 +539,7 @@ def test_exit_3():
                         timeout=.5,
                         exception_on_error=False)
     tuple(rt.run())
-    assert_true(rt.process.poll() is not None)
+    assert_true(rt.return_code is not None)
 
 
 def test_exit_4():
@@ -548,7 +548,7 @@ def test_exit_4():
                         protocol_class=GenNothing,
                         timeout=.5)
     tuple(rt.run())
-    assert_true(rt.process.poll() is not None)
+    assert_true(rt.return_code is not None)
 
 
 def test_generator_throw():

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -90,6 +90,12 @@ class GenNothing(GeneratorMixIn, NoCapture):
 
 
 class GenStdoutLines(GeneratorMixIn, StdOutCapture):
+    """A generator-based protocol yielding individual subprocess' stdout lines
+
+    This is a simple implementation that is good enough for tests, i.e. with
+    controlled inpute. It will fail if data is delivered in parts to
+    self.pipe_data_received that are split inside an encoded character.
+    """
     def __init__(self,
                  done_future=None,
                  encoding=None):

--- a/datalad/runner/tests/test_threadsafety.py
+++ b/datalad/runner/tests/test_threadsafety.py
@@ -79,14 +79,6 @@ def _reentry_detection_run(protocol: type[WitlessProtocol],
     return exception
 
 
-def test_thread_reentry_detection():
-    # expect that two run calls on the same runner with a generator-protocol
-    # and an active generator create a runtime error
-
-    exceptions = _reentry_detection_run(MinimalGeneratorProtocol, False)
-    assert exceptions == [RuntimeError]
-
-
 def test_thread_serialization():
     # expect that two run calls on the same runner with a non-generator-protocol
     # do not create a runtime error (executions are serialized though)

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -182,7 +182,7 @@ def test_runner_empty_stdin():
     # Ensure a runner without stdin data and output capture progresses
     runner = Runner()
     runner.run(
-        ["cat"],
+        py2cmd('import sys; print(sys.stdin.read())'),
         stdin=b"",
         protocol=None
     )

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -14,6 +14,10 @@ import os
 import signal
 import sys
 import unittest.mock
+from threading import (
+    Lock,
+    Thread,
+)
 from time import (
     sleep,
     time,
@@ -50,6 +54,9 @@ from .. import (
     StdOutErrCapture,
 )
 from .utils import py2cmd
+
+
+result_counter = 0
 
 
 @assert_cwd_unchanged
@@ -381,3 +388,44 @@ def test_argument_priority():
             **test_env_2,
             'PWD': test_path_2
         }
+
+
+def test_concurrent_execution():
+    runner = Runner()
+    caller_threads = []
+
+    result_list = []
+    result_list_lock = Lock()
+
+    def target(count, r_list, r_list_lock):
+        result = runner.run(
+            py2cmd(
+                "import time;"
+                "import sys;"
+                "time.sleep(1);"
+                "print('end', sys.argv[1])",
+                str(count)
+            ),
+            protocol=StdOutCapture,
+        )
+        output = result["stdout"].strip()
+        assert output == f"end {str(count)}"
+        with r_list_lock:
+            r_list.append(output)
+
+    for c in range(100):
+        caller_thread = Thread(
+            target=target,
+            kwargs=dict(
+                count=c,
+                r_list=result_list,
+                r_list_lock=result_list_lock,
+            ))
+        caller_thread.start()
+        caller_threads.append(caller_thread)
+
+    while caller_threads:
+        t = caller_threads.pop()
+        t.join()
+
+    assert len(result_list) == 100

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -60,8 +60,8 @@ def test_batched_close_abandon():
     response = bc("import time; print('a')")
     assert_equal(response, "a")
     bc.stdin_queue.put("time.sleep(2); exit(1)\n".encode())
-    with unittest.mock.patch("datalad.cfg") as cfg_mock:
-        cfg_mock.configure_mock(**{"obtain.return_value": "abandon"})
+
+    with unittest.mock.patch("datalad.cmd._cfg_val", "abandon"):
         bc.close(return_stderr=False)
         assert_true(bc.wait_timed_out is True)
         assert_is_none(bc.return_code)

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -19,14 +19,12 @@ from datalad.cmd import (
     readline_rstripped,
 )
 from datalad.cmd import BatchedCommandError
-from datalad.runner.exception import CommandError
 from datalad.runner.tests.utils import py2cmd
 from datalad.tests.utils_pytest import (
     assert_equal,
     assert_is_none,
     assert_is_not_none,
     assert_not_equal,
-    assert_raises,
     assert_true,
 )
 
@@ -81,7 +79,8 @@ def test_batched_close_timeout_exception():
     bc.stdin_queue.put("time.sleep(2); exit(1)\n".encode())
     with unittest.mock.patch("datalad.cfg") as cfg_mock:
         cfg_mock.configure_mock(**{"obtain.return_value": "abandon"})
-        assert_raises(TimeoutExpired, bc.close)
+        with pytest.raises(TimeoutExpired) as exc:
+            bc.close()
 
 
 def test_batched_close_wait():

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -65,6 +65,7 @@ def test_batched_close_abandon():
         assert_is_none(bc.return_code)
 
 
+@pytest.mark.filterwarnings("ignore:Exception ignored")
 def test_batched_close_timeout_exception():
     # Expect a timeout if the process runs longer than timeout and the config
     # for "datalad.runtime.stalled-external" is "abandon".


### PR DESCRIPTION
This PR fixes a number of issues.

The PR extends the number of concurrent runner-call scenarios beyond the current implementation, i.e. serialize synchronous (non-generator) `ThreadedRunner.run()`-calls. The scenarios now supported are:

1. Concurrently invoke `ThreadedRunner.run()` without generator, leading to serialization of invocations.
2. Concurrently invoke `ThreadedRunner.run()` with generator, leading to serialisation of invocations, i.e. later invocations return if the currently active generator is exhausted
3. Concurrently read from a generator returned by `ThreadedRunner.run()`. Any number of threads can call `send()` on a generator, results will be returned as soon as they are available. Which of the waiting threads is continued is non-deterministic. If the generator is exhausted, all threads will receive a `StopIteration`-exception.

The serialization should fix spurious test errors. Fixes #7138

In addition the PR fixes an error that could lead to hanging threads if `close()` or `del` is called on a `BatchedCommand`-instance. This should fix a number of hanging errors in tests that use the `@serve_path_via_http()` decorator. Fixes #6804 
