### PR TITLE
Codespell more (CHANGELOGs etc) and remove custom CLI options from tox.ini

### DIFF
--- a/.codespell-ignorewords
+++ b/.codespell-ignorewords
@@ -1,4 +1,0 @@
-commitish
-ba
-froms
-ro

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+[codespell]
+skip = .venv,venvs,.git,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem
+# commitish - vote if we want to fix (should be committish) -- used in GitRepo API
+# froms - plural "from" introduced by export_archive_ora
+# ned - Ned is a name
+ignore-words-list = ba,commitish,froms,ro,ned
+exclude-file = .codespell-ignorelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2700,7 +2700,7 @@ only supported Python flavor.
   `--alternative-source` parameter has been removed, and a `clone_dataset`
   function with multi-source capabilities is provided instead. The
   `--reckless` parameter can now take literal mode labels instead of just
-  beeing a binary flag, but backwards compatibility is maintained.
+  being a binary flag, but backwards compatibility is maintained.
 
 - The `get_file_content` method of `GitRepo` was no longer used
   internally or in any known DataLad extensions and has been removed.
@@ -3699,7 +3699,7 @@ Rushed out bugfix release to stay fully compatible with recent
     while considering subdataset metadata for re-aggregation ([#3007][])
 - `annex` commands are now chunked assuming 50% "safety margin" on the
   maximal command line length. Should resolve crashes while operating
-  ot too many files at ones ([#3001][])
+  of too many files at ones ([#3001][])
 - `run` sidecar config processing ([#2991][])
 - no double trailing period in docs ([#2984][])
 - correct identification of the repository with symlinks in the paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@
 
 ## 🧪 Tests
 
-- Reenable two now-passing core test on Windows CI.
+- Re-enable two now-passing core test on Windows CI.
   [PR #7152](https://github.com/datalad/datalad/pull/7152) (by [@adswa](https://api.github.com/users/adswa))
 
 - Remove the `with_testrepos` decorator and associated tests for it
@@ -218,7 +218,7 @@
 
 - Fix test failure with old annex.  Fixes [#7157](https://github.com/datalad/datalad/issues/7157) via [PR #7159](https://github.com/datalad/datalad/pull/7159) (by [@bpoldrack](https://github.com/bpoldrack))
 
-- Reenable now passing test_path_diff test on Windows.  Fixes [#3725](https://github.com/datalad/datalad/issues/3725) via [PR #7194](https://github.com/datalad/datalad/pull/7194) (by [@yarikoptic](https://github.com/yarikoptic))
+- Re-enable now passing test_path_diff test on Windows.  Fixes [#3725](https://github.com/datalad/datalad/issues/3725) via [PR #7194](https://github.com/datalad/datalad/pull/7194) (by [@yarikoptic](https://github.com/yarikoptic))
 
 - Use Plaintext keyring backend in tests to avoid the need for (interactive)
   authentication to unlock the keyring during (CI-) test runs.
@@ -850,7 +850,7 @@
 #### 🏠 Internal
 
 - The internal ``status()`` helper was equipped with docstrings and promotes "breadth-first" reporting with a new parameter ``reporting_order`` [#6006](https://github.com/datalad/datalad/pull/6006) (by @mih)
-- ``AnnexRepo.get_file_annexinfo()`` is introduced for more convinient queries for single files and replaces a now deprecated ``AnnexRepo.get_file_key()`` to receive information with fewer calls to Git [#6104](https://github.com/datalad/datalad/pull/6104) (by @mih)
+- ``AnnexRepo.get_file_annexinfo()`` is introduced for more convenient queries for single files and replaces a now deprecated ``AnnexRepo.get_file_key()`` to receive information with fewer calls to Git [#6104](https://github.com/datalad/datalad/pull/6104) (by @mih)
 - A new ``get_paths_by_ds()`` helper exposes ``status``' path normalization and sorting [#6110](https://github.com/datalad/datalad/pull/6110) (by @mih)
 - ``status`` is optimized with a cache for dataset roots [#6137](https://github.com/datalad/datalad/pull/6137) (by @yarikoptic)
 - The internal ``get_func_args_doc()`` helper with Python 2 is removed from DataLad core [#6175](https://github.com/datalad/datalad/pull/6175) (by @yarikoptic)
@@ -905,7 +905,7 @@
 - DataLad and its dependency stack were packaged for Gentoo Linux [#6088](https://github.com/datalad/datalad/pull/6088) (by @TheChymera)
 - The readthedocs configuration is modernized to version 2 [#6207](https://github.com/datalad/datalad/pull/6207) (by @adswa)
 - The Windows CI setup now runs on Appveyor's Visual Studio 2022 configuration [#6228](https://github.com/datalad/datalad/pull/6228) (by @adswa)
-- The ``readthedocs-theme`` and ``Sphinx`` versions were pinned to reenable rendering of bullet points in the documentation [#6346](https://github.com/datalad/datalad/pull/6346) (by @adswa)
+- The ``readthedocs-theme`` and ``Sphinx`` versions were pinned to re-enable rendering of bullet points in the documentation [#6346](https://github.com/datalad/datalad/pull/6346) (by @adswa)
 - The PR template was updated with a CHANGELOG template. Future PRs should use it to include a summary for the CHANGELOG [#6396](https://github.com/datalad/datalad/pull/6396) (by @mih)
 
 #### Authors: 11
@@ -1909,7 +1909,7 @@
   ([#5218][])
 
 - The internal command runner's handling of the event loop has been
-  tweaked to hopefully fix issues with runnning DataLad from IPython.
+  tweaked to hopefully fix issues with running DataLad from IPython.
   ([#5106][])
 
 - SSH cleanup wasn't reliably triggered by the ORA special remote on
@@ -2937,7 +2937,7 @@ bet we will fix some bugs and make a world even a better place.
 
 - Correctly handle relative paths in [publish][]. ([#3799][]) ([#3102][])
 
-- Do not errorneously discover directory as a procedure. ([#3793][])
+- Do not erroneously discover directory as a procedure. ([#3793][])
 
 - Correctly extract version from manpage to trigger use of manpages for
   `--help`. ([#3798][])
@@ -3165,7 +3165,7 @@ local dataset operations (`create`, `run`, `save`, `status`, `diff`) is
 
 ## Enhancements and new features
 
-- `SSHConnection` now offers methods for file upload and dowload (`get()`,
+- `SSHConnection` now offers methods for file upload and download (`get()`,
   `put()`. The previous `copy()` method only supported upload and was
   discontinued ([#3401][])
 
@@ -3830,7 +3830,7 @@ of fixes and enhancements in the past months.
     with latency and locking issues on Windows.  ([#2795][])
 - Internal git fetch calls have been updated to work around a
   GitPython `BadName` issue.  ([#2712][]), ([#2794][])
-- The progess bar for annex file transferring was unable to handle an
+- The progress bar for annex file transferring was unable to handle an
   empty file.  ([#2717][])
 - `datalad add-readme` halted when no aggregated metadata was found
   rather than displaying a warning.  ([#2731][])
@@ -4172,7 +4172,7 @@ Minor bugfix release
   See [screencast](http://datalad.org/features.html#reproducible-science)
 - [save][] now uses Git for detecting with sundatasets need to be inspected for
   potential changes, instead of performing a complete traversal of a dataset tree
-- [add][] looks for changes relative to the last commited state of a dataset
+- [add][] looks for changes relative to the last committed state of a dataset
   to discover files to add more efficiently
 - [diff][] can now report untracked files in addition to modified files
 - [uninstall][] will check itself whether a subdataset is properly registered in a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -444,7 +444,7 @@ without much prior knowledge.  Your assistance in this area will be greatly
 appreciated by the more experienced developers as it helps free up their time to
 concentrate on other issues.
 
-## Maintenace teams coordination
+## Maintenance teams coordination
 
 We distinguish particular aspects of DataLad's functionality, each corresponding
 to parts of the code base in this repository, and loosely maintain teams assigned

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# simple makefile to simplify repetetive build env management tasks under posix
+# simple makefile to simplify repetitive build env management tasks under posix
 # Ideas borrowed from scikit-learn's and PyMVPA Makefiles  -- thanks!
 
 PYTHON ?= python

--- a/changelog.d/pr-7271.md
+++ b/changelog.d/pr-7271.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Codespell more (CHANGELOGs etc) and remove custom CLI options from tox.ini.  [PR #7271](https://github.com/datalad/datalad/pull/7271) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -50,7 +50,7 @@ a part of this provider -- only download from the web::
     mode = (download|fast|relaxed)            # fast/relaxed/download
     filename = (url|request)                  # of cause also could be _e'valuated given the bs4 link get_video_filename(link, filename)
     recurse_(a|href) =                        # regexes to recurse
-    # mimicing scrapy
+    # mimicking scrapy
     start_urls = http://...                   #
     certificates =                            # if there are https -- we need to allow specifying those
     allowed_domains = example.com/buga/duga   # to limit recursion

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -89,7 +89,7 @@ part of any number of such collections.
 
 Benefiting from Git's support for workflows based on decentralized "clones" of
 a repository, DataLad's datasets can be (re-)published to a new location
-without loosing the connection between the "original" and the new "copy". This
+without losing the connection between the "original" and the new "copy". This
 is extremely useful for collaborative work, but also in more mundane scenarios
 such as data backup, or temporary deployment of a dataset on a compute cluster,
 or in the cloud.  Using git-annex, data can also get synchronized across

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -222,7 +222,7 @@ Performance
 Tests
 -----
 
--  Reenable two now-passing core test on Windows CI. `PR
+-  Re-enable two now-passing core test on Windows CI. `PR
    #7152 <https://github.com/datalad/datalad/pull/7152>`__ (by
    `@adswa <https://api.github.com/users/adswa>`__)
 
@@ -350,7 +350,7 @@ Tests
    #7159 <https://github.com/datalad/datalad/pull/7159>`__ (by
    `@bpoldrack <https://github.com/bpoldrack>`__)
 
--  Reenable now passing test_path_diff test on Windows. Fixes
+-  Re-enable now passing test_path_diff test on Windows. Fixes
    `#3725 <https://github.com/datalad/datalad/issues/3725>`__ via `PR
    #7194 <https://github.com/datalad/datalad/pull/7194>`__ (by
    `@yarikoptic <https://github.com/yarikoptic>`__)
@@ -1838,7 +1838,7 @@ Internal
    promotes “breadth-first” reporting with a new parameter
    ``reporting_order``
    `#6006 <https://github.com/datalad/datalad/pull/6006>`__ (by @mih)
--  ``AnnexRepo.get_file_annexinfo()`` is introduced for more convinient
+-  ``AnnexRepo.get_file_annexinfo()`` is introduced for more convenient
    queries for single files and replaces a now deprecated
    ``AnnexRepo.get_file_key()`` to receive information with fewer calls
    to Git `#6104 <https://github.com/datalad/datalad/pull/6104>`__ (by
@@ -2016,7 +2016,7 @@ Infra
    configuration
    `#6228 <https://github.com/datalad/datalad/pull/6228>`__ (by @adswa)
 -  The ``readthedocs-theme`` and ``Sphinx`` versions were pinned to
-   reenable rendering of bullet points in the documentation
+   re-enable rendering of bullet points in the documentation
    `#6346 <https://github.com/datalad/datalad/pull/6346>`__ (by @adswa)
 -  The PR template was updated with a CHANGELOG template. Future PRs
    should use it to include a summary for the CHANGELOG
@@ -3697,7 +3697,7 @@ Fixes
    (`#5218 <https://github.com/datalad/datalad/issues/5218>`__)
 
 -  The internal command runner’s handling of the event loop has been
-   tweaked to hopefully fix issues with runnning DataLad from IPython.
+   tweaked to hopefully fix issues with running DataLad from IPython.
    (`#5106 <https://github.com/datalad/datalad/issues/5106>`__)
 
 -  SSH cleanup wasn’t reliably triggered by the ORA special remote on
@@ -5160,7 +5160,7 @@ Fixes
    (`#3799 <https://github.com/datalad/datalad/issues/3799>`__)
    (`#3102 <https://github.com/datalad/datalad/issues/3102>`__)
 
--  Do not errorneously discover directory as a procedure.
+-  Do not erroneously discover directory as a procedure.
    (`#3793 <https://github.com/datalad/datalad/issues/3793>`__)
 
 -  Correctly extract version from manpage to trigger use of manpages for
@@ -5478,7 +5478,7 @@ Fixes
 Enhancements and new features
 -----------------------------
 
--  ``SSHConnection`` now offers methods for file upload and dowload
+-  ``SSHConnection`` now offers methods for file upload and download
    (``get()``, ``put()``. The previous ``copy()`` method only supported
    upload and was discontinued
    (`#3401 <https://github.com/datalad/datalad/issues/3401>`__)
@@ -6472,7 +6472,7 @@ Fixes
    ``BadName`` issue.
    (`#2712 <https://github.com/datalad/datalad/issues/2712>`__),
    (`#2794 <https://github.com/datalad/datalad/issues/2794>`__)
--  The progess bar for annex file transferring was unable to handle an
+-  The progress bar for annex file transferring was unable to handle an
    empty file.
    (`#2717 <https://github.com/datalad/datalad/issues/2717>`__)
 -  ``datalad add-readme`` halted when no aggregated metadata was found
@@ -6941,7 +6941,7 @@ Enhancements and new features
    potential changes, instead of performing a complete traversal of a
    dataset tree
 -  `add <http://datalad.readthedocs.io/en/latest/generated/man/datalad-add.html>`__
-   looks for changes relative to the last commited state of a dataset to
+   looks for changes relative to the last committed state of a dataset to
    discover files to add more efficiently
 -  `diff <http://datalad.readthedocs.io/en/latest/generated/man/datalad-diff.html>`__
    can now report untracked files in addition to modified files

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4839,7 +4839,7 @@ Major refactoring and deprecations since 0.12.0rc6
    ``--alternative-source`` parameter has been removed, and a
    ``clone_dataset`` function with multi-source capabilities is provided
    instead. The ``--reckless`` parameter can now take literal mode
-   labels instead of just beeing a binary flag, but backwards
+   labels instead of just being a binary flag, but backwards
    compatibility is maintained.
 
 -  The ``get_file_content`` method of ``GitRepo`` was no longer used
@@ -6261,7 +6261,7 @@ Fixes
 
 -  ``annex`` commands are now chunked assuming 50% “safety margin” on
    the maximal command line length. Should resolve crashes while
-   operating ot too many files at ones
+   operating of too many files at ones
    (`#3001 <https://github.com/datalad/datalad/issues/3001>`__)
 -  ``run`` sidecar config processing
    (`#2991 <https://github.com/datalad/datalad/issues/2991>`__)

--- a/docs/source/design/drop.rst
+++ b/docs/source/design/drop.rst
@@ -32,7 +32,7 @@ preferred content (``--what preferred-content``, `#3122
 §4 :command:`drop` prevents data loss by default (`#4750
 <https://github.com/datalad/datalad/issues/4750>`__). Like :command:`get` it
 features a ``--reckless`` "mode-switch" to disable some or all potentially slow
-safety mechnism, i.e. 'key available in sufficient number of other remotes',
+safety mechanism, i.e. 'key available in sufficient number of other remotes',
 'main or all branches pushed to remote(s)' (`#1142
 <https://github.com/datalad/datalad/issues/1142>`__), 'only check availability
 of keys associated with the worktree, but not other branches'. "Reckless
@@ -43,7 +43,7 @@ operation" can be automatic, when following a reckless :command:`get` (`#4744
 an annex as ``dead`` on removal of a repository (`#3887
 <https://github.com/datalad/datalad/issues/3887>`__).
 
-§6 Like :command:`get`, drop supports parallization `#1953
+§6 Like :command:`get`, drop supports parallelization `#1953
 <https://github.com/datalad/datalad/issues/1953>`__ 
 
 §7 `datalad drop` is not intended to be a comprehensive frontend to `git annex

--- a/docs/source/design/exception_handling.rst
+++ b/docs/source/design/exception_handling.rst
@@ -69,7 +69,7 @@ users.
 For message creation :class:`~datalad.support.exceptions.CapturedException`
 comes with a couple of ``format_*`` helper methods, its ``__str__`` provides a
 short representation of the form ``ExceptionClass(message)`` and its
-``__repr__`` the log form with a traceback tht is used for the auto-generated
+``__repr__`` the log form with a traceback that is used for the auto-generated
 log.
 
 For result dictionaries :class:`~datalad.support.exceptions.CapturedException`

--- a/tools/ci/install-annex.sh
+++ b/tools/ci/install-annex.sh
@@ -206,7 +206,7 @@ case "$scenario" in
           exit 1
         fi
         # We are interested only to get git-annex into our environment
-        # So to not interfer with "system wide" Python etc, we will add miniconda at the
+        # So to not interfere with "system wide" Python etc, we will add miniconda at the
         # end of the path
         export PATH="$PATH:${_annex_bin}";;
       conda-forge)

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     codespell~=2.0
     pylint~=2.15
 commands =
-    codespell -x .codespell-ignorelines -D- -I .codespell-ignorewords --skip "_version.py,*.pem" datalad setup.py _datalad_build_support
+    codespell datalad setup.py _datalad_build_support
     # pylinting limited set of known obvious issues only
     pylint -d all -e W1202 datalad setup.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     codespell~=2.0
     pylint~=2.15
 commands =
-    codespell datalad setup.py _datalad_build_support
+    codespell 
     # pylinting limited set of known obvious issues only
     pylint -d all -e W1202 datalad setup.py
 


### PR DESCRIPTION
I was codespell'ing a few other projects and got scared that we do not codespell our own DataLad because there were no `.codespellrc`.  apparently we did codespell but with custom CLI options in tox.ini and only the main package.  This PR makes codespelling more thorough, and in particular with us using scriv for changelogs - makes more sense now since we can then spellcheck those entries too (I checked using strace that codespell does open files under `changelog.d/`).