### PR TITLE
Fix EnsureListOf() and EnsureTupleOf() for string inputs

### DIFF
--- a/changelog.d/pr-7267.md
+++ b/changelog.d/pr-7267.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Fix EnsureListOf() and EnsureTupleOf() for string inputs.  [PR #7267](https://github.com/datalad/datalad/pull/7267) (by [@nobodyinperson](https://github.com/nobodyinperson))

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -135,7 +135,7 @@ class EnsureListOf(Constraint):
         super(EnsureListOf, self).__init__()
 
     def __call__(self, value):
-        return list(map(self._dtype, value))
+        return list(map(self._dtype, ([value] if isinstance(value, str) else value)))
 
     def short_description(self):
         return 'list(%s)' % _type_str(self._dtype)
@@ -157,7 +157,7 @@ class EnsureTupleOf(Constraint):
         super(EnsureTupleOf, self).__init__()
 
     def __call__(self, value):
-        return tuple(map(self._dtype, value))
+        return tuple(map(self._dtype, ([value] if isinstance(value, str) else value)))
 
     def short_description(self):
         return 'tuple(%s)' % _type_str(self._dtype)

--- a/datalad/tests/test_constraints.py
+++ b/datalad/tests/test_constraints.py
@@ -158,12 +158,14 @@ def test_listof():
     c = ct.EnsureListOf(str)
     assert_equal(c(['a', 'b']), ['a', 'b'])
     assert_equal(c(['a1', 'b2']), ['a1', 'b2'])
+    assert_equal(c('a1 b2'), ['a1 b2'])
 
 
 def test_tupleof():
     c = ct.EnsureTupleOf(str)
     assert_equal(c(('a', 'b')), ('a', 'b'))
     assert_equal(c(('a1', 'b2')), ('a1', 'b2'))
+    assert_equal(c('a1 b2'), ('a1 b2',))
 
 
 def test_constraints():


### PR DESCRIPTION
`EnsureListOf()` and `EnsureTupleOf()` took string inputs as iterables. This PR fixes this.

(I don't understand this `scriv` thing, `scriv create` etc. all error out with unfound files, so I'll leave it to you to add this CHANGELOG label.)