### PR TITLE
BF: path from .gitmodules could not be used with source candidate template

### DIFF
--- a/changelog.d/pr-7280.md
+++ b/changelog.d/pr-7280.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- Fixed that the `get` command would fail, when subdataset source-candidate-templates where using the `path` property from `.gitmodules`.
+  Also enhance the respective documentation for the `get` command. 
+  Fixes [#7274](https://github.com/datalad/datalad/issues/7274) via
+  [PR #7280](https://github.com/datalad/datalad/pull/7280)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -787,6 +787,14 @@ class Get(Interface):
     submodule commit is available as `remote-<name>` properties, where `name`
     is the configured remote name.
 
+    Hence, such a template could be `http://example.org/datasets/{id}` or
+    `http://example.org/datasets/{path}`, where `{id}` and `{path}` would be
+    replaced by the `datalad-id` or `path` entry in the `.gitmodules` record.
+
+    If this config is committed in `.datalad/config`, a clone of a dataset can
+    look up any subdataset's URL according to such scheme(s) irrespective of
+    what URL is recorded in `.gitmodules`.
+
     Lastly, all candidates are sorted according to their cost (lower values
     first), and duplicate URLs are stripped, while preserving the first item in the
     candidate list.

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -148,6 +148,18 @@ def test_get_flexible_source_candidates_for_submodule(t=None, t2=None, t3=None):
                 dict(cost=700, name='bang', url='pre-{}-post'.format(sub.id),
                      from_config=True),
         ])
+    # template using the "regular" property `path` (`id` above is shortened from
+    # actual record `datalad-id` in .gitmodules)
+    with patch.dict(
+            'os.environ',
+            {'DATALAD_GET_SUBDATASET__SOURCE__CANDIDATE__BANG': 'somewhe.re/{path}'}):
+        eq_(f(clone, clone.subdatasets(return_type='item-or-list')),
+            [
+                dict(cost=600, name=DEFAULT_REMOTE, url=ds_subpath),
+                dict(cost=700, name='bang', url='somewhe.re/sub',
+                     from_config=True),
+        ])
+
     # now again, but have an additional remote besides origin that
     # actually has the relevant commit
     clone3 = install(

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2353,7 +2353,7 @@ class GitRepo(CoreGitRepo):
                 continue
             modprops = {'gitmodule_{}'.format(k): v
                         for k, v in props.items()
-                        if not (k.startswith('__') or k == 'path')}
+                        if not k.startswith('__')}
             # Keep as PurePosixPath for possible normalization of / in the path etc
             modpath = PurePosixPath(props['path'])
             modprops['gitmodule_name'] = name


### PR DESCRIPTION
The `path` property was treated as a special case in `GitRepo.get_submodules_` presumably to not yield redundant information, because what is returned is a dict where the path is the key and the other properties from `.gitmodules` make up the value (another dict), prefixed with `gitmodule_`.

However, actual usage from `get` via `subdatasets` suggests, that the easiest is to just yield this "redundant" record. Once as the reported property exactly like `url`, `datalad-id` and whatever else, and in addition let the path remain the key. Throughout that chain the latter gets possibly turned into an absolute path anyway (which is not what we want to report here - it's just for internal use).

Closes #7274