### PR TITLE
Fix `create-sibling` for non-English SSH remotes

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -130,6 +130,11 @@
         {
             "affiliation": "Institute of Energy and Climate Research - Stratosphere (IEK-7), Research Centre Jülich, Jülich, Germany",
             "name": "Riße, Matthias"
+        },
+        {
+            "affiliation": "Eberhard Karls Universität Tübingen",
+            "name": "Büchau, Yann Georg",
+            "orcid": "0000-0003-2472-2051"
         }
     ],
     "grants": [

--- a/changelog.d/pr-7265.md
+++ b/changelog.d/pr-7265.md
@@ -1,3 +1,3 @@
 ### 🐛 Bug Fixes
 
-- Fix `create-sibling` for non-English SSH remotes.  [PR #7265](https://github.com/datalad/datalad/pull/7265) (by [@nobodyinperson](https://github.com/nobodyinperson))
+- Fix `create-sibling` for non-English SSH remotes by providing `LC_ALL=C` for the `ls` call.  [PR #7265](https://github.com/datalad/datalad/pull/7265) (by [@nobodyinperson](https://github.com/nobodyinperson))

--- a/changelog.d/pr-7265.md
+++ b/changelog.d/pr-7265.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Fix `create-sibling` for non-English SSH remotes.  [PR #7265](https://github.com/datalad/datalad/pull/7265) (by [@nobodyinperson](https://github.com/nobodyinperson))

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -392,7 +392,7 @@ def _create_dataset_sibling(
 def _ls_remote_path(ssh, path):
     try:
         # yoh tried ls on mac
-        out, err = ssh("ls -A1 {}".format(sh_quote(path)))
+        out, err = ssh("LC_ALL=C ls -A1 {}".format(sh_quote(path)))
         if err:
             # we might even want to raise an exception, but since it was
             # not raised, let's just log a warning

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -392,7 +392,9 @@ def _create_dataset_sibling(
 def _ls_remote_path(ssh, path):
     try:
         # yoh tried ls on mac
-        out, err = ssh("LC_ALL=C ls -A1 {}".format(sh_quote(path)))
+        out, err = ssh('sh -c "LC_ALL=C; export LC_ALL; /bin/ls -A1 {}"'.format(
+            sh_quote(path)))
+
         if err:
             # we might even want to raise an exception, but since it was
             # not raised, let's just log a warning

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -15,6 +15,7 @@ import logging
 import os
 from distutils.version import LooseVersion
 from os.path import curdir
+import shlex
 from os.path import join as opj
 from os.path import (
     normpath,
@@ -392,8 +393,13 @@ def _create_dataset_sibling(
 def _ls_remote_path(ssh, path):
     try:
         # yoh tried ls on mac
-        out, err = ssh('sh -c "LC_ALL=C; export LC_ALL; /bin/ls -A1 {}"'.format(
-            sh_quote(path)))
+        # escape path explicitly with shlex.quote as 'sh' is a POSIX shell and
+        # sh_quote could decide to quote Windows-style
+        ls_cmd = "LC_ALL=C; export LC_ALL; /bin/ls -A1 {}".format(shlex.quote(path))
+        # TODO: Using sh_quote here is also flawed as it checks whether the
+        # *local* machine is Windows. Doesn't help if the remote we're ssh'ing in is Windows.
+        ssh_cmd = "sh -c {}".format(sh_quote(ls_cmd))
+        out, err = ssh(ssh_cmd)
 
         if err:
             # we might even want to raise an exception, but since it was

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -946,7 +946,7 @@ def test_preserve_attrs(src=None, dest=None):
         assert fp.read() == "This is test text."
 
 
-@skip_if_on_windows
+@known_failure_windows # backstory: https://github.com/datalad/datalad/pull/7265
 @with_tempfile(mkdir=True)
 def test_only_one_level_without_recursion(path=None):
     # this tests for https://github.com/datalad/datalad/issues/5614: accidental

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -946,6 +946,7 @@ def test_preserve_attrs(src=None, dest=None):
         assert fp.read() == "This is test text."
 
 
+@skip_if_on_windows
 @with_tempfile(mkdir=True)
 def test_only_one_level_without_recursion(path=None):
     # this tests for https://github.com/datalad/datalad/issues/5614: accidental


### PR DESCRIPTION
Came up in [chat](https://app.element.io/#/room/#datalad:matrix.org):

`datalad create-sibling` failed when trying to check for the existance of the sibling because of a non-fixed locale. Example:

```bash
yann in machine in ~/code/datalad 
❯ datalad create ds
[WARNING] Requested extension 'next' is not available 
create(ok): /home/yann/code/datalad/ds (dataset)
yann in machine in ~/code/datalad took 4s220ms 
❮ datalad create-sibling -d ds machine.server.de:code/datalad/ds-sibling
[WARNING] Requested extension 'next' is not available 
[INFO   ] No sibling name given. Using URL hostname 'machine.server.de' as sibling name 
[INFO   ] Connecting ... 
[INFO   ] Considering to create a target dataset /home/yann/code/datalad/ds at code/datalad/ds-sibling of machine.server.de 
CommandError: 'ssh -o ControlPath=/home/yann/.cache/datalad/sockets/cb4db4c9 machine.server.de 'ls -A1 code/datalad/ds-sibling'' failed with exitcode 2
ls: Zugriff auf 'code/datalad/ds-sibling' nicht möglich: Datei oder Verzeichnis nicht gefunden 
# ☝️☝️☝️☝️ shouldn't be German as the error message is compared to the English equivalent in the code
```

This PR fixes this by setting the locale of the used `ls` command to the default `C` locale. 

Fixes #7264 