### PR TITLE
BF: Set language when parsing output

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -392,7 +392,7 @@ def _create_dataset_sibling(
 def _ls_remote_path(ssh, path):
     try:
         # yoh tried ls on mac
-        out, err = ssh("ls -A1 {}".format(sh_quote(path)))
+        out, err = ssh("LC_ALL=C ls -A1 {}".format(sh_quote(path)))
         if err:
             # we might even want to raise an exception, but since it was
             # not raised, let's just log a warning


### PR DESCRIPTION
In `create-siblling` we rely on parsing the output of `ls`. This failed when the language on the target system isn't english.

Closes #7264

