### PR TITLE
NF: make extra_remote_settings configurable in git config

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -126,6 +126,10 @@
             "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
             "name": "Szczepanik, Michał",
             "orcid": "0000-0002-4028-2087"
+        },
+        {
+            "affiliation": "Institute of Energy and Climate Research - Stratosphere (IEK-7), Research Centre Jülich, Jülich, Germany",
+            "name": "Riße, Matthias"
         }
     ],
     "grants": [

--- a/changelog.d/pr-7213.md
+++ b/changelog.d/pr-7213.md
@@ -1,3 +1,3 @@
 ### 🚀 Enhancements and New Features
 
-- NF: make extra_remote_settings configurable in git config.  [PR #7213](https://github.com/datalad/datalad/pull/7213) (by [@matrss](https://github.com/matrss))
+- New config `datalad.create-sibling-ghlike.extra-remote-settings.NETLOC.KEY=VALUE` allows to add and/or overwrite local configuration for the created sibling by the commands `create-sibling-<gin|gitea|github|gitlab|gogs>`.  [PR #7213](https://github.com/datalad/datalad/pull/7213) (by [@matrss](https://github.com/matrss))

--- a/changelog.d/pr-7213.md
+++ b/changelog.d/pr-7213.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- NF: make extra_remote_settings configurable in git config.  [PR #7213](https://github.com/datalad/datalad/pull/7213) (by [@matrss](https://github.com/matrss))

--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -18,6 +18,7 @@ from urllib.parse import (
 
 import requests
 
+from datalad import cfg as dlcfg
 from datalad.distribution.dataset import (
     EnsureDataset,
     require_dataset,
@@ -157,6 +158,19 @@ class _GitHubLike(object):
             + f'. {token_info}' if token_info else '',
             require_token,
         )
+        self._set_extra_remote_settings()
+
+    def _set_extra_remote_settings(self):
+        target_name = urlparse(self.api_url).netloc
+        config_section = "datalad.create-sibling-ghlike.extra-remote-settings.{}".format(target_name)
+        target_specific_settings = {
+            option: dlcfg.get_value(config_section, option)
+            for option in dlcfg.options(config_section)
+        }
+        self.extra_remote_settings = {
+            **self.extra_remote_settings,
+            **target_specific_settings,
+        }
 
     @todo_interface_for_extensions
     def _set_request_headers(self, credential_name, auth_info, require_token):

--- a/datalad/distributed/create_sibling_gin.py
+++ b/datalad/distributed/create_sibling_gin.py
@@ -71,6 +71,18 @@ class CreateSiblingGin(Interface):
     generated on the platform (Account->Your Settings->Applications->Generate
     New Token).
 
+    This command can be configured with
+    "datalad.create-sibling-ghlike.extra-remote-settings.NETLOC.KEY=VALUE" in
+    order to add any local KEY = VALUE configuration to the created sibling in
+    the local `.git/config` file. NETLOC is the domain of the Gin instance to
+    apply the configuration for.
+    This leads to a behavior that is equivalent to calling datalad's
+    ``siblings('configure', ...)``||``siblings configure`` command with the
+    respective KEY-VALUE pair after creating the sibling.
+    The configuration, like any other, could be set at user- or system level, so
+    users do not need to add this configuration to every sibling created with
+    the service at NETLOC themselves.
+
     .. versionadded:: 0.16
     """
 

--- a/datalad/distributed/create_sibling_gitea.py
+++ b/datalad/distributed/create_sibling_gitea.py
@@ -94,6 +94,18 @@ class CreateSiblingGitea(Interface):
     In order to be able to use this command, a personal access token has to be
     generated on the platform (Account->Settings->Applications->Generate Token).
 
+    This command can be configured with
+    "datalad.create-sibling-ghlike.extra-remote-settings.NETLOC.KEY=VALUE" in
+    order to add any local KEY = VALUE configuration to the created sibling in
+    the local `.git/config` file. NETLOC is the domain of the Gitea instance to
+    apply the configuration for.
+    This leads to a behavior that is equivalent to calling datalad's
+    ``siblings('configure', ...)``||``siblings configure`` command with the
+    respective KEY-VALUE pair after creating the sibling.
+    The configuration, like any other, could be set at user- or system level, so
+    users do not need to add this configuration to every sibling created with
+    the service at NETLOC themselves.
+
     .. versionadded:: 0.16
     """
 

--- a/datalad/distributed/create_sibling_github.py
+++ b/datalad/distributed/create_sibling_github.py
@@ -129,6 +129,18 @@ class CreateSiblingGithub(Interface):
     generated on the platform (Account->Settings->Developer Settings->Personal
     access tokens->Generate new token).
 
+    This command can be configured with
+    "datalad.create-sibling-ghlike.extra-remote-settings.NETLOC.KEY=VALUE" in
+    order to add any local KEY = VALUE configuration to the created sibling in
+    the local `.git/config` file. NETLOC is the domain of the Github instance to
+    apply the configuration for.
+    This leads to a behavior that is equivalent to calling datalad's
+    ``siblings('configure', ...)``||``siblings configure`` command with the
+    respective KEY-VALUE pair after creating the sibling.
+    The configuration, like any other, could be set at user- or system level, so
+    users do not need to add this configuration to every sibling created with
+    the service at NETLOC themselves.
+
     .. versionchanged:: 0.16
        || REFLOW >>
        The API has been aligned with the some

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -119,6 +119,19 @@ class CreateSiblingGitlab(Interface):
         Project location/path used for a datasets at GitLab instance
         SITENAME (see --project). Configuring this is useful for deriving
         project paths for subdatasets, relative to superdataset.
+
+    This command can be configured with
+    "datalad.create-sibling-ghlike.extra-remote-settings.NETLOC.KEY=VALUE" in
+    order to add any local KEY = VALUE configuration to the created sibling in
+    the local `.git/config` file. NETLOC is the domain of the Gitlab instance to
+    apply the configuration for.
+    This leads to a behavior that is equivalent to calling datalad's
+    ``siblings('configure', ...)``||``siblings configure`` command with the
+    respective KEY-VALUE pair after creating the sibling.
+    The configuration, like any other, could be set at user- or system level, so
+    users do not need to add this configuration to every sibling created with
+    the service at NETLOC themselves.
+
     """
     _params_ = dict(
         path=Parameter(

--- a/datalad/distributed/create_sibling_gogs.py
+++ b/datalad/distributed/create_sibling_gogs.py
@@ -63,6 +63,18 @@ class CreateSiblingGogs(Interface):
     generated on the platform
     (Account->Your Settings->Applications->Generate New Token).
 
+    This command can be configured with
+    "datalad.create-sibling-ghlike.extra-remote-settings.NETLOC.KEY=VALUE" in
+    order to add any local KEY = VALUE configuration to the created sibling in
+    the local `.git/config` file. NETLOC is the domain of the Gogs instance to
+    apply the configuration for.
+    This leads to a behavior that is equivalent to calling datalad's
+    ``siblings('configure', ...)``||``siblings configure`` command with the
+    respective KEY-VALUE pair after creating the sibling.
+    The configuration, like any other, could be set at user- or system level, so
+    users do not need to add this configuration to every sibling created with
+    the service at NETLOC themselves.
+
     .. versionadded:: 0.16
     """
 


### PR DESCRIPTION
This PR makes the extra_remote_settings attribute for GitHub-like create_sibling targets configurable on a per target basis. One usecase would be to override an annex-ignore setting, which is otherwise unconditionally set. E.g. if we host a gitea server which does support git-annex at example.com, we could set:
```
[datalad "extra_remote_settings.example.com"]
	annex-ignore = false
```
in e.g. ~/.gitconfig to override the default of not using git-annex with gitea.

This approach does have the issue that the settings are apparently set before first enabling the remote. This leads to spurious warnings like this when creating the sibling:
```
[INFO   ] Could not enable annex remote origin. This is expected if origin is a pure Git remote, or happens if it is not accessible. 
[WARNING] Could not detect whether origin carries an annex. If origin is a pure Git remote, this is expected.
```
but a subsequent push does work with annex enabled.
The code for create_sibling_gin apparently sets annex-ignore afterwards, but I am not sure if there are any implications for other possible options in extra_remote_settings which might need to be set before or after first enabling the remote. Feedback welcome.

Fixes #7179.