### PR TITLE
BF: declare string r-aw for the \. escape

### DIFF
--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -1095,7 +1095,7 @@ class ORARemote(SpecialRemote):
             # version.
             # Lets try to find ourselves: Find remote with matching annex uuid
             response = _get_gitcfg(self.gitdir,
-                                   "^remote\..*\.annex-uuid",
+                                   r"^remote\..*\.annex-uuid",
                                    regex=True)
             response = response.splitlines() if response else []
             candidates = set()


### PR DESCRIPTION
Minor "fix".  I don't think it is even worth a changelog entry.

But also sending to to reconfirm that we observe fails of #7296 