### PR TITLE
Fix setup.py for type-check action

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ requires.update({
         'pypandoc',
         # Documentation
         'sphinx>=4.3.0',
-        'sphinx-rtd-theme>=0.5.1"',
+        'sphinx-rtd-theme>=0.5.1',
     ],
     'devel-utils': [
         'asv',        # benchmarks


### PR DESCRIPTION
Superfluous quotes made type-check action fail.

No changelog intended.
