### PR TITLE
PERF: Buffer size optimization from datalad-next

### DIFF
--- a/changelog.d/pr-7250.md
+++ b/changelog.d/pr-7250.md
@@ -1,0 +1,7 @@
+### 🏎 Performance
+
+- Integrate buffer size optimization from datalad-next, leading to significant
+  performance improvement for status and diff.
+  Fixes [#7190](https://github.com/datalad/datalad/issues/7190) via
+  [PR #7250](https://github.com/datalad/datalad/pull/7250)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/runner/runnerthreads.py
+++ b/datalad/runner/runnerthreads.py
@@ -18,6 +18,7 @@ from typing import (
     IO,
     Optional,
 )
+from datalad.utils import COPY_BUFSIZE
 
 
 lgr = logging.getLogger("datalad.runner.runnerthreads")
@@ -189,7 +190,7 @@ class ReadThread(TransportThread):
                  user_info: Any,
                  source: IO,
                  destination_queue: Queue,
-                 length: int = 1024
+                 length: int = COPY_BUFSIZE
                  ):
 
         super().__init__(identifier, signal_queues, user_info)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -79,6 +79,16 @@ on_windows = platform_system == 'windows'
 on_osx = platform_system == 'darwin'
 on_linux = platform_system == 'linux'
 
+# COPY_BUFSIZE sort of belongs into datalad.consts, but that would lead to
+# circular import due to `on_windows`
+try:
+    from shutil import COPY_BUFSIZE
+except ImportError:  # pragma: no cover
+    # too old
+    from datalad.utils import on_windows
+    # from PY3.10
+    COPY_BUFSIZE = 1024 * 1024 if on_windows else 64 * 1024
+
 
 # Takes ~200msec, so should not be called at import time
 @lru_cache()  # output should not change through life time of datalad process


### PR DESCRIPTION
This is a trivial patch from datalad-next, that significantly improves performance of save,status, etc. b/c of a much too small buffer when the runner is reading output.

Closes #7190
