### PR TITLE
sphinx: do not call build_schema

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ for setup_py_path in (opj(pardir, 'setup.py'),  # travis
                       opj(pardir, pardir, 'setup.py')):  # RTD
     if exists(setup_py_path):
         try:
-            for cmd in 'manpage', 'cfginfo', 'schema':
+            for cmd in 'manpage', 'cfginfo':
                 os.system('{} build_{}'.format(setup_py_path, cmd))
         except:
             # shut up and do your best


### PR DESCRIPTION
Follow up to https://github.com/datalad/datalad/pull/7014 which removed all metadata handling.  Without this change we get

    ❯ make -C docs html

    make: Entering directory '/home/yoh/proj/datalad/datalad-maint/docs'
    DATALAD_SPHINX_RUN=1 sphinx-build -b html -d build/doctrees  -W source build/html
    Running Sphinx v6.1.3
    running build_manpage
    running build_cfginfo
    usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: setup.py --help [cmd1 cmd2 ...]
       or: setup.py --help-commands
       or: setup.py cmd --help

    error: invalid command 'build_schema'
    ... proceeding normally

without crashing so we missed that
