### PR TITLE
Mark some tests as known fails on github CI windows

### DIFF
--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -517,6 +517,7 @@ def test_force_checkdatapresent(srcpath=None, dstpath=None):
                       message='Slated for transport, but no content present')
 
 
+@known_failure_githubci_win  # recent git-annex, https://github.com/datalad/datalad/issues/7185
 @with_tempfile(mkdir=True)
 @with_tree(tree={'ria-layout-version': '1\n'})
 def test_ria_push(srcpath=None, dstpath=None):
@@ -882,6 +883,7 @@ def test_push_matching(path=None):
 
 
 @slow  # can run over 30 sec when running in parallel with n=2. Cannot force serial yet, see https://github.com/pytest-dev/pytest-xdist/issues/385
+@known_failure_githubci_win  # recent git-annex, https://github.com/datalad/datalad/issues/7184
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -39,6 +39,7 @@ from datalad.tests.utils_pytest import (
     assert_status,
     eq_,
     get_deeply_nested_structure,
+    known_failure_githubci_win,
     nok_,
     ok_,
     with_tempfile,
@@ -574,6 +575,7 @@ def test_drop_allkeys_result_contains_annex_error_messages(path=None):
 
 
 # https://github.com/datalad/datalad/issues/6948
+@known_failure_githubci_win  # recent git-annex, https://github.com/datalad/datalad/issues/7197
 @with_tempfile
 @with_tempfile
 def test_nodrop_symlinked_annex(origpath=None, clonepath=None):


### PR DESCRIPTION
Ref: #7184, #7185, #7197

Need to do that since there is no human force available to investigate and address them currently and we might this way miss more failures on datalad/git-annex CI setup.

- Note: that I marked them as known only for github CI, so they might resurface on appveyor whenever a new release of git-annex comes out. Then either they would need to be addressed or marked as generally known to fail on windows

- Another note: PR is against `master` since seems there is no such fails on `maint`. See e.g. https://github.com/datalad/git-annex/actions/runs/3561508598 for comparison

- I think I will not bother with changelog entry for this change