### PR TITLE
Allow for brackets in PY&CMD doc markups

### DIFF
--- a/changelog.d/pr-7226.md
+++ b/changelog.d/pr-7226.md
@@ -1,0 +1,6 @@
+### 🐛 Bug Fixes
+
+- Interface-specific (python vs CLI) doc generation for commands and their parameters was broken when brackets were used within the interface markups. 
+  Fixes [#7225](https://github.com/datalad/datalad/issues/7225) via
+  [PR #7226](https://github.com/datalad/datalad/pull/7226)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/cli/interface.py
+++ b/datalad/cli/interface.py
@@ -60,15 +60,15 @@ def alter_interface_docs_for_cmdline(docs):
         flags=re.MULTILINE | re.DOTALL)
     # clean cmdline in-line bits
     docs = re.sub(
-        r'\[PY:\s[^\[\]]*\sPY\]',
+        r'\[PY:\s.*?\sPY\]',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        r'\[CMD:\s([^\[\]]*)\sCMD\]',
+        r'\[CMD:\s(.*?)\sCMD\]',
         lambda match: match.group(1),
         docs,
-        flags=re.MULTILINE)
+        flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
         r'\|\| CMDLINE \>\>(.*?)\<\< CMDLINE \|\|',
         lambda match: match.group(1),

--- a/datalad/cli/tests/test_interface.py
+++ b/datalad/cli/tests/test_interface.py
@@ -28,6 +28,12 @@ def test_alter_interface_docs_for_cmdline():
     assert_in('a b', alt)
     assert_in('not\n   reflowed', alt)
     assert_in("Something for the cmdline only Multiline!", alt)
+    assert_not_in("Some Python-only bits", alt)
+    assert_not_in("just for Python", alt)
+    assert_in("just for the command line", alt)
+    assert_in("multiline cli-only with [ brackets\n[] ]", alt)
+    assert_not_in("multiline\npython-only with [ brackets [] ]", alt)
+
     # args
     altarg = alter_interface_docs_for_cmdline(demo_argdoc)
     # RST role markup
@@ -42,10 +48,15 @@ def test_alter_interface_docs_for_cmdline():
         'one bla bla two bla')
 
     altpd = alter_interface_docs_for_cmdline(demo_paramdoc)
+    assert_not_in("PY", altpd)
+    assert_not_in("CMD", altpd)
     assert_not_in('python', altpd)
+    assert_not_in("python-only with [ some brackets []", altpd)
     assert_in('in between', altpd)
     assert_in('appended', altpd)
     assert_in('cmdline', altpd)
+    assert_in("multiline cli-only [\n  brackets included "
+              "[ can we also have || ?]", altpd)
 
 
 def test_name_generation():

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -184,15 +184,15 @@ def alter_interface_docs_for_api(docs):
         flags=re.MULTILINE | re.DOTALL)
     # clean cmdline in-line bits
     docs = re.sub(
-        r'\[CMD:\s[^\[\]]*\sCMD\]',
+        r'\[CMD:\s.*?\sCMD\]',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        r'\[PY:\s([^\[\]]*)\sPY\]',
+        r'\[PY:\s(.*?)\sPY\]',
         lambda match: match.group(1),
         docs,
-        flags=re.MULTILINE)
+        flags=re.MULTILINE | re.DOTALL)
     # select only the python alternative from argument specifications
     docs = re.sub(
         r'``([a-zA-Z0-9_,.]+)\|\|([a-zA-Z0-9-,.]+)``',

--- a/datalad/interface/tests/test_docs.py
+++ b/datalad/interface/tests/test_docs.py
@@ -57,7 +57,9 @@ demo_doc = """\
     << PYTHON ||
 
     And an example for in-line markup: [PY: just for Python PY] and
-    the other one [CMD: just for the command line CMD]. End of demo.
+    the other one [CMD: just for the command line CMD]. [PY: multiline
+    python-only with [ brackets [] ] PY][CMD: multiline cli-only with [ brackets
+    [] ] CMD]. End of demo.
 
     Generic appendix. Ding dong ding dong ding dong.  Ding dong ding dong ding
     dong.  Ding dong ding dong ding dong.  Ding dong ding dong ding dong.  Ding
@@ -70,7 +72,10 @@ demo_paramdoc = """\
     Parameters
     ----------
     dataset : Dataset or None, optional
-      something [PY: python only PY] in between [CMD: cmdline only CMD] appended [PY: more python PY]
+      something [PY: python only PY] in between [CMD: cmdline only CMD] appended
+      Brackets can also be within and we can deal with [PY: multiline
+      python-only with [ some brackets [] PY] [CMD: multiline cli-only [
+      brackets included [ can we also have || ?] CMD].
       dataset is given, an attempt is made to identify the dataset based
       Dataset (e.g. a path), or value must be `None`. [Default: None]
 """
@@ -102,9 +107,19 @@ def test_alter_interface_docs_for_api():
     assert_in('a b', alt)
     assert_in('not\n   reflowed', alt)
     assert_in("Some Python-only bits Multiline!", alt)
+    assert_in("Some Python-only bits", alt)
+    assert_in("just for Python", alt)
+    assert_not_in("just for the command line", alt)
+    assert_not_in("multiline cli-only with [ brackets\n[] ]", alt)
+    assert_in("multiline\npython-only with [ brackets [] ]", alt)
 
     altpd = alter_interface_docs_for_api(demo_paramdoc)
+    assert_not_in("PY", altpd)
+    assert_not_in("CMD", altpd)
     assert_in('python', altpd)
     assert_in('in between', altpd)
     assert_in('appended', altpd)
+    assert_in("multiline\n  python-only with [ some brackets []", altpd)
     assert_not_in('cmdline', altpd)
+    assert_not_in("multiline cli-only [\n  brackets included "
+                  "[ can we also have || ?]", altpd)


### PR DESCRIPTION
Fixes #7225

Interface specific substitutions did not work with nested brackets (and for some reason also not crossing newlines).

Looks like those regexes were simply meant to not be greedy.

