### PR TITLE
Bf fix installation link git annex

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -126,6 +126,10 @@
             "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
             "name": "Szczepanik, Michał",
             "orcid": "0000-0002-4028-2087"
+        },
+        {
+            "affiliation": "Dartmouth College, Hanover, NH, United States",
+            "name": "Macdonald, Austin"
         }
     ],
     "grants": [

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -476,7 +476,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     def _check_git_annex_version(cls):
         ver = external_versions['cmd:annex']
         # in case it is missing
-        msg = "Visit http://handbook.datalad.org/r.html?install " \
+        msg = "Visit http://handbook.datalad.org/en/latest/intro/installation.html" \
               "for instructions on how to install DataLad and git-annex."
 
         exc_kwargs = dict(


### PR DESCRIPTION
I didn't have git annex installed. The error was helpful, but the link has changed:

```
datalad.support.exceptions.MissingExternalDependency: No working git-annex installation of version >= 8.20200309. Visit http://handbook.datalad.org/r.html?install for instructions on how to install DataLad and git-annex
```
### PR checklist

- [X] Provide an overview of the changes you're making and explain why you're proposing them.
- [ ] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title; (**asmacdo) IMO no changelog necessary for this?**
- [X] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.