### PR TITLE
create-sibling: Use C.UTF-8 locale instead of C

### DIFF
--- a/changelog.d/pr-7273.md
+++ b/changelog.d/pr-7273.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- create-sibling: Use C.UTF-8 locale instead of C.  [PR #7273](https://github.com/datalad/datalad/pull/7273) (by [@nobodyinperson](https://github.com/nobodyinperson))

--- a/changelog.d/pr-7273.md
+++ b/changelog.d/pr-7273.md
@@ -1,3 +1,3 @@
 ### 🐛 Bug Fixes
 
-- create-sibling: Use C.UTF-8 locale instead of C.  [PR #7273](https://github.com/datalad/datalad/pull/7273) (by [@nobodyinperson](https://github.com/nobodyinperson))
+- create-sibling: Use C.UTF-8 locale instead of C on the remote end.  [PR #7273](https://github.com/datalad/datalad/pull/7273) (by [@nobodyinperson](https://github.com/nobodyinperson))

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -395,7 +395,9 @@ def _ls_remote_path(ssh, path):
         # yoh tried ls on mac
         # escape path explicitly with shlex.quote as 'sh' is a POSIX shell and
         # sh_quote could decide to quote Windows-style
-        ls_cmd = "LC_ALL=C; export LC_ALL; /bin/ls -A1 {}".format(shlex.quote(path))
+        # C.UTF-8 locale as opposed to C locale handles special characters (umlauts etc.)
+        # ls falls back to C locale if LC_ALL is set to unknown locale, so this should be safe.
+        ls_cmd = "LC_ALL=C.UTF-8; export LC_ALL; /bin/ls -A1 {}".format(shlex.quote(path))
         # TODO: Using sh_quote here is also flawed as it checks whether the
         # *local* machine is Windows. Doesn't help if the remote we're ssh'ing in is Windows.
         ssh_cmd = "sh -c {}".format(sh_quote(ls_cmd))


### PR DESCRIPTION
- supports special characters in filenames (like umlauts, etc.)
- `ls` seems to fall back to predictable `C` locale if `LC_ALL` is set to an unknown locale, so this should be safe.
- still: `create-sibling` currently fails silently if an umlaut is in the `--target-dir` and the remote `ls` doesn't handle it properly.

follow-up on PR #7265