### PR TITLE
BF: install git-annex from datalad/packages for Mac on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,7 +100,7 @@ environment:
       # does not give a functional installation
       # INSTALL_GITANNEX: git-annex -m snapshot
       #INSTALL_GITANNEX: git-annex=8.20201129
-      INSTALL_GITANNEX: git-annex
+      INSTALL_GITANNEX: git-annex -m datalad/packages
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
 
@@ -156,7 +156,7 @@ environment:
           datalad.ui
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.8
-      INSTALL_GITANNEX: git-annex
+      INSTALL_GITANNEX: git-annex -m datalad/packages
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
     - ID: MacP38a2
@@ -166,7 +166,7 @@ environment:
           datalad.distributed
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.8
-      INSTALL_GITANNEX: git-annex
+      INSTALL_GITANNEX: git-annex -m datalad/packages
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
 


### PR DESCRIPTION
The default "brew" way seems to error out as could be seen on eg. https://ci.appveyor.com/project/mih/datalad/builds/45696242/job/h7a2890c5yyt5ekw

	==> Installing git-annex dependency: ghc
	Warning: Your Xcode (12.3) is outdated.
	Please update to Xcode 12.4 (or delete it).
	Xcode can be updated from the App Store.
	==> ./configure --prefix=/private/tmp/ghc-20221215-3593-1fb8317/ghc-9.4.3/binary
	==> make install
	==> cabal v2-update
	==> ./configure --prefix=/usr/local/Cellar/ghc/9.4.3 --disable-numa --with-intree-gmp
	==> hadrian/build install -j2 --prefix=/usr/local/Cellar/ghc/9.4.3 --flavour=release --docs=no-sphinx-pdfs *.iserv.ghc.link.opts += -optl-Wl,-rpath,@loader_path/../lib/x86_64-osx-ghc-9.4.3

So -- to overcome that, decided to why not use datalad/packages -- we have it automated now to get them updated with new git-annex releases. Never tried on Mac though -- let's see.
