### PR TITLE
Let CLI report on exception causes

### DIFF
--- a/changelog.d/pr-7210.md
+++ b/changelog.d/pr-7210.md
@@ -1,0 +1,7 @@
+### 🚀 Enhancements and New Features
+
+- Exceptions bubbling up through CLI are now reported on including their chain
+  of __cause__.
+  Fixes [#7163](https://github.com/datalad/datalad/issues/7163) via
+  [PR #7210](https://github.com/datalad/datalad/pull/7210)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -216,7 +216,7 @@ def _run_with_exception_handler(cmdlineargs):
             exit_code = 3
         else:
             # some unforeseen problem
-            lgr.error('%s (%s)', ce.message, ce.name)
+            lgr.error('%s', ce.format_with_cause())
         sys.exit(exit_code)
 
 

--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -93,6 +93,12 @@ class CapturedException(object):
         """
         return self.name + '(' + self.message + ')'
 
+    def format_with_cause(self):
+        """Returns a representation of the original exception including the
+        underlying causes"""
+
+        return format_exception_with_cause(self.tb)
+
     @property
     def message(self):
         """Returns only the message of the original exception
@@ -198,7 +204,9 @@ def format_exception_with_cause(e):
     while being recognizably different from potential exception payload
     messages.
     """
-    s = str(e) or e.__class__.__name__
+    s = str(e) or \
+        (e.exc_type.__name__ if isinstance(e, traceback.TracebackException)
+         else e.__class__.__name__)
     exc_cause = getattr(e, '__cause__', None)
     if exc_cause:
         s += f' -caused by- {format_exception_with_cause(exc_cause)}'

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -110,3 +110,8 @@ def test_format_exception_with_cause():
         assert_equal(
             format_exception_with_cause(e),
             'RuntimeError -caused by- ValueError -caused by- Mike')
+        # make sure it also works with TracebackException/CapturedException:
+        ce = CapturedException(e)
+        assert_equal(
+            ce.format_with_cause(),
+            'RuntimeError -caused by- ValueError -caused by- Mike')


### PR DESCRIPTION
Ensure the already existing `format_exception_with_cause` also works with `traceback.TracebackException` and use this to provide another format method for `CapturedException`. This is then used with unexpectedly bubbled up exceptions by the CLI.

Fixes #7163


FTR:

Actually hard to find a case where I know an exception would bubble up and actually have a `__cause__` in core.

Making one up like this: 

```
 raise ValueError("something is wrong") from RuntimeError("severe problem")
```

Would now be:

```
> datalad wtf
[ERROR  ] something is wrong -caused by- severe problem 
```

Whereas 

```
 raise ValueError("something is wrong") from RuntimeError
 ```
 
 Would lead to 
 
 ```
> datalad wtf
[ERROR  ] something is wrong -caused by- RuntimeError
```


Rational for sparing the class name when there's a message, is taken from the existing implementation used by special remotes: 

> For each exception in the chain either the str() of it is taken, or the
> class name of the exception, with the aim to generate a simple and
> comprehensible description that can be used in user-facing messages.
> It is explicitly not aiming to provide a detailed/comprehensive source
> of information for in-depth debugging.

