### PR TITLE
Improve uptodateness of config reports across manager instances

### DIFF
--- a/changelog.d/pr-7301.md
+++ b/changelog.d/pr-7301.md
@@ -1,3 +1,3 @@
 ### 🐛 Bug Fixes
 
-- Improve uptodateness of config reports across manager instances.  Fixes [#7299](https://github.com/datalad/datalad/issues/7299) via [PR #7301](https://github.com/datalad/datalad/pull/7301) (by [@mih](https://github.com/mih))
+- Improve up-to-dateness of config reports across manager instances.  Fixes [#7299](https://github.com/datalad/datalad/issues/7299) via [PR #7301](https://github.com/datalad/datalad/pull/7301) (by [@mih](https://github.com/mih))

--- a/changelog.d/pr-7301.md
+++ b/changelog.d/pr-7301.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Improve uptodateness of config reports across manager instances.  Fixes [#7299](https://github.com/datalad/datalad/issues/7299) via [PR #7301](https://github.com/datalad/datalad/pull/7301) (by [@mih](https://github.com/mih))

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -904,6 +904,12 @@ class ConfigManager(object):
 
         if reload:
             self.reload()
+            # this function is only used to modify config. If any manager
+            # has modified the global scope, and is not itself the global
+            # manager, we reload that one too in order to avoid stale
+            # configuration reports
+            if scope == 'global' and id(self) != id(datalad.cfg):
+                datalad.cfg.reload()
         return out['stdout'], out['stderr']
 
     def _get_location_args(self, scope, args=None):

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -908,7 +908,7 @@ class ConfigManager(object):
             # has modified the global scope, and is not itself the global
             # manager, we reload that one too in order to avoid stale
             # configuration reports
-            if scope == 'global' and id(self) != id(datalad.cfg):
+            if scope == 'global' and self is not datalad.cfg:
                 datalad.cfg.reload()
         return out['stdout'], out['stderr']
 

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -313,7 +313,11 @@ class Dataset(object, metaclass=PathBasedFlyweight):
 
     @property
     def config(self):
-        """Get an instance of the parser for the persistent dataset configuration.
+        """Get a ``ConfigManager`` instance for a dataset's configuration
+
+        In case a dataset does not (yet) have an existing corresponding
+        repository, the returned ``ConfigManager`` is the global instance
+        that is also provided via ``datalad.cfg``.
 
         Note, that this property is evaluated every time it is used. If used
         multiple times within a function it's probably a good idea to store its
@@ -329,9 +333,10 @@ class Dataset(object, metaclass=PathBasedFlyweight):
             # if there's no repo (yet or anymore), we can't read/write config at
             # dataset level, but only at user/system level
             # However, if this was the case before as well, we don't want a new
-            # instance of ConfigManager
+            # instance of ConfigManager, but use the global one
             if self._cfg_bound in (True, None):
-                self._cfg = ConfigManager(dataset=None)
+                # for the sake of uniformity assign datalad.cfg to self._cfg
+                self._cfg = cfg
                 self._cfg_bound = False
 
         else:

--- a/datalad/tests/test_base.py
+++ b/datalad/tests/test_base.py
@@ -84,11 +84,9 @@ def test_git_config_warning(path=None):
             patch.dict('os.environ', patched_env, clear=True), \
             swallow_logs(new_level=30) as cml:
         # no configs in that empty HOME
-        from datalad.api import Dataset
         from datalad.config import ConfigManager
-
         # reach into the class and disable the "checked" flag that
         # has already been tripped before we get here
-        ConfigManager._checked_git_identity = False
-        Dataset(path).config.reload()
-        assert_in("configure Git before", cml.out)
+        with patch.object(ConfigManager, "_checked_git_identity", False):
+            ConfigManager()
+            assert_in("configure Git before", cml.out)


### PR DESCRIPTION
The issue is described in #7299. This change set contains three commits

- one documents both aspects of the issue in a test
- one reduced the amount of manager synchronization that needs to be done by no longer handing out custom `ConfigManager` instances for `Dataset`s without a repository
- one now causes an update of the global `datalad.cfg` instance, whenever any `ConfigManager` updated the `global` configuration scope

Closes #7299