### PR TITLE
Display version badges of DataLad across various package distributions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-47-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-## Distribubtion
+## Distribution
 
 [![AUR package](https://repology.org/badge/version-for-repo/aur/datalad.svg)](https://repology.org/project/datalad/versions)
+[![Conda-forge](https://anaconda.org/conda-forge/datalad/badges/version.svg)](https://anaconda.org/conda-forge/datalad)
+[![Debian Stable](https://badges.debian.net/badges/debian/stable/datalad/version.svg)](https://packages.debian.org/stable/datalad)
+[![Debian Unstable](https://badges.debian.net/badges/debian/unstable/datalad/version.svg)](https://packages.debian.org/unstable/datalad)
+[![GitHub release](https://img.shields.io/github/release/datalad/datalad.svg)](https://GitHub.com/datalad/datalad/releases/)
 [![Gentoo Science package](https://repology.org/badge/version-for-repo/gentoo_ovl_science/datalad.svg)](https://repology.org/project/datalad/versions)
 [![PyPI package](https://repology.org/badge/version-for-repo/pypi/datalad.svg)](https://repology.org/project/datalad/versions)
-
 
 # 10000-ft. overview
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![Documentation](https://readthedocs.org/projects/datalad/badge/?version=latest)](http://datalad.rtfd.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub release](https://img.shields.io/github/release/datalad/datalad.svg)](https://GitHub.com/datalad/datalad/releases/)
-[![PyPI version fury.io](https://badge.fury.io/py/datalad.svg)](https://pypi.python.org/pypi/datalad/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/datalad)](https://pypi.org/project/datalad/)
 [![Testimonials 4](https://img.shields.io/badge/testimonials-4-brightgreen.svg)](https://github.com/datalad/datalad/wiki/Testimonials)
 [![https://www.singularity-hub.org/static/img/hosted-singularity--hub-%23e32929.svg](https://www.singularity-hub.org/static/img/hosted-singularity--hub-%23e32929.svg)](https://singularity-hub.org/collections/667)
@@ -21,6 +20,12 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-47-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+## Distribubtion
+
+[![AUR package](https://repology.org/badge/version-for-repo/aur/datalad.svg)](https://repology.org/project/datalad/versions)
+[![Gentoo Science package](https://repology.org/badge/version-for-repo/gentoo_ovl_science/datalad.svg)](https://repology.org/project/datalad/versions)
+[![PyPI package](https://repology.org/badge/version-for-repo/pypi/datalad.svg)](https://repology.org/project/datalad/versions)
 
 
 # 10000-ft. overview


### PR DESCRIPTION
Datalad is available directly via the package managers of a number of distributions (full list: https://repology.org/project/datalad/versions ), in addition to PyPI. I think it would be good to list the few of them which have more-or-less up-to-date versions available.

This PR creates an alphabetically ordered sub-heading for that, and moves PyPI inline with the others for consistency.

I know Debian also has somewhat up-to-date versions available, but as seen in the link above it seems to be versioned, so I'm unsure how to dynamically refer to the newest, or maybe whether we should instead refer to the unstable entry (and in that case whether to refer to NeuroDebian or just Debian). I would assume @yarikoptic knows more about this.
