### PR TITLE
Clean up conversion between local file system paths and file-URL path components

### DIFF
--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -9,9 +9,18 @@
 """Helper for RIA stores
 
 """
+from __future__ import annotations
 
 import logging
 from pathlib import Path
+from urllib.parse import (
+    unquote,
+    urlparse,
+)
+from urllib.request import (
+    url2pathname,
+    pathname2url,
+)
 
 
 lgr = logging.getLogger('datalad.customremotes.ria_utils')
@@ -87,6 +96,7 @@ def verify_ria_url(url, cfg):
       (host, base-path, rewritten url)
       `host` is not just a hostname, but is a stub URL that may also contain
       username, password, and port, if specified in a given URL.
+      `base-path` is the path component of the url
     """
     from datalad.config import rewrite_url
     from datalad.support.network import URL
@@ -243,3 +253,16 @@ def create_ds_in_store(io, base_path, dsid, obj_version, store_version,
         except FileExistsError:
             lgr.warning("Alias %r already exists in the RIA store, not adding an "
                         "alias.", alias)
+
+
+def local_path2url_path(local_path: str) -> str:
+    """Convert a local path into a URL path part"""
+    if not local_path:
+        return '/'
+    return urlparse(unquote(pathname2url(local_path))).path
+
+
+def url_path2local_path(url_path: str) -> str:
+    if not url_path:
+        return str(Path('/'))
+    return url2pathname(url_path)

--- a/datalad/customremotes/tests/test_ria_utils.py
+++ b/datalad/customremotes/tests/test_ria_utils.py
@@ -170,12 +170,13 @@ def test_verify_ria_url():
 def test_mapping_identity():
     from datalad.tests.utils_pytest import OBSCURE_FILENAME
 
-    absolute_obsure_path = str(Path('/') / OBSCURE_FILENAME)
+    absolute_obscure_path = str(Path('/').absolute() / OBSCURE_FILENAME)
     temp_dir = tempfile.gettempdir()
-    for name in (temp_dir, join(temp_dir, "x.txt"), absolute_obsure_path):
+    for name in (temp_dir, join(temp_dir, "x.txt"), absolute_obscure_path):
         assert url_path2local_path(local_path2url_path(name)) == name
 
-    for name in map(quote_path, ("/c:/window", "/d", absolute_obsure_path)):
+    prefix = "/C:" if on_windows else ""
+    for name in map(quote_path, (prefix + "/window", prefix + "/d", prefix + "/" + OBSCURE_FILENAME)):
         assert local_path2url_path(url_path2local_path(name)) == name
 
 

--- a/datalad/customremotes/tests/test_ria_utils.py
+++ b/datalad/customremotes/tests/test_ria_utils.py
@@ -1,7 +1,12 @@
+import tempfile
+from os.path import join
+
 from datalad.customremotes.ria_utils import (
     UnknownLayoutVersion,
     create_ds_in_store,
     create_store,
+    local_path2url_path,
+    url_path2local_path,
     verify_ria_url,
 )
 from datalad.distributed.ora_remote import (
@@ -157,3 +162,13 @@ def test_verify_ria_url():
     for i, o in cases.items():
         # we are not testing the URL rewriting here
         assert_equal(o, verify_ria_url(i, {})[:2])
+
+
+def test_mapping_identity():
+
+    temp_dir = tempfile.gettempdir()
+    for name in (temp_dir, join(temp_dir, "x.txt")):
+        assert url_path2local_path(local_path2url_path(name)) == name
+
+    for name in ("/c:/window", "/d"):
+        assert local_path2url_path(url_path2local_path(name)) == name

--- a/datalad/customremotes/tests/test_ria_utils.py
+++ b/datalad/customremotes/tests/test_ria_utils.py
@@ -164,7 +164,7 @@ def test_verify_ria_url():
     }
     for i, o in cases.items():
         # we are not testing the URL rewriting here
-        assert_equal(o, verify_ria_url(i, {})[:2])
+        assert o == verify_ria_url(i, {})[:2]
 
 
 def test_mapping_identity():

--- a/datalad/customremotes/tests/test_ria_utils.py
+++ b/datalad/customremotes/tests/test_ria_utils.py
@@ -7,9 +7,6 @@ from datalad.customremotes.ria_utils import (
     UnknownLayoutVersion,
     create_ds_in_store,
     create_store,
-    local_path2url_path,
-    quote_path,
-    url_path2local_path,
     verify_ria_url,
 )
 from datalad.distributed.ora_remote import (
@@ -165,27 +162,3 @@ def test_verify_ria_url():
     for i, o in cases.items():
         # we are not testing the URL rewriting here
         assert o == verify_ria_url(i, {})[:2]
-
-
-def test_mapping_identity():
-    from datalad.tests.utils_pytest import OBSCURE_FILENAME
-
-    absolute_obscure_path = str(Path('/').absolute() / OBSCURE_FILENAME)
-    temp_dir = tempfile.gettempdir()
-    for name in (temp_dir, join(temp_dir, "x.txt"), absolute_obscure_path):
-        assert url_path2local_path(local_path2url_path(name)) == name
-
-    prefix = "/C:" if on_windows else ""
-    for name in map(quote_path, (prefix + "/window", prefix + "/d", prefix + "/" + OBSCURE_FILENAME)):
-        assert local_path2url_path(url_path2local_path(name)) == name
-
-
-def test_quote_path(monkeypatch):
-    with monkeypatch.context() as ctx:
-        ctx.setattr(ria_utils, 'on_windows', True)
-        assert quote_path("/c:/win:xxx") == "/c:/win%3Axxx"
-        assert quote_path("/C:/win:xxx") == "/C:/win%3Axxx"
-
-        ctx.setattr(ria_utils, 'on_windows', False)
-        assert quote_path("/c:/win:xxx") == "/c%3A/win%3Axxx"
-        assert quote_path("/C:/win:xxx") == "/C%3A/win%3Axxx"

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -21,7 +21,6 @@ from datalad.customremotes.ria_utils import (
     create_store,
     get_layout_locations,
     verify_ria_url,
-    url_path2local_path,
 )
 from datalad.distributed.ora_remote import (
     LocalIO,
@@ -55,6 +54,7 @@ from datalad.support.constraints import (
 )
 from datalad.support.exceptions import CommandError
 from datalad.support.gitrepo import GitRepo
+from datalad.support.network import url_path2local_path
 from datalad.support.param import Parameter
 from datalad.utils import (
     Path,

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -60,7 +60,6 @@ from datalad.utils import (
     quote_cmdlinearg,
 )
 
-
 lgr = logging.getLogger('datalad.distributed.create_sibling_ria')
 
 

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -12,6 +12,7 @@ __docformat__ = 'restructuredtext'
 
 
 import logging
+from pathlib import PurePosixPath as UrlPath
 
 from datalad.cmd import WitlessRunner as Runner
 from datalad.core.distributed.clone import decode_source_spec
@@ -309,7 +310,7 @@ class CreateSiblingRia(Interface):
             )
             return
 
-        local_base_path = Path(url_base_path)
+        local_base_path = Path(url_path2local_path(url_base_path))
 
         if ds.repo.get_hexsha() is None or ds.id is None:
             raise RuntimeError(

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -309,7 +309,7 @@ class CreateSiblingRia(Interface):
             )
             return
 
-        local_base_path = Path(url_path2local_path(url_base_path))
+        local_base_path = Path(url_base_path)
 
         if ds.repo.get_hexsha() is None or ds.id is None:
             raise RuntimeError(

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -20,7 +20,6 @@ from datalad.customremotes import (
     SpecialRemote,
 )
 from datalad.customremotes.main import main as super_main
-from datalad.customremotes.ria_utils import url_path2local_path
 from datalad.support.annex_utils import _sanitize_key
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import (
@@ -28,6 +27,7 @@ from datalad.support.exceptions import (
     AccessFailedError,
     DownloadError
 )
+from datalad.support.network import url_path2local_path
 from datalad.customremotes.ria_utils import (
     get_layout_locations,
     UnknownLayoutVersion,

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1024,11 +1024,11 @@ class RIARemote(SpecialRemote):
                 "No base path configured for RIA store. Specify a proper "
                 "ria+<scheme>://... URL.")
 
-        # the base path is ultimately derived from a URL, always treat as POSIX
+        # the base path is ultimately derived from a URL
         if not Path(self.store_base_path).is_absolute():
             raise RIARemoteError(
                 'Non-absolute object tree base path configuration: %s'
-                '' % str(self.store_base_path))
+                % str(self.store_base_path))
 
         if self.ria_store_pushurl:
             if self.ria_store_pushurl.startswith("ria+http"):

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -813,9 +813,12 @@ def handle_errors(func):
                             "".format(time=datetime.now(),
                                       exc_str=exc_str)
                     # ensure base path is platform path
-                    log_target = Path(self.store_base_path) / 'error_logs' / \
-                        "{dsid}.{uuid}.log".format(dsid=self.archive_id,
-                                                   uuid=self._repo.uuid)
+                    log_target = (
+                        url_path2local_path(self.store_base_path)
+                        / "error_logs"
+                        / "{dsid}.{uuid}.log".format(
+                            dsid=self.archive_id,
+                            uuid=self._repo.uuid))
                     self.io.write_file(log_target, entry, mode='a')
                 except Exception:
                     # If logging of the exception does fail itself, there's
@@ -1061,10 +1064,12 @@ class RIARemote(SpecialRemote):
         """
         if self.ria_store_url:
             # construct path to ria_layout_version file for reporting
-            store_base_path = Path(
-                url_path2local_path(str(self.store_base_path)))
-            target_ri = self.ria_store_url[4:] + path.relative_to(
-                store_base_path).as_posix()
+            local_store_base_path = url_path2local_path(self.store_base_path)
+            target_ri = (
+                self.ria_store_url[4:]
+                + "/"
+                + path.relative_to(local_store_base_path).as_posix()
+            )
         elif self.storage_host:
             target_ri = "ssh://{}{}".format(self.storage_host, path.as_posix())
         else:
@@ -1119,8 +1124,10 @@ class RIARemote(SpecialRemote):
         # but it is subsequently assumed to be a platform path, by
         # get_layout_locations() etc. Hence it must be converted
         # to match the *remote* platform, not the local client
-        store_base_path = Path(url_path2local_path(str(self.store_base_path))) \
-            if self._local_io else self.store_base_path
+        store_base_path = (
+            url_path2local_path(self.store_base_path)
+            if self._local_io
+            else self.store_base_path)
 
         # cache remote layout directories
         self.remote_git_dir, self.remote_archive_dir, self.remote_obj_dir = \
@@ -1289,8 +1296,10 @@ class RIARemote(SpecialRemote):
                 self._last_archive_path = None
                 self._last_keypath = (None, None)
 
-                store_base_path = Path(self.store_base_path) \
-                    if self._local_io else self.store_base_path
+                store_base_path = (
+                    url_path2local_path(self.store_base_path)
+                    if self._local_io
+                    else self.store_base_path)
 
                 self.remote_git_dir, \
                 self.remote_archive_dir, \

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -918,9 +918,8 @@ class RIARemote(SpecialRemote):
         """
 
         # ensure base path is platform path
-        dataset_tree_version_file = Path(
-            url_path2local_path(
-                str(self.store_base_path))) / 'ria-layout-version'
+        dataset_tree_version_file = \
+            url_path2local_path(self.store_base_path) / 'ria-layout-version'
 
         # check dataset tree version
         try:
@@ -1040,6 +1039,7 @@ class RIARemote(SpecialRemote):
             self.storage_host_push, self.store_base_path_push, \
                 self.ria_store_pushurl = verify_ria_url(self.ria_store_pushurl,
                                                         url_cfgs)
+            self.store_base_path_push = PurePosixPath(self.store_base_path_push)
 
         # TODO duplicates call to `git-config` after RIA url rewrite
         self._load_cfg(gitdir, name)
@@ -1082,6 +1082,7 @@ class RIARemote(SpecialRemote):
                 f"{target_ri} not found, "
                 f"self.ria_store_url: {self.ria_store_url}, "
                 f"self.store_base_pass: {self.store_base_path}, "
+                f"self.store_base_pass_push: {self.store_base_path_push}, "
                 f"path: {type(path)} {path}") from exc
         except PermissionError as exc:
             raise PermissionError(f"Permission denied: {target_ri}") from exc

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -31,6 +31,7 @@ from datalad.customremotes.ria_utils import (
     get_layout_locations,
     UnknownLayoutVersion,
     verify_ria_url,
+    url_path2local_path,
 )
 from datalad.utils import (
     ensure_write_permission,
@@ -989,9 +990,9 @@ class RIARemote(SpecialRemote):
                     if k.startswith('url.')}
 
         if self.ria_store_url:
-            self.storage_host, self.store_base_path, self.ria_store_url = \
+            self.storage_host, url_base_path, self.ria_store_url = \
                 verify_ria_url(self.ria_store_url, url_cfgs)
-
+            self.store_base_path = url_path2local_path(url_base_path)
         else:
             # for now still accept the configs, if no ria-URL is known, but
             # issue deprecation warning:
@@ -1024,8 +1025,7 @@ class RIARemote(SpecialRemote):
                 "ria+<scheme>://... URL.")
 
         # the base path is ultimately derived from a URL, always treat as POSIX
-        self.store_base_path = PurePosixPath(self.store_base_path)
-        if not self.store_base_path.is_absolute():
+        if not Path(self.store_base_path).is_absolute():
             raise RIARemoteError(
                 'Non-absolute object tree base path configuration: %s'
                 '' % str(self.store_base_path))
@@ -1035,10 +1035,10 @@ class RIARemote(SpecialRemote):
                 raise RIARemoteError("Invalid push-url: {}. Pushing over HTTP "
                                      "not implemented."
                                      "".format(self.ria_store_pushurl))
-            self.storage_host_push, self.store_base_path_push, \
+            self.storage_host_push, url_store_base_path_push, \
                 self.ria_store_pushurl = verify_ria_url(self.ria_store_pushurl,
                                                         url_cfgs)
-
+            self.store_base_path_push = url_path2local_path(url_store_base_path_push)
         # TODO duplicates call to `git-config` after RIA url rewrite
         self._load_cfg(gitdir, name)
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -17,7 +17,6 @@ import email.utils
 import os
 import pickle
 import re
-import sys
 import time
 from collections import OrderedDict
 from hashlib import md5
@@ -50,6 +49,7 @@ from datalad import (
     cfg,
     consts,
 )
+from datalad.customremotes.ria_utils import local_path2url_path
 from datalad.support.cache import lru_cache
 from datalad.support.exceptions import CapturedException
 from datalad.utils import (
@@ -83,7 +83,8 @@ def local_url_path_representation(url_path: str) -> str:
     Unix-like operating systems and "C:\\Windows" on Windows-like operating
     systems.
     """
-    return url2pathname(url_path)
+    from urllib.parse import quote
+    return url2pathname(quote(url_path))
 
 
 def local_path_from_url(url: str) -> str:
@@ -979,8 +980,11 @@ def get_local_file_url(fname, compatibility='git-annex'):
     compatibility : str, optional
         This parameter exists for compatibility reasons only, it has no effect.
     """
-    from datalad.customremotes.ria_utils import local_path2url_path
-    return f'file://{local_path2url_path(fname)}'
+    path = str(Path(fname).resolve().absolute())
+    r1 = local_path2url_path(path)
+    print(f"fname: {repr(path)}")
+    print(f"local_path2url_path(fname): {repr(r1)}")
+    return f'file://{local_path2url_path(path)}'
 
 
 def get_url_cache_filename(url, name=None):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -973,7 +973,7 @@ def is_ssh(ri):
 def get_local_file_url(fname: str,
                        compatibility: str = 'git-annex',
                        include_netloc: bool = True,
-                       allow_relative_path: bool = False
+                       allow_relative_path: bool = True
                        ) -> str:
     """Return OS specific URL pointing to a local file
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -620,6 +620,13 @@ class URL(RI):
         'fragment',
     )
 
+    # Only interpreted on Windows. If set to `True`, UNC-names encoded in
+    # file-URLs, e.g. "file://server/share/path", would be considered local
+    # and mapped onto "\\server\share\path". If set to `False`, UNC-names
+    # encoded in file-URLs would not be considered local and cannot be resolved
+    # to a local path.
+    support_unc = False
+
     def as_str(self):
         """Render URL as a string"""
         return urlunparse(self.to_pr())
@@ -765,7 +772,7 @@ class URL(RI):
                 or hostname.startswith('127.')
                 or re.match('^[a-zA-Z]:$', self.netloc)):
             if on_windows:
-                return self._windows_local_path(support_unc=True)
+                return self._windows_local_path(support_unc=self.support_unc)
             raise ValueError("file:// URL does not point to 'localhost'")
 
         if on_windows:

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -419,7 +419,7 @@ class RI(object):
     provided as output, e.g.
 
     >>> RI('http://example.com')
-    URL(hostname='example.com', scheme='http')
+    URL(hostname='example.com', netloc='example.com', scheme='http')
     >>> RI('example.com:path')
     SSHRI(hostname='example.com', path='path')
     """

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -84,7 +84,6 @@ def local_url_path_representation(url_path: str) -> str:
     Unix-like operating systems and "C:\\Windows" on Windows-like operating
     systems.
     """
-    from urllib.parse import quote
     return url2pathname(quote(url_path))
 
 
@@ -421,6 +420,8 @@ class RI(object):
 
     >>> RI('http://example.com')
     URL(hostname='example.com', netloc='example.com', scheme='http')
+    >>> RI('file://C:/Windows')
+    URL(hostname='c', netloc='C:', path='/Windows', scheme='file')
     >>> RI('example.com:path')
     SSHRI(hostname='example.com', path='path')
     """

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -1044,7 +1044,11 @@ def get_local_file_url(fname: str,
         return "file:/" + url_path
 
     result = "file://" + url_path
-    assert result == Path(fname).as_uri()
+    if result != Path(fname).as_uri():
+        lgr.warning(
+            f"get_local_file_url({fname}, {compatibility}, "
+            f"{allow_relative_path}) returned {result} instead of "
+            f"{Path(fname).as_uri()}")
     return result
 
 

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -1185,7 +1185,29 @@ def url_path2local_path(url_path: str | PurePosixPath) -> str | Path:
 
 
 def quote_path(path: str, safe: str = "/") -> str:
-    """quote the path component of a URL, takes OS specifics into account"""
+    """quote the path component of a URL, takes OS specifics into account
+
+    On Windows-like system a path-prefix consisting of a slash, a single letter,
+    a colon, and a slash, i.e. '/c:/Windows', the colon will not be quoted.
+    All characters after the colon will be quoted by `urllib.parse.quote`.
+
+    On Unix-like systems the complete path component will be quoted by
+    'urllib.parse.quote'.
+
+    Parameters
+    ----------
+    path: str
+      The path that should be quoted
+
+    safe: str (default '/')
+       Characters that should not be quoted, passed
+       on to the save-parameter of `urllib.parse.quote`.
+
+    Returns
+    -------
+    str
+       The quoted path component
+    """
     if on_windows:
         if re.match("^/[a-zA-Z]:/", path):
             return path[:3] + quote(path[3:], safe=safe)

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -976,31 +976,11 @@ def get_local_file_url(fname, compatibility='git-annex'):
     ----------
     fname : string
         Filename.  If not absolute, abspath is used
-    compatibility : {'git', 'git-annex'}, optional
-        On Windows, and only on that platform, file:// URLs may need to look
-        different depending on the use case or consuming application. This
-        switch selects different compatibility modes: 'git' for use with
-        Git commands (e.g. `clone` or `submodule add`); 'git-annex` for
-        Git-annex command input (e.g. `addurl`). On any other platform this
-        setting has no effect.
+    compatibility : str, optional
+        This parameter exists for compatibility reasons only, it has no effect.
     """
-    # we resolve the path to circumwent potential short paths on unfortunate
-    # platforms that would ruin the URL format.
-    #path = Path(fname).resolve().absolute()
-    path = Path(fname).resolve()
-    if on_windows:
-        # in addition we need to absolute(), as on windows resolve() doesn't
-        # imply that
-        path = path.absolute().as_posix()
-        furl = 'file://{}{}'.format(
-            '/' if compatibility == 'git' else '',
-            urlquote(
-                re.sub(r'([a-zA-Z]):', r'\1', path)
-            ))
-    else:
-        # TODO:  need to fix for all the encoding etc
-        furl = str(URL(scheme='file', path=str(path)))
-    return furl
+    from datalad.customremotes.ria_utils import local_path2url_path
+    return f'file://{local_path2url_path(fname)}'
 
 
 def get_url_cache_filename(url, name=None):

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -1029,7 +1029,7 @@ def get_local_file_url(fname: str,
     """
     path_obj = Path(fname)
     if not path_obj.is_absolute():
-        if allow_relative_path is True:
+        if allow_relative_path:
             fname = str(Path(os.getcwd()) / path_obj)
         else:
             raise ValueError('cannot create file-URL with relative path')

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -749,6 +749,7 @@ class URL(RI):
                 return self.netloc + local_path
             if support_unc:
                 return '\\\\' + self.netloc + local_path
+            raise ValueError("Unsupported file: URL: {self}")
         return local_path
 
     @property
@@ -763,6 +764,8 @@ class URL(RI):
         if not (hostname in (None, '', 'localhost', '::1')
                 or hostname.startswith('127.')
                 or re.match('^[a-zA-Z]:$', self.netloc)):
+            if on_windows:
+                return self._windows_local_path(support_unc=True)
             raise ValueError("file:// URL does not point to 'localhost'")
 
         if on_windows:

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -81,7 +81,7 @@ def test_GitRepo_invalid_path(path=None):
     with chpwd(path):
         assert_raises(ValueError, GitRepo, path="git://some/url", create=True)
         ok_(not op.exists(op.join(path, "git:")))
-        assert_raises(ValueError, GitRepo, path="file://some/relative/path", create=True)
+        assert_raises(ValueError, GitRepo, path="file://some_location/path/at/location", create=True)
         ok_(not op.exists(op.join(path, "file:")))
 
 

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -589,8 +589,13 @@ def test_mapping_identity():
 
     absolute_obscure_path = str(Path('/').absolute() / OBSCURE_FILENAME)
     temp_dir = tempfile.gettempdir()
+    print(f"temp_dir: {temp_dir}")
     for name in (temp_dir, opj(temp_dir, "x.txt"), absolute_obscure_path):
-        assert url_path2local_path(local_path2url_path(name)) == name
+        # On some platforms, e.g. MacOS, `temp_dir` might contain trailing
+        # slashes. Since the conversion and its inverse normalize paths, we
+        # compare the result to the normalized path
+        normalized_name = str(Path(name))
+        assert url_path2local_path(local_path2url_path(name)) == normalized_name
 
     prefix = "/C:" if on_windows else ""
     for name in map(quote_path, (prefix + "/window", prefix + "/d", prefix + "/" + OBSCURE_FILENAME)):

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -492,13 +492,10 @@ def test_get_local_file_url():
         # Yarik found no better way to trigger.  .decode() isn't enough
         print("D: %s" % path)
         if isabs(path):
-            eq_(get_local_file_url(path), url)
+            assert get_local_file_url(path) == url
         else:
-            eq_(get_local_file_url(path),
-                '/'.join((
-                    get_local_file_url(os.getcwd()),
-                    url))
-            )
+            assert get_local_file_url(path) == '/'.join(
+                (get_local_file_url(os.getcwd()), url))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_network.py
+++ b/datalad/support/tests/test_network.py
@@ -508,7 +508,7 @@ def test_get_local_file_url():
                 # relpaths are special-cased below
                 ('test.txt', 'test.txt', compat_annex),
                 (OBSCURE_FILENAME, urlquote(OBSCURE_FILENAME), compat_annex),
-            ) + (
+            ) + ((
                 ('C:\\Windows\\notepad.exe', 'file://C:/Windows/notepad.exe', compat_annex),
                 ('C:\\Windows\\notepad.exe', 'file:///C:/Windows/notepad.exe', compat_git),
             ) if on_windows else (
@@ -518,14 +518,19 @@ def test_get_local_file_url():
                 # there are no files with trailing slashes in the name
                 #('/a b/', 'file:///a%20b/'),
                 ('/a b/name', 'file:///a%20b/name', compat_annex),
-            ):
+            )):
         # Yarik found no better way to trigger.  .decode() isn't enough
         print("D: %s" % path)
         if isabs(path):
             assert get_local_file_url(path, compatibility=compatibility) == url
+            abs_path = path
         else:
             assert get_local_file_url(path, allow_relative_path=True, compatibility=compatibility) \
                    == '/'.join((get_local_file_url(os.getcwd(), compatibility=compatibility), url))
+            abs_path = opj(os.getcwd(), path)
+        if compatibility == compat_git:
+            assert get_local_file_url(abs_path, compatibility=compatibility) == Path(abs_path).as_uri()
+
 
 @with_tempfile(mkdir=True)
 def test_get_local_file_url_compatibility(path=None):
@@ -606,7 +611,7 @@ def test_auto_resolve_path():
     relative_path = str(Path("a/b"))
     with pytest.raises(ValueError):
         local_path2url_path(relative_path)
-    local_path2url_path("", auto_resolve=True)
+    local_path2url_path("", allow_relative_path=True)
 
 
 @skip_if(not on_windows)

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ requires.update({
         'pypandoc',
         # Documentation
         'sphinx>=4.3.0',
-        'sphinx-rtd-theme>=0.5.1"',
+        'sphinx-rtd-theme>=0.5.1',
     ],
     'devel-utils': [
         'asv',        # benchmarks


### PR DESCRIPTION
Fixes #7212 

This PR introduces functions to convert the path component of a file-URL to local file system paths, independent from the OS.

We should probably perform a proper check of the code base to find the places in which we handle file-URL path components naively, i.e. take them verbatim as local paths. Even with automated conversion of `/` in path components to `\` on Windows-like OS, e.g. when using `Path()`, a simple approach would fail because it does not take Windows-anchor encoding into account. For example the local Windows path `C:\\Windows` might be encoded as `/c:/Windows` in the path component of a file-URL.