### PR TITLE
BF(TST): use older python 3.8 in testing nose utils

### DIFF
--- a/.github/workflows/test-nose.yml
+++ b/.github/workflows/test-nose.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -r requirements-devel.txt
           pip install coverage datalad-installer nose
           datalad-installer --sudo ok -E /tmp/new.env \
-            miniconda --batch \
+            miniconda --spec python==3.8 --batch \
             git-annex=8.20201007 -m conda
           . /tmp/new.env
           echo "PATH=$PATH" >> "$GITHUB_ENV"

--- a/changelog.d/pr-7260.md
+++ b/changelog.d/pr-7260.md
@@ -1,3 +1,3 @@
 ### 🧪 Tests
 
-- BF(TST): use older python 3.8 in testing nose utils.  Fixes [#7259](https://github.com/datalad/datalad/issues/7259) via [PR #7260](https://github.com/datalad/datalad/pull/7260) (by [@yarikoptic](https://github.com/yarikoptic))
+- Use older python 3.8 in testing nose utils in github-action test-nose.  Fixes [#7259](https://github.com/datalad/datalad/issues/7259) via [PR #7260](https://github.com/datalad/datalad/pull/7260) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/changelog.d/pr-7260.md
+++ b/changelog.d/pr-7260.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- BF(TST): use older python 3.8 in testing nose utils.  Fixes [#7259](https://github.com/datalad/datalad/issues/7259) via [PR #7260](https://github.com/datalad/datalad/pull/7260) (by [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
New one 3.10 causes installation problems since likely simply no longer maintained/compatible. For the sake of it, fix it to test against 3.8 and in another PR against master we should deprecate/remove nose parts entirely

Closes #7259 