### PR TITLE
Rf batched command

### DIFF
--- a/changelog.d/pr-7252.md
+++ b/changelog.d/pr-7252.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Rf batched command.  Fixes [#7251](https://github.com/datalad/datalad/issues/7251) via [PR #7252](https://github.com/datalad/datalad/pull/7252) (by [@christian-monch](https://github.com/christian-monch))

--- a/changelog.d/pr-7252.md
+++ b/changelog.d/pr-7252.md
@@ -1,3 +1,3 @@
 ### 🏠 Internal
 
-- Rf batched command.  Fixes [#7251](https://github.com/datalad/datalad/issues/7251) via [PR #7252](https://github.com/datalad/datalad/pull/7252) (by [@christian-monch](https://github.com/christian-monch))
+- Ensure thread safety in BatchedCommand cleanup code. Fixes [#7251](https://github.com/datalad/datalad/issues/7251) via [PR #7252](https://github.com/datalad/datalad/pull/7252) (by [@christian-monch](https://github.com/christian-monch))

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -123,6 +123,7 @@ def increased_active(batched_command):
         batched_command._active -= 1
         if batched_command._active == 0:
             BatchedCommand._cleanup_lock.release()
+            batched_command._active_last = _now()
 
 
 class BatchedCommandError(CommandError):
@@ -345,8 +346,6 @@ class BatchedCommand(SafeDelCloseMixin):
             output_proc=self.output_proc,
         )
         self.encoding = self.generator.runner.protocol.encoding
-
-        self._active_last = _now()
 
     def process_running(self) -> bool:
         if self.runner:

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -78,6 +78,38 @@ _cfg_var = "datalad.runtime.stalled-external"
 _cfg_val = cfg.obtain(_cfg_var)
 
 
+lgr = logging.getLogger('datalad.cmd')
+
+# TODO unused?
+# In python3 to split byte stream on newline, it must be bytes
+linesep_bytes = os.linesep.encode()
+
+# TODO unused?
+_TEMP_std = sys.stdout, sys.stderr
+
+# TODO unused?
+# To be used in the temp file name to distinguish the ones we create
+# in Runner so we take care about their removal, in contrast to those
+# which might be created outside and passed into Runner
+_MAGICAL_OUTPUT_MARKER = "_runneroutput_"
+
+
+def readline_rstripped(stdout):
+    warnings.warn("the function `readline_rstripped()` is deprecated "
+                  "and will be removed in a future release",
+                  DeprecationWarning)
+    return _readline_rstripped(stdout)
+
+
+def _readline_rstripped(stdout):
+    """Internal helper for BatchedCommand"""
+    return stdout.readline().rstrip()
+
+
+def _now():
+    return datetime.now().astimezone()
+
+
 class BatchedCommandError(CommandError):
     def __init__(self,
                  cmd="",
@@ -113,34 +145,6 @@ class BatchedCommandError(CommandError):
             **kwargs
         )
         self.last_processed_request = last_processed_request
-
-
-lgr = logging.getLogger('datalad.cmd')
-
-# TODO unused?
-# In python3 to split byte stream on newline, it must be bytes
-linesep_bytes = os.linesep.encode()
-
-# TODO unused?
-_TEMP_std = sys.stdout, sys.stderr
-
-# TODO unused?
-# To be used in the temp file name to distinguish the ones we create
-# in Runner so we take care about their removal, in contrast to those
-# which might be created outside and passed into Runner
-_MAGICAL_OUTPUT_MARKER = "_runneroutput_"
-
-
-def readline_rstripped(stdout):
-    warnings.warn("the function `readline_rstripped()` is deprecated "
-                  "and will be removed in a future release",
-                  DeprecationWarning)
-    return _readline_rstripped(stdout)
-
-
-def _readline_rstripped(stdout):
-    """Internal helper for BatchedCommand"""
-    return stdout.readline().rstrip()
 
 
 class BatchedCommandProtocol(GeneratorMixIn, StdOutErrCapture):
@@ -618,7 +622,3 @@ class BatchedCommand(SafeDelCloseMixin):
                 raise ValueError(f"Unexpected value: {_cfg_var}={_cfg_val!r}")
             self._abandon_cache = _cfg_val == "abandon"
         return self._abandon_cache
-
-
-def _now():
-    return datetime.now().astimezone()

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -255,7 +255,6 @@ class BatchedCommand(SafeDelCloseMixin):
 
     # Collection of BatchedCommand instances that have a runner associated
     _running_instances: WeakValueDictionary[int, BatchedCommand] = WeakValueDictionary()
-    _cleanup_lock = threading.Lock()
 
     def __init__(self,
                  cmd: Union[str, Tuple, List],

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -28,7 +28,6 @@ from subprocess import TimeoutExpired
 from typing import (
     Any,
     Callable,
-    Iterable,
     List,
     Optional,
     Tuple,
@@ -126,7 +125,7 @@ def increased_active(batched_command: "BatchedCommand"):
 
 
 @contextmanager
-def locked_instances(batched_commands: Iterable):
+def locked_instances(batched_commands: List):
     for batched_command in batched_commands:
         batched_command.lock.acquire()
     try:
@@ -295,7 +294,7 @@ class BatchedCommand(SafeDelCloseMixin):
         max_inactive_age = cfg.obtain("datalad.runtime.max-inactive-age")
 
         # Lock all known
-        with locked_instances(BatchedCommand._running_instances.values()[:]):
+        with locked_instances(list(BatchedCommand._running_instances.values())):
             try_to_close = len(cls._running_instances) - max_batched
             if try_to_close <= 0:
                 return

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -304,7 +304,7 @@ class BatchedCommand(SafeDelCloseMixin):
                 batched_command
                 for batched_command in cls._running_instances.values()
                 if batched_command._active == 0
-                and now - batched_command._active_last.total_seconds() >= max_inactive_age
+                and (now - batched_command._active_last).total_seconds() >= max_inactive_age
             }
 
             if len(old_inactive) < try_to_close:


### PR DESCRIPTION
Fixes #7251

This PR uses thread-locks to ensure thread-safe determination of whether a `BatchedCommand` instance is active or not.

TODO:
- [ ] add regression-tests
 