### PR TITLE
Reorder commands in ORA get via SSH

### DIFF
--- a/changelog.d/pr-7215.md
+++ b/changelog.d/pr-7215.md
@@ -1,3 +1,3 @@
 ### 🐛 Bug Fixes
 
-- Reorder commands in ORA get via SSH.  Fixes [#7214](https://github.com/datalad/datalad/issues/7214) via [PR #7215](https://github.com/datalad/datalad/pull/7215) (by [@mslw](https://github.com/mslw))
+- Fix a bug when retrieving several files from a RIA store via SSH, when the annex key does not contain size information. Fixes [#7214](https://github.com/datalad/datalad/issues/7214) via [PR #7215](https://github.com/datalad/datalad/pull/7215) (by [@mslw](https://github.com/mslw))

--- a/changelog.d/pr-7215.md
+++ b/changelog.d/pr-7215.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Reorder commands in ORA get via SSH.  Fixes [#7214](https://github.com/datalad/datalad/issues/7214) via [PR #7215](https://github.com/datalad/datalad/pull/7215) (by [@mslw](https://github.com/mslw))


### PR DESCRIPTION
This delays the remote-end `cat` command until just before its output is needed, for two reasons:

1. The command output is not needed if `get` decides to use scp
2. When getting multiple files encrypted by git-annex (which would use scp, due to size not being part of the annex key), the `cat` output would remain in standard output and would be read when checking whether the *next* file exists (i.e. when trying to parse a completely different output), crashing upon `decode()`. 

Fixes #7214