### PR TITLE
DOC: Use standard key name 'error_message' in result record design docs

### DIFF
--- a/docs/source/design/result_records.rst
+++ b/docs/source/design/result_records.rst
@@ -173,8 +173,8 @@ A string label categorizing the state of an entity. Common values are:
 - ``present``
 
 
-``error-messages``
-------------------
+``error_message``
+-----------------
 
 List of any error messages that were captured or produced while achieving a
 result.


### PR DESCRIPTION
This is a small documentation fix for an old issue I found fully dissected, but yet unaddressed:
As elaborated in detail by @mslw in #6620, the common keyname for an error message in a result record is ``error_message``. The Design document on result records however spells this key as ``error-messages``, not as ``error_message`` as understood by ``generic_result_renderer()``. This commit changes the design document to use error_message. Fixes #6620

I would appreciate a brief review by @mslw to check if I understood his issue correctly.
