### PR TITLE
 BF: Don't skip subds underneath paths in reckless & recursive drop

### DIFF
--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -346,6 +346,30 @@ def _drop_dataset(ds, paths, what, reckless, recursive, recursion_limit, jobs):
         return
 
     if paths is not None and paths != [ds.pathobj] and what == 'all':
+        if recursive and reckless == 'kill':
+            # check if any paths contains a subdataset, and if so, drop it to
+            # ensure its not left behind
+            for sub in ds.subdatasets(
+                    # just check for subds at the provided path
+                    path=paths,
+                    state='present',
+                    recursive=recursive,
+                    recursion_limit=recursion_limit,
+                    result_xfm='datasets',
+                    on_failure='ignore',
+                    return_type='generator',
+                    result_renderer='disabled'):
+                if sub is not None:
+                    # there is a subdataset underneath the given path
+                    yield from _drop_dataset(
+                        ds=sub,
+                        # everything underneath the subds can go
+                        paths=None,
+                        what=what,
+                        reckless=reckless,
+                        recursive=False,
+                        recursion_limit=None,
+                        jobs=jobs)
         # so we have paths constraints that prevent dropping the full dataset
         lgr.debug('Only dropping file content for given paths in %s, '
                   'allthough instruction was to drop %s', ds, what)

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -462,7 +462,8 @@ def test_kill(path=None):
 
 @with_tempfile
 def test_kill_7013(path=None):
-    """check that a recursive kill does not silently skip subds"""
+    """check that a recursive kill does not silently skip subdatasets
+     contained in subdirectory: github.com/datalad/datalad/issues/7013"""
     ds = Dataset(path).create()
     (ds.pathobj / 'subdir').mkdir()
     ds.create('subdir/subds')

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -460,6 +460,20 @@ def test_kill(path=None):
     eq_(False, ds.pathobj.exists())
 
 
+@with_tempfile
+def test_kill_7013(path=None):
+    """check that a recursive kill does not silently skip subds"""
+    ds = Dataset(path).create()
+    (ds.pathobj / 'subdir').mkdir()
+    ds.create('subdir/subds')
+    ds.create('subds')
+    res = ds.drop(path=['subds', 'subdir'], what='all',
+                  reckless='kill', recursive=True)
+    # ensure that both subdatasets were killed
+    subs = ds.subdatasets(state='present')
+    assert len(subs) == 0
+
+
 @with_tempfile()
 def test_refuse_to_drop_cwd(path=None):
     ds = Dataset(path).create()

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -465,7 +465,8 @@ def test_kill_7013(path=None):
     """check that a recursive kill does not silently skip subdatasets
      contained in subdirectory: github.com/datalad/datalad/issues/7013"""
     ds = Dataset(path).create()
-    (ds.pathobj / 'subdir').mkdir()
+    (ds.pathobj / 'subdir' / 'subsubdir' / 'subsubsubdir').mkdir(parents=True)
+    ds.create('subdir/subdir/subds')
     ds.create('subdir/subds')
     ds.create('subds')
     res = ds.drop(path=['subds', 'subdir'], what='all',


### PR DESCRIPTION
This fixes #7013.
If a drop --recursive --what all --reckless kill was provided with paths
to directories, it silently skipped killing the contained subdatasets.
The problem arises when the internal resolving of paths to datasets
determines that the provided directory path belongs to the superdataset.
Instead of then recursing into the subdirectory's potential subdatasets,
drop restrained the scope of what was to be dropped to only
'filecontent' in order to limit the drop from the determined
superdataset to the provided path as an internal safety mechanism:

    if paths is not None and paths != [ds.pathobj] and what == 'all':
        # so we have paths constraints that prevent dropping the full dataset
        lgr.debug('Only dropping file content for given paths in %s, '
                  'allthough instruction was to drop %s', ds, what)
        what = 'filecontent'
    
This change lifts this safety mechanism partially: Whenever reckless is
set to 'kill', and the provided path does not match the currently
investigated dataset, it adds a subdataset call constrained to the path
in question. If this returns a dataset, we know that this dataset is
meant to be dropped as well, as recursive (which has to be set whenever
reckless==kill) must be set, too.
