### PR TITLE
BF: Fix invalid version comparison

### DIFF
--- a/changelog.d/pr-7249.md
+++ b/changelog.d/pr-7249.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- Fixes crashes on windows where DataLad was mistaking git-annex 10.20221212 for
+  a not yet released git-annex version and trying to use a new feature.
+  Fixes [#7248](https://github.com/datalad/datalad/issues/7248) via
+  [PR #7249](https://github.com/datalad/datalad/pull/7249)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -553,7 +553,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         kludges["grp1-supports-batch-keys"] = ver >= "8.20210903"
         # applies to find, findref to list all known.
         # was added in 10.20221212-17-g0b2dd374d on 20221220.
-        kludges["find-supports-anything"] = ver >= "10.20221212+git18"
+        kludges["find-supports-anything"] = ver >= "10.20221213"
         cls._version_kludges = kludges
         return kludges[key]
 


### PR DESCRIPTION
Specifying 10.20221212+git18 as requirement doesn't work, when the reported version of an annex build is using a different scheme. It was used because the git-annex version required isn't released yet. See issue 7248.

However, we know the scheme of annex versions (it's a date after the dot), therefore setting the required version to one day after the previous release does the trick with respect to released annex versions. Hence, we will use this only with the coming release (not a current snapshot). But that is clearly more sensible than crashing on an annex version that doesn't support it yet.

Closes #7248