### PR TITLE
Fix localpath handling for file-URLs on different OS, especially on Windows

### DIFF
--- a/changelog.d/pr-7206.md
+++ b/changelog.d/pr-7206.md
@@ -1,0 +1,6 @@
+### 🐛 Bug Fixes
+
+- Interpret file-URL path components according to the local operating system as described in RFC 8089. With this fix, `datalad.network.RI('file:...').localpath` returns a correct local path on Windows if the RI is constructed with a file-URL.  
+  Fixes [#7186](https://github.com/datalad/datalad/issues/7186) via
+  [PR #7206](https://github.com/datalad/datalad/pull/7206)
+  (by [@christian-monch](https://github.com/christian-monch))

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -67,12 +67,28 @@ from datalad.utils import (
 
 
 def local_path_representation(path: str) -> str:
-    """Return an OS-specific representation of a "file:" URI-style path
+    """Return an OS-specific representation of a Posix-style path
 
     With a posix path in the form of "a/b" this function will return "a/b" on
     Unix-like operating systems and "a\\b" on Windows-style operating systems.
     """
     return str(Path(path))
+
+
+def local_url_path_representation(url_path: str) -> str:
+    """Return an OS-specific representation of the path component in a file:-URL
+
+    With a path component like "/c:/Windows" (i.e. from a URL that reads
+    "file:///c:/Windows"), this function will return "/c:/Windows" on a
+    Unix-like operating systems and "C:\\Windows" on Windows-like operating
+    systems.
+    """
+    return url2pathname(url_path)
+
+
+def local_path_from_url(url: str) -> str:
+    """Parse the url and extract an OS-specific local path representation"""
+    return local_url_path_representation(urlparse(url).path)
 
 
 def is_windows_path(path):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -741,15 +741,6 @@ class URL(RI):
         # verbatim copy of a Windows-style path.
         unified_path = self.path.replace('\\', '/')
         return url2pathname(unified_path)
-        print("---: self.path:", self.path, file=sys.stderr)
-        print("|1 : unified_path:", unified_path, file=sys.stderr)
-        print("|2 : url2pathname(unified_path):", url2pathname(unified_path), file=sys.stderr)
-        print("|3 : pathname2url(url2pathname(unified_path)):", pathname2url(url2pathname(unified_path)), file=sys.stderr)
-        print("|r : url2pathname(unified_path):", url2pathname(unified_path), file=sys.stderr)
-        pathname = url2pathname(unified_path)
-        if on_windows:
-            return pathname.replace("\\", "/")
-        return pathname
 
 
 class PathRI(RI):

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -9,7 +9,6 @@
 
 import logging
 import os
-import sys
 from collections import OrderedDict
 from os.path import isabs
 from os.path import join as opj
@@ -53,7 +52,6 @@ from datalad.tests.utils_pytest import (
     nok_,
     ok_,
     skip_if,
-    skip_if_on_windows,
     swallow_logs,
     with_tempfile,
 )

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -50,6 +50,7 @@ from datalad.tests.utils_pytest import (
     neq_,
     nok_,
     ok_,
+    skip_if,
     skip_if_on_windows,
     swallow_logs,
     with_tempfile,
@@ -230,6 +231,11 @@ def test_pathri_guessing(filename=None):
             # Does not happen on Windows since paths with \ instead of / do not
             # look like possible URLs
             assert_in('ParseResults contains params', cml.out)
+
+
+@skip_if(not on_windows)
+def test_pathri_windows_anchor():
+    assert RI('file:///c:/Windows').localpath == 'C:\\Windows'
 
 
 @known_failure_githubci_win

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -35,6 +35,7 @@ from datalad.support.network import (
     is_url,
     iso8601_to_epoch,
     local_path_representation,
+    local_url_path_representation,
     parse_url_opts,
     same_website,
     urlquote,
@@ -172,7 +173,11 @@ def _check_ri(ri, cls, exact_str=True, localpath=None, **fields):
         eq_(getattr(ri_, f), v)
 
     if localpath:
-        assert ri_.localpath == local_path_representation(localpath)
+        if cls == URL:
+            local_representation = local_url_path_representation(localpath)
+        else:
+            local_representation = local_path_representation(localpath)
+        assert ri_.localpath == local_representation
         old_localpath = ri_.localpath  # for a test below
     else:
         # if not given -- must be a remote url, should raise exception
@@ -300,7 +305,7 @@ def test_url_samples():
     _check_ri("file:///~/path/sp1", URL, localpath='/~/path/sp1', scheme='file', path='/~/path/sp1')
     _check_ri("file:///%7E/path/sp1", URL, localpath='/~/path/sp1', scheme='file', path='/~/path/sp1', exact_str=False)
     # not sure but let's check
-    _check_ri("file:///c:/path/sp1", URL, localpath='C:/path/sp1', scheme='file', path='/c:/path/sp1', exact_str=False)
+    _check_ri("file:///C:/path/sp1", URL, localpath='/C:/path/sp1', scheme='file', path='/C:/path/sp1', exact_str=False)
 
     # and now implicit paths or actually they are also "URI references"
     _check_ri("f", PathRI, localpath='f', path='f')

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -34,6 +34,7 @@ from datalad.support.network import (
     is_ssh,
     is_url,
     iso8601_to_epoch,
+    local_path_representation,
     parse_url_opts,
     same_website,
     urlquote,
@@ -171,7 +172,7 @@ def _check_ri(ri, cls, exact_str=True, localpath=None, **fields):
         eq_(getattr(ri_, f), v)
 
     if localpath:
-        eq_(ri_.localpath, localpath)
+        assert ri_.localpath == local_path_representation(localpath)
         old_localpath = ri_.localpath  # for a test below
     else:
         # if not given -- must be a remote url, should raise exception
@@ -188,7 +189,7 @@ def _check_ri(ri, cls, exact_str=True, localpath=None, **fields):
     eq_(ri_.path, newpath)
     neq_(str(ri_), old_str)
     if localpath:
-        eq_(ri_.localpath, opj(old_localpath, 'sub'))
+        assert ri_.localpath == local_path_representation(opj(old_localpath, 'sub'))
 
 
 def test_url_base():
@@ -299,7 +300,7 @@ def test_url_samples():
     _check_ri("file:///~/path/sp1", URL, localpath='/~/path/sp1', scheme='file', path='/~/path/sp1')
     _check_ri("file:///%7E/path/sp1", URL, localpath='/~/path/sp1', scheme='file', path='/~/path/sp1', exact_str=False)
     # not sure but let's check
-    _check_ri("file:///c:/path/sp1", URL, localpath='/c:/path/sp1', scheme='file', path='/c:/path/sp1', exact_str=False)
+    _check_ri("file:///c:/path/sp1", URL, localpath='C:/path/sp1', scheme='file', path='/c:/path/sp1', exact_str=False)
 
     # and now implicit paths or actually they are also "URI references"
     _check_ri("f", PathRI, localpath='f', path='f')
@@ -432,11 +433,11 @@ def test_url_dicts():
 
 
 def test_get_url_path_on_fileurls():
-    eq_(URL('file:///a').path, '/a')
-    eq_(URL('file:///a/b').path, '/a/b')
-    eq_(URL('file:///a/b').localpath, '/a/b')
-    eq_(URL('file:///a/b#id').path, '/a/b')
-    eq_(URL('file:///a/b?whatever').path, '/a/b')
+    assert URL('file:///a').path == '/a'
+    assert URL('file:///a/b').path == '/a/b'
+    assert URL('file:///a/b').localpath == local_path_representation('/a/b')
+    assert URL('file:///a/b#id').path == '/a/b'
+    assert URL('file:///a/b?whatever').path == '/a/b'
 
 
 def test_is_url():


### PR DESCRIPTION
Fixes #7186 

The current code base treats the `path` component of `file`-URLs not according to the conventions described in the relevant standard, i.e. [RFC8089](https://www.ietf.org/rfc/rfc8089.html) in [Appendix D.2](https://www.ietf.org/rfc/rfc8089.html#appendix-D.2) and [Appendix E.2](https://www.ietf.org/rfc/rfc8089.html#appendix-E.2) (funnily enough Append E.2 defines some "nonstandard techniques for interacting with DOS- or Windows-like file paths and URIs").

As @mih pointed out, there is support for the conventions described in RFC8089 Appendix D.2 and RFC8089 Appendix E.2 in python, implemented in `nturl2path`, which is transparently used in `urllib.request.url2pathname` on Windows systems.

This PR uses `urllib.request.url2pathname` to convert the path of a file-URL to a local path. This changes the behavior of `RI.localpath` if an `RI` is an instance of `URL`, and the URL-scheme is `file`, In this case `localpath` will return a result from `urllib.request.url2pathname`. This means for example that the following holds:

* On Posix-like systems: `RI('file:/c:/Windows').localpath == '/c:/Windows'`
* On Windows-like systems: `RI('file:/c:/Windows').localpath == 'C:\\Windows'`

Note that the drive letter is converted to a canonical "upper case" representation.