### PR TITLE
Revert "Bf fix installation link git annex"

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -126,10 +126,6 @@
             "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
             "name": "Szczepanik, Michał",
             "orcid": "0000-0002-4028-2087"
-        },
-        {
-            "affiliation": "Dartmouth College, Hanover, NH, United States",
-            "name": "Macdonald, Austin"
         }
     ],
     "grants": [

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -476,7 +476,7 @@ class AnnexRepo(GitRepo, RepoInterface):
     def _check_git_annex_version(cls):
         ver = external_versions['cmd:annex']
         # in case it is missing
-        msg = "Visit http://handbook.datalad.org/en/latest/intro/installation.html" \
+        msg = "Visit http://handbook.datalad.org/r.html?install " \
               "for instructions on how to install DataLad and git-annex."
 
         exc_kwargs = dict(


### PR DESCRIPTION
Reverts datalad/datalad#7223


This was merged prematurely (by me). Actual issue is with handbook/readthedocs. See https://github.com/datalad-handbook/book/pull/880.

