### PR TITLE
Don't be scary when failing to annex-enable

### DIFF
--- a/changelog.d/pr-7217.md
+++ b/changelog.d/pr-7217.md
@@ -1,0 +1,6 @@
+### 🚀 Enhancements and New Features
+
+- The `siblings` command does not concern the user with messages about 
+  inconsequential failure to annex-enable a remote anymore. 
+  [PR #7217](https://github.com/datalad/datalad/pull/7217)
+  (by [@bpoldrack](https://github.com/bpoldrack))


### PR DESCRIPTION
`datalad-siblings` would unconditionally issue an INFO level or even WARNING level log, whenever `git annex enableremote` returned non-zero. Those messages would also say, that this may be expected with a pure git remote or an empty repository on the remote end.

The main issue here is, that datalad users may not even have any expectation and are left with a message that suggests they should. This is confusing. At best we are training users to ignore our output.

Another aspect to this is, that when used as an internal command (most notably from within `create-sibling-*`), _we_ are the ones calling and having an expectation. The user didn't even call `siblings configure` let alone `git annex enableremote`. At the same time, with `create-sibling-*` we know that there is an empty repo at the remote end - we just created it. The only reason to "probe" via `enableremote` is to figure whether the remote end *in principle* is usable with annex. In that case, `enableremote` will still fail, but it will leave the `annex-ignore` setting untouched.

Hence, inform the user only, if the failure was consequential in that `annex-ignore=true` was actually set.
Note, that `CapturedException` logs the original error anyway (level 8 by default).

This annoyance surfaced once more in the context of PR #7213