### PR TITLE
Reduce test environment complexity by redirecting HOME

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,6 +281,11 @@ Additionally, [tools/testing/test_README_in_docker](tools/testing/test_README_in
 be used to establish a clean docker environment (based on any NtesteuroDebian-supported
 release of Debian or Ubuntu) with all dependencies listed in README.md pre-installed.
 
+The pytest setup creates a new temporary HOME directory for each test run in order to
+minimize interaction with a user's particular configuration. Via the `GIT_HOME`
+environment variable, the test setup can be instructed to use a different particular
+(possibly persistent) HOME directory.
+
 ### CI setup
 
 We are using several continuous integration services to run our tests battery for every PR and on the default branch.

--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -92,3 +92,16 @@ def test_git_config_warning(path=None):
         ConfigManager._checked_git_identity = False
         Dataset(path).config.reload()
         assert_in("configure Git before", cml.out)
+
+
+def test_standard_setup():
+    # we define a temporary HOME setup in conftest.py to provide some
+    # isolation against a user's config. this tests whether this is happening
+    if 'GIT_HOME' in os.environ:
+        raise SkipTest("We are not using the standard temporary HOME setup")
+
+    # there is no need for something expensive. Whenever we see the custom
+    # email we set in conftest.py, we can be confident that nothing is
+    # broken fundamentally
+    from datalad import cfg
+    assert cfg['user.email'] == 'test@example.com'


### PR DESCRIPTION
Since Git 2.32 we are still creating a dedicated temporary HOME directory for running tests, but no longer actually enable it to be used beyond the global git config (i.e., `.gitconfig`).

This change rectifies that and actually reconfigures the environment to use this temporary HOME.

This should more effectively avoid "carry-over effects" between test runs, and make debugging easier (because of more similar conditions with the CI systems that are destroyed entirely after each run).

Without this change, tests could still trigger changes in a real user's `$HOME/.config` or `$HOME/.cache` that are persistent across test runs.

A simple test is included to trigger breakage in case someone is making modifications to this setup.

Closes #7297