### PR TITLE
Revert "Revert "Remove chardet version upper limit""

### DIFF
--- a/changelog.d/pr-7263.md
+++ b/changelog.d/pr-7263.md
@@ -1,0 +1,3 @@
+### 🔩 Dependencies
+
+- Revert "Revert "Remove chardet version upper limit"".  [PR #7263](https://github.com/datalad/datalad/pull/7263) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from _datalad_build_support.setup import (
 requires = {
     'core': [
         'platformdirs',
-        'chardet>=3.0.4, <5.0.0',      # rarely used but small/omnipresent
+        'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
         'distro; python_version >= "3.8"',
         'importlib-metadata >=3.6; python_version < "3.10"',


### PR DESCRIPTION
This reverts commit 09cb41ce5b5d8800d00e2ead9c8a95cc2e4e767a. Original PR which removed upper bound:
https://github.com/datalad/datalad/pull/7029

Debians now have 5.1.0, and we can't package while demanding an outdated chardet. Let's see again if we really need to limit upper version.
