### PR TITLE
Use --include=* or --anything instead of --copies 0 to speed up get_content_annexinfo

### DIFF
--- a/changelog.d/pr-7230.md
+++ b/changelog.d/pr-7230.md
@@ -1,0 +1,3 @@
+### 🏎 Performance
+
+- Use --include=* or --anything instead of --copies 0 to speed up get_content_annexinfo.  [PR #7230](https://github.com/datalad/datalad/pull/7230) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3366,8 +3366,10 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         # use this funny-looking option with both find and findref
         # it takes care of git-annex reporting on any known key, regardless
-        # of whether or not it actually (did) exist in the local annex
-        cmd = ['--copies', '0']
+        # of whether or not it actually (did) exist in the local annex.
+        # --include=* was recommended by Joey in
+        # https://git-annex.branchable.com/todo/add_--all___40__or_alike__41___to_find_and_findref/
+        cmd = ['--include=*']
         files = None
         if ref:
             cmd = ['findref'] + cmd

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -551,6 +551,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         kludges["fromkey-supports-unlocked"] = ver > "8.20210428"
         # applies to get, drop, move, copy, whereis
         kludges["grp1-supports-batch-keys"] = ver >= "8.20210903"
+        # applies to find, findref to list all known.
+        # was added in 10.20221212-17-g0b2dd374d on 20221220.
+        kludges["find-supports-anything"] = ver >= "10.20221212+git18"
         cls._version_kludges = kludges
         return kludges[key]
 
@@ -3367,9 +3370,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         # use this funny-looking option with both find and findref
         # it takes care of git-annex reporting on any known key, regardless
         # of whether or not it actually (did) exist in the local annex.
-        # --include=* was recommended by Joey in
-        # https://git-annex.branchable.com/todo/add_--all___40__or_alike__41___to_find_and_findref/
-        cmd = ['--include=*']
+        if self._check_version_kludges("find-supports-anything"):
+            cmd = ['--anything']
+        else:
+            # --include=* was recommended by Joey in
+            # https://git-annex.branchable.com/todo/add_--all___40__or_alike__41___to_find_and_findref/
+            cmd = ['--include=*']
         files = None
         if ref:
             cmd = ['findref'] + cmd


### PR DESCRIPTION
Apparently `--copies 0` could result in up to 10 (or more) penalty of running find or findref.  

TODO
- [x] Future proof it -- use `--anything` which was added in 10.20221212-17-g0b2dd374d on Dec 20 (so we can compare against `10.20221220` version) -- but yet to wait for datalad/git-annex get that build