### PR TITLE
RF: get_modules_ - avoid O(N^2) if paths provided via use of get_parent_paths

### DIFF
--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -964,6 +964,11 @@ def test_GitRepo_get_submodules(path=None):
          for s in repo.get_submodules(paths=["s_abc"])],
         ["s_abc"])
 
+    # top level should list all submodules
+    eq_([s["gitmodule_name"]
+         for s in repo.get_submodules(paths=[repo.path])],
+        ["s_abc", "s_xyz"])
+
     # Limit by non-existing/non-matching path
     eq_([s["gitmodule_name"]
          for s in repo.get_submodules(paths=["s_unknown"])],


### PR DESCRIPTION
Redone https://github.com/datalad/datalad/pull/6974 .  Now that https://github.com/datalad/datalad/pull/7189 has finished the RFing to avoid some slow operations at the cost of making some use cases slower, this should resolve it back to avoid any slow operation.

get_parent_paths function was originally created for get_content_info for that specific reason (performance). #6974 commits avoided a hypothetical infinite recursion (my code analysis says it was not possible, see https://github.com/datalad/datalad/issues/6941#issuecomment-1222385283) and performance issues by introducing similar logic directly in the code of get_modules_.

This commit RFs that back to use get_parent_paths but also extends it to return not parent paths but actual paths. So we reuse the same logic but manipulate what is returned by the function. That allows us to subselect paths which are under "parents".

It also adds rudimentary tests for invocation with paths limiting etc.

Some timings as in https://github.com/datalad/datalad/pull/6942#discussion_r947956976 on master

```shell
❯ datalad --version; (builtin cd /home/yoh/datalad/hcp-openaccess; /bin/time python -c "from datalad.support.gitrepo import *; from glob import glob; print('\n'.join(map(str,GitRepo('.').get_submodules_(glob('HCP1200/*')))))" | wc -l; )
datalad 0.17.9+183.g34a28a622
4.32user 0.14system 0:04.44elapsed 100%CPU (0avgtext+0avgdata 29308maxresident)k
0inputs+0outputs (0major+8234minor)pagefaults 0swaps
1113
```

and this PR

```shell
❯ datalad --version; (builtin cd /home/yoh/datalad/hcp-openaccess; /bin/time python -c "from datalad.support.gitrepo import *; from glob import glob; print('\n'.join(map(str,GitRepo('.').get_submodules_(glob('HCP1200/*')))))" | wc -l; )
datalad 0.17.9+184.ge605b29d6
0.64user 0.13system 0:00.74elapsed 104%CPU (0avgtext+0avgdata 28976maxresident)k
0inputs+160outputs (0major+8231minor)pagefaults 0swaps
1113
```

I don't think we need a dedicated changelog entry since no release since #7189 