### PR TITLE
RF ORA

### DIFF
--- a/changelog.d/pr-7235.md
+++ b/changelog.d/pr-7235.md
@@ -1,0 +1,16 @@
+### 💥 Breaking Changes
+
+- Automatic reconfiguration of the ORA special remote when cloning from RIA 
+  stores now only applies locally rather than being committed.
+  [PR #7235](https://github.com/datalad/datalad/pull/7235)
+  (by [@bpoldrack](https://github.com/bpoldrack))
+
+### 🚀 Enhancements and New Features
+
+- ORA special remote now allows to override its configuration locally.
+  [PR #7235](https://github.com/datalad/datalad/pull/7235)
+  (by [@bpoldrack](https://github.com/bpoldrack))
+- Added a 'ria' special remote to provide backwards compatibility with datasets
+  that were set up with the deprecated [ria-remote](https://github.com/datalad/git-annex-ria-remote).
+  [PR #7235](https://github.com/datalad/datalad/pull/7235)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/core/distributed/clone_utils.py
+++ b/datalad/core/distributed/clone_utils.py
@@ -212,9 +212,11 @@ def postclonecfg_ria(ds, props, remote="origin"):
                 # we only need the store:
                 new_url = props['source'].split('#')[0]
                 try:
-                    repo.enable_remote(srs[org_uuid]['name'],
-                                       options=['url={}'.format(new_url)]
-                                       )
+                    # local config to overwrite committed URL
+                    repo.config.set(
+                        f"remote.{srs[org_uuid]['name']}.ora-url",
+                        new_url, scope='local')
+                    repo.enable_remote(srs[org_uuid]['name'])
                     lgr.info("Reconfigured %s for %s",
                              srs[org_uuid]['name'], new_url)
                     # update ora_remotes for considering publication dependency
@@ -227,6 +229,8 @@ def postclonecfg_ria(ds, props, remote="origin"):
                 except CommandError as e:
                     ce = CapturedException(e)
                     lgr.debug("Failed to reconfigure ORA special remote: %s", ce)
+                    repo.config.unset(f"remote.{srs[org_uuid]['name']}.ora-url",
+                                      scope='local')
             else:
                 lgr.debug("Unknown ORA special remote uuid at '%s': %s",
                           remote, org_uuid)

--- a/datalad/customremotes/ria_remote.py
+++ b/datalad/customremotes/ria_remote.py
@@ -1,0 +1,47 @@
+from datalad.customremotes.main import main as super_main
+from datalad.distributed.ora_remote import ORARemote
+from datalad.support.annexrepo import AnnexRepo
+
+
+class DeprecatedRIARemote(ORARemote):
+    """This is a shim for backwards compatibility with the old and archived
+    git-annex-ria-remote, which the current ORA remote is based on. Providing
+    this remote allows datasets that are configured with the old name (and the
+    respective config names) to still work.
+    However, this is intended to be somewhat temporary and be replaced by
+    another implementation that actually migrates from ria to ora once we
+    settled for an approach.
+    """
+
+    def __init__(self, annex):
+        super().__init__(annex)
+
+    def initremote(self):
+        self.message("special remote type 'ria' is deprecated. Consider "
+                     "migrating to 'ora'.", type='info')
+        super().initremote(self)
+
+    def _load_local_cfg(self):
+        """Overwrite _load_local_cfg in order to initialize attributes with
+        deprecated 'ria' configs if they exist and then go on to let 'super' do
+        it's thing"""
+        self._repo = AnnexRepo(self.gitdir)
+        self.storage_host = \
+            self._repo.config.get(f"annex.ria-remote.{self.name}.ssh-host")
+        self.store_base_path = \
+            self._repo.config.get(f"annex.ria-remote.{self.name}.base-path")
+        self.force_write = \
+            self._repo.config.get(f"annex.ria-remote.{self.name}.force-write")
+        self.ignore_remote_config = \
+            self._repo.config.get(f"annex.ria-remote.{self.name}.ignore-remote-config")
+        super()._load_local_cfg()
+
+
+def main():
+    """cmdline entry point"""
+    super_main(
+        cls=DeprecatedRIARemote,
+        remote_name='ria',
+        description=\
+        "transport file content to and from datasets hosted in RIA stores",
+    )

--- a/datalad/customremotes/ria_utils.py
+++ b/datalad/customremotes/ria_utils.py
@@ -118,7 +118,7 @@ def verify_ria_url(url, cfg):
         port=url_ri.port or '',
     )
     # this != file is critical behavior, if removed, it will ruin the IO selection
-    # in RIARemote!!
+    # in ORARemote!!
     return host if protocol != 'file' else None, \
         url_ri.path if url_ri.path else '/', \
         url

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -707,7 +707,7 @@ class HTTPRemoteIO(object):
     # We want ORA over HTTP, but with a server side CGI to talk to in order to
     # reduce the number of requests. Implementing this as such an IO class would
     # mean to have separate requests for all server side executions, which is
-    # what we do not want. As a consequence RIARemote class implementation needs
+    # what we do not want. As a consequence ORARemote class implementation needs
     # to treat HTTP as a special case until refactoring to a design that fits
     # both approaches.
 
@@ -860,7 +860,7 @@ class NoLayoutVersion(Exception):
     pass
 
 
-class RIARemote(SpecialRemote):
+class ORARemote(SpecialRemote):
     """This is the class of RIA remotes.
     """
 
@@ -872,7 +872,7 @@ class RIARemote(SpecialRemote):
 
     @handle_errors
     def __init__(self, annex):
-        super(RIARemote, self).__init__(annex)
+        super(ORARemote, self).__init__(annex)
         if hasattr(self, 'configs'):
             # introduced in annexremote 1.4.2 to support LISTCONFIGS
             self.configs['url'] = "RIA store to use"
@@ -1601,7 +1601,7 @@ class RIARemote(SpecialRemote):
 
     def _get_obj_location(self, key):
         # Notes: - Changes to this method may require an update of
-        #          RIARemote._layout_version
+        #          ORARemote._layout_version
         #        - archive_path is always the same ATM. However, it might depend
         #          on `key` in the future. Therefore build the actual filename
         #          for the archive herein as opposed to `get_layout_locations`.
@@ -1631,7 +1631,7 @@ class RIARemote(SpecialRemote):
 def main():
     """cmdline entry point"""
     super_main(
-        cls=RIARemote,
+        cls=ORARemote,
         remote_name='ora',
         description=\
         "transport file content to and from datasets hosted in RIA stores",

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -15,7 +15,9 @@ import logging
 from functools import wraps
 
 from datalad import ssh_manager
+from datalad.config import anything2bool
 from datalad.customremotes import (
+    ProtocolError,
     RemoteError,
     SpecialRemote,
 )
@@ -25,6 +27,7 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import (
     AccessDeniedError,
     AccessFailedError,
+    CapturedException,
     DownloadError
 )
 from datalad.customremotes.ria_utils import (
@@ -875,10 +878,17 @@ class RIARemote(SpecialRemote):
             self.configs['url'] = "RIA store to use"
             self.configs['push-url'] = "URL for pushing to the RIA store. " \
                                        "Optional."
-            self.configs['archive-id'] = "Dataset ID. Should be set " \
-                                         "automatically by datalad"
+            self.configs['archive-id'] = "Dataset ID (fallback: annex uuid. " \
+                                         "Should be set automatically by " \
+                                         "datalad"
         # the local repo
         self._repo = None
+        self.gitdir = None
+        self.name = None  # name of the special remote
+        self.gitcfg_name = None  # name in respective git remote
+
+        self.ria_store_url = None
+        self.ria_store_pushurl = None
         # machine to SSH-log-in to access/store the data
         # subclass must set this
         self.storage_host = None
@@ -906,6 +916,9 @@ class RIARemote(SpecialRemote):
         # cache obj_locations:
         self._last_archive_path = None
         self._last_keypath = (None, None)
+
+        # SSH "streaming" buffer
+        self.buffer_size = DEFAULT_BUFFER_SIZE
 
     def verify_store(self):
         """Check whether the store exists and reports a layout version we
@@ -954,6 +967,153 @@ class RIARemote(SpecialRemote):
             raise UnknownLayoutVersion(f"RIA dataset layout version unknown: "
                                        f"{self.remote_object_tree_version}")
 
+    def _load_local_cfg(self):
+
+        # this will work, even when this is not a bare repo
+        # but it is not capable of reading out dataset/branch config
+        self._repo = AnnexRepo(self.gitdir)
+
+        cfg_map = {"ora-force-write": "force_write",
+                   "ora-ignore-ria-config": "ignore_remote_config",
+                   "ora-buffer-size": "buffer_size",
+                   "ora-url": "ria_store_url",
+                   "ora-push-url": "ria_store_pushurl"
+                   }
+
+        if self.gitcfg_name:
+            for cfg, att in cfg_map.items():
+                value = self._repo.config.get(f"remote.{self.gitcfg_name}.{cfg}")
+                if value is not None:
+                    self.__setattr__(cfg_map[cfg], value)
+                    if cfg == "ora-url":
+                        self.ria_store_url_source = 'local'
+                    elif cfg == "ora-push-url":
+                        self.ria_store_pushurl_source = 'local'
+            if self.buffer_size:
+                try:
+                    self.buffer_size = int(self.buffer_size)
+                except ValueError:
+                    self.message(f"Invalid value of config "
+                                 f"'remote.{self.gitcfg_name}."
+                                 f"ora-buffer-size': {self.buffer_size}")
+                    self.buffer_size = DEFAULT_BUFFER_SIZE
+
+        if self.name:
+            # Consider deprecated configs if there's no value yet
+            if self.force_write is None:
+                self.force_write = self._repo.config.get(
+                    f'annex.ora-remote.{self.name}.force-write')
+                if self.force_write:
+                    self.message("WARNING: config "
+                                 "'annex.ora-remote.{}.force-write' is "
+                                 "deprecated. Use 'remote.{}.ora-force-write' "
+                                 "instead.".format(self.name, self.gitcfg_name))
+                    try:
+                        self.force_write = anything2bool(self.force_write)
+                    except TypeError:
+                        raise RIARemoteError("Invalid value of config "
+                                             "'annex.ora-remote.{}.force-write'"
+                                             ": {}".format(self.name,
+                                                           self.force_write))
+
+            if self.ignore_remote_config is None:
+                self.ignore_remote_config = self._repo.config.get(
+                    f"annex.ora-remote.{self.name}.ignore-remote-config")
+                if self.ignore_remote_config:
+                    self.message("WARNING: config "
+                                 "'annex.ora-remote.{}.ignore-remote-config' is"
+                                 " deprecated. Use "
+                                 "'remote.{}.ora-ignore-ria-config' instead."
+                                 "".format(self.name, self.gitcfg_name))
+                    try:
+                        self.ignore_remote_config = \
+                            anything2bool(self.ignore_remote_config)
+                    except TypeError:
+                        raise RIARemoteError(
+                            "Invalid value of config "
+                            "'annex.ora-remote.{}.ignore-remote-config': {}"
+                            "".format(self.name, self.ignore_remote_config))
+
+    def _load_committed_cfg(self, fail_noid=True):
+
+        # which repo are we talking about
+        self.gitdir = self.annex.getgitdir()
+
+        # go look for an ID
+        self.archive_id = self.annex.getconfig('archive-id')
+        if fail_noid and not self.archive_id:
+            # TODO: Message! "archive ID" is confusing. dl-id or annex-uuid
+            raise RIARemoteError(
+                "No archive ID configured. This should not happen.")
+
+        # what is our uuid?
+        self.uuid = self.annex.getuuid()
+
+        # RIA store URL(s)
+        self.ria_store_url = self.annex.getconfig('url')
+        if self.ria_store_url:
+            self.ria_store_url_source = 'annex'
+        self.ria_store_pushurl = self.annex.getconfig('push-url')
+        if self.ria_store_pushurl:
+            self.ria_store_pushurl_source = 'annex'
+
+        # TODO: This should prob. not be done! Would only have an effect if
+        #       force-write was committed annex-special-remote-config and this
+        #       is likely a bad idea.
+        self.force_write = self.annex.getconfig('force-write')
+        if self.force_write == "":
+            self.force_write = None
+
+        # Get the special remote name
+        # TODO: Make 'name' a property of `SpecialRemote`;
+        #       Same for `gitcfg_name`, `_repo`?
+        self.name = self.annex.getconfig('name')
+        if not self.name:
+            self.name = self.annex.getconfig('sameas-name')
+        if not self.name:
+            # TODO: Do we need to crash? Not necessarily, I think. We could
+            #       still find configs and if not - might work out.
+            raise RIARemoteError(
+                "Cannot determine special remote name, got: {}".format(
+                    repr(self.name)))
+        # Get the name of the remote entry in .git/config.
+        # Note, that this by default is the same as the stored name of the
+        # special remote, but can be different (for example after
+        # git-remote-rename). The actual connection is the uuid of the special
+        # remote, not the name.
+        try:
+            self.gitcfg_name = self.annex.getgitremotename()
+        except (ProtocolError, AttributeError):
+            # GETGITREMOTENAME not supported by annex version or by annexremote
+            # version.
+            # Lets try to find ourselves: Find remote with matching annex uuid
+            response = _get_gitcfg(self.gitdir,
+                                   "^remote\..*\.annex-uuid",
+                                   regex=True)
+            response = response.splitlines() if response else []
+            candidates = set()
+            for line in response:
+                k, v = line.split()
+                if v == self.annex.getuuid():  # TODO: Where else? self.uuid?
+                    candidates.add(''.join(k.split('.')[1:-1]))
+            num_candidates = len(candidates)
+            if num_candidates == 1:
+                self.gitcfg_name = candidates.pop()
+            elif num_candidates > 1:
+                self.message("Found multiple used remote names in git "
+                             "config: %s" % str(candidates))
+                # try same name:
+                if self.name in candidates:
+                    self.gitcfg_name = self.name
+                    self.message("Choose '%s'" % self.name)
+                else:
+                    self.gitcfg_name = None
+                    self.message("Ignore git config")
+            else:
+                # No entry found.
+                # Possible if we are in "initremote".
+                self.gitcfg_name = None
+
     def _load_cfg(self, gitdir, name):
         # Whether or not to force writing to the remote. Currently used to
         # overrule write protection due to layout version mismatch.
@@ -972,18 +1132,14 @@ class RIARemote(SpecialRemote):
         if self.buffer_size:
             self.buffer_size = int(self.buffer_size)
 
-    def _verify_config(self, gitdir, fail_noid=True):
+    def _verify_config(self, fail_noid=True):
         # try loading all needed info from (git) config
-        name = self.annex.getconfig('name')
-        if not name:
-            name = self.annex.getconfig('sameas-name')
-        if not name:
-            raise RIARemoteError(
-                "Cannot determine special remote name, got: {}".format(
-                    repr(name)))
-        # get store url(s):
-        self.ria_store_url = self.annex.getconfig('url')
-        self.ria_store_pushurl = self.annex.getconfig('push-url')
+
+        # first load committed config
+        self._load_committed_cfg(fail_noid=fail_noid)
+        # now local configs (possible overwrite of committed)
+        self._load_local_cfg()
+
         # get URL rewriting config
         url_cfgs = {k: v for k, v in self._repo.config.items()
                     if k.startswith('url.')}
@@ -993,21 +1149,26 @@ class RIARemote(SpecialRemote):
                 verify_ria_url(self.ria_store_url, url_cfgs)
 
         else:
-            # for now still accept the configs, if no ria-URL is known, but
-            # issue deprecation warning:
-            host = self._repo.config.get(
-                f'annex.ora-remote.{name}.ssh-host') or \
-                self.annex.getconfig('ssh-host')
-            # Note: Special value '0' is replaced by None only after checking
-            # the repository's annex config. This is to uniformly handle '0' and
-            # None later on, but let a user's config '0' overrule what's
-            # stored by git-annex.
-            self.storage_host = None if host == '0' else host
+            # There's one exception to the precedence of local configs:
+            # Age-old "ssh-host" + "base-path" configs are only considered,
+            # if there was no RIA URL (local or committed). However, issue
+            # deprecation warning, if that situation is encountered:
+            host = None
+            path = None
 
-            path = self._repo.config.get(
-                f'annex.ora-remote.{name}.base-path') or \
-                self.annex.getconfig('base-path')
-            self.store_base_path = path.strip() if path else path
+            if self.name:
+                host = self._repo.config.get(
+                    f'annex.ora-remote.{self.name}.ssh-host') or \
+                       self.annex.getconfig('ssh-host')
+                # Note: Special value '0' is replaced by None only after checking
+                # the repository's annex config. This is to uniformly handle '0' and
+                # None later on, but let a user's config '0' overrule what's
+                # stored by git-annex.
+                self.storage_host = None if host == '0' else host
+                path = self._repo.config.get(
+                    f'annex.ora-remote.{self.name}.base-path') or \
+                       self.annex.getconfig('base-path')
+                self.store_base_path = path.strip() if path else path
 
             if path or host:
                 self.message("WARNING: base-path + ssh-host configs are "
@@ -1015,8 +1176,9 @@ class RIARemote(SpecialRemote):
                              " Use 'git annex enableremote {} "
                              "url=<RIA-URL-TO-STORE>' to store a ria+<scheme>:"
                              "//... URL in the special remote's config."
-                             "".format(name),
+                             "".format(self.name),
                              type='info')
+
 
         if not self.store_base_path:
             raise RIARemoteError(
@@ -1027,7 +1189,7 @@ class RIARemote(SpecialRemote):
         self.store_base_path = PurePosixPath(self.store_base_path)
         if not self.store_base_path.is_absolute():
             raise RIARemoteError(
-                'Non-absolute object tree base path configuration: %s'
+                'Non-absolute RIA store base path configuration: %s'
                 '' % str(self.store_base_path))
 
         if self.ria_store_pushurl:
@@ -1035,28 +1197,15 @@ class RIARemote(SpecialRemote):
                 raise RIARemoteError("Invalid push-url: {}. Pushing over HTTP "
                                      "not implemented."
                                      "".format(self.ria_store_pushurl))
-            self.storage_host_push, self.store_base_path_push, \
-                self.ria_store_pushurl = verify_ria_url(self.ria_store_pushurl,
-                                                        url_cfgs)
-
-        # TODO duplicates call to `git-config` after RIA url rewrite
-        self._load_cfg(gitdir, name)
-
-        # go look for an ID
-        self.archive_id = self.annex.getconfig('archive-id')
-        if fail_noid and not self.archive_id:
-            raise RIARemoteError(
-                "No archive ID configured. This should not happen.")
-
-        # TODO: This should prob. not be done! Would only have an effect if
-        #       force-write was committed annex-special-remote-config and this
-        #       is likely a bad idea.
-        if not self.force_write:
-            self.force_write = self.annex.getconfig('force-write')
+            self.storage_host_push, \
+            self.store_base_path_push, \
+            self.ria_store_pushurl = \
+                verify_ria_url(self.ria_store_pushurl, url_cfgs)
 
     def _get_version_config(self, path):
-        """ Get version and config flags from remote file
+        """ Get version and config flags from RIA store's layout file
         """
+
         if self.ria_store_url:
             # construct path to ria_layout_version file for reporting
             target_ri = self.ria_store_url[4:] +\
@@ -1156,14 +1305,9 @@ class RIARemote(SpecialRemote):
 
     @handle_errors
     def initremote(self):
-        # which repo are we talking about
-        gitdir = self.annex.getgitdir()
-        # this will work, even when this is not a bare repo
-        # but it is not capable of reading out dataset/branch config
-        self._repo = AnnexRepo(gitdir)
-        self._verify_config(gitdir, fail_noid=False)
+        self._verify_config(fail_noid=False)
         if not self.archive_id:
-            self.archive_id = _get_datalad_id(gitdir)
+            self.archive_id = _get_datalad_id(self.gitdir)
             if not self.archive_id:
                 # fall back on the UUID for the annex remote
                 self.archive_id = self.annex.getuuid()
@@ -1171,9 +1315,11 @@ class RIARemote(SpecialRemote):
         self.get_store()
 
         self.annex.setconfig('archive-id', self.archive_id)
-        # make sure, we store the potentially rewritten URL
-        self.annex.setconfig('url', self.ria_store_url)
-        if self.ria_store_pushurl:
+        # Make sure, we store the potentially rewritten URL. But only, if the
+        # source was annex as opposed to a local config.
+        if self.ria_store_url and self.ria_store_url_source == 'annex':
+            self.annex.setconfig('url', self.ria_store_url)
+        if self.ria_store_pushurl and self.ria_store_pushurl_source == 'annex':
             self.annex.setconfig('push-url', self.ria_store_pushurl)
 
     def _local_io(self):
@@ -1299,7 +1445,7 @@ class RIARemote(SpecialRemote):
 
         gitdir = self.annex.getgitdir()
         self._repo = AnnexRepo(gitdir)
-        self._verify_config(gitdir)
+        self._verify_config()
 
         self.get_store()
 

--- a/datalad/distributed/tests/test_ria_git_remote.py
+++ b/datalad/distributed/tests/test_ria_git_remote.py
@@ -264,7 +264,7 @@ def test_bare_git_version_2():
 #
 #     # add the ria remote:
 #     # Note: For serve_path_via_http to work (which we need later), the directory needs to already exist.
-#     #       But by default RIARemote will reject to create the remote structure in an already existing directory,
+#     #       But by default ORARemote will reject to create the remote structure in an already existing directory,
 #     #       that wasn't created by itself (lacks as ria-layout-version file).
 #     #       So, we can either configure force-write here or put a version file in it beforehand.
 #     #       However, this is specific to the test environment!

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ entry_points = {
         'datalad=datalad.cli.main:main',
         'git-annex-remote-datalad-archives=datalad.customremotes.archives:main',
         'git-annex-remote-datalad=datalad.customremotes.datalad:main',
+        'git-annex-remote-ria=datalad.customremotes.ria_remote:main',
         'git-annex-remote-ora=datalad.distributed.ora_remote:main',
         'git-credential-datalad=datalad.local.gitcredential_datalad:git_credential_datalad',
     ],


### PR DESCRIPTION
This is a revival of #5859 (which I thought was long merged).

Apart from some refactoring in ORA, it introduces the possibility to override the special remote configs (in `git-annex:remote.log`) by local configs. This is then used to change the reconfiguration of ORA remotes by `clone` to only apply locally instead of committing a changed RIA URL (which could lead to a constant ping pong between different access methods to a RIA store).

In addition, there is a shim special remote introduced here, that allows datasets using the old ria remote (https://github.com/datalad/git-annex-ria-remote) to still work. This doesn't come with a proper test, since there's little point in making the tests depend on a package that is deprecated and archived. Please note, that there are two more points about introducing this "second flavor" of the special remote:
1. One idea is to have this replaced by an implementation that would auto-migrate during `initremote`/`enableremote`.
2. Following up on #7022,  after 0.18 I want to move all the RIA/ORA stuff into https://github.com/datalad/datalad-ria. Those two special remotes here in core would then be replaced by a dummy implementation that simply issues an error message to annex, reading something like "please install datalad-ria extension".
So, the point here is to introduce that second "spot".