### PR TITLE
DOC: Add a "User messaging" design doc

### DIFF
--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -34,3 +34,4 @@ subsystems in DataLad.
    progress_reporting
    github_actions
    testing
+   user_messaging

--- a/docs/source/design/result_records.rst
+++ b/docs/source/design/result_records.rst
@@ -60,6 +60,7 @@ be downloaded), to ``path`` value should be determined with respect to the
 potential impact of the result on any local entity (e.g., a URL downloaded
 to a local file path, a local dataset modified based on remote information).
 
+.. _target-result-status:
 
 ``status``
 ----------

--- a/docs/source/design/user_messaging.rst
+++ b/docs/source/design/user_messaging.rst
@@ -9,7 +9,7 @@ User messaging: result records vs exceptions vs logging
 
 .. topic:: Specification scope and status
 
-   This specification provides a partial overview of the current implementation.
+   This specification provides a partial overview of the implementation goal.
 
 Motivation
 ==========
@@ -98,10 +98,9 @@ The :mod:`~datalad.ui` module provides the means to communicate information
 to the user in a user-interface-specific manner, e.g. via a console, dialog, or an iPython interface.
 Internally, all DataLad results processed by the result renderer are passed through the UI module.
 
-Therefore: in cases where existing user communication processes are not appropriate,
-developers should let explicit user communication happen through the UI module
-as it provides the flexibility to adjust to the present UI. Specifically,
-:py:func:`datalad.ui.message` allows passing a simple message via the UI module.
+Therefore: unless the criteria for logging apply, developers should let explicit user communication
+happen through the UI module as it provides the flexibility to adjust to the present UI.
+Specifically, :py:func:`datalad.ui.message` allows passing a simple message via the UI module.
 
 
 Examples

--- a/docs/source/design/user_messaging.rst
+++ b/docs/source/design/user_messaging.rst
@@ -28,8 +28,9 @@ Result records
 
 **Result records are the only return value format** for all DataLad interfaces.
 
-Constrasting with classic Python interfaces that return specific non-annotated values,
-DataLad interfaces implement message passing by yielding :ref:`result records <chap_design_result_records>`
+Contrasting with classic Python interfaces that return specific non-annotated values,
+DataLad interfaces (i.e. subclasses of :py:class:`datalad.interface.base.Interface`)
+implement message passing by yielding :ref:`result records <chap_design_result_records>`
 that are associated with individual operations. Result records are routinely inspected throughout
 the code base and their annotations are used to inform general program flow and error handling.
 
@@ -55,7 +56,7 @@ the offending action**.
 More specifically, raise an exception when:
 
 1. A DataLad interface's parameter specifications are violated
-2. An additional requirement (beyond parameters) for the successful running of a
+2. An additional requirement (beyond parameters) for the meaningful continuation of a
    command, function, or process is not met
 
 It must be made clear to the user/caller what the exact cause of the exception
@@ -106,5 +107,15 @@ as it provides the flexibility to adjust to the present UI. Specifically,
 Examples
 ========
 
-.. note::
-   TODO
+The following links point to actual code implementations of the respective user
+messaging methods:
+
+- `Result yielding`_
+- `Exception handling`_
+- `Logging`_
+- `UI messaging`_
+
+.. _Result yielding: https://github.com/datalad/datalad/blob/a8d7c63b763aacfbca15925bb1562a62b4448ea6/datalad/core/local/status.py#L402-L426
+.. _Exception handling: https://github.com/datalad/datalad/blob/a8d7c63b763aacfbca15925bb1562a62b4448ea6/datalad/core/local/status.py#L149-L150
+.. _Logging: https://github.com/datalad/datalad/blob/a8d7c63b763aacfbca15925bb1562a62b4448ea6/datalad/core/local/status.py#L158
+.. _UI messaging: https://github.com/datalad/datalad/blob/a8d7c63b763aacfbca15925bb1562a62b4448ea6/datalad/core/local/status.py#L438-L457

--- a/docs/source/design/user_messaging.rst
+++ b/docs/source/design/user_messaging.rst
@@ -65,7 +65,7 @@ results records which could be ignored or unseen by the user.
 
 .. note::
    In the case of a complex set of dependent actions it could be expensive to
-   confirm parameter violations. In such cases, initial sub-processes might already generate
+   confirm parameter violations. In such cases, initial sub-routines might already generate
    result records that have to be inspected by the caller, and it could be practically better
    to yield a result record (with ``status=[error|impossible]``) to communicate the failure.
    It would then be up to the upstream caller to decide whether to specify

--- a/docs/source/design/user_messaging.rst
+++ b/docs/source/design/user_messaging.rst
@@ -36,7 +36,7 @@ the code base and their annotations are used to inform general program flow and 
 Command calls can include an ``on_failure`` parameterization to specify how to
 proceed with a particular operation if a returned result record is
 :ref:`classified as a failure result <target-result-status>`. Command calls can
-also can include a ``result_renderer`` parameterization to explicitly enable or
+also include a ``result_renderer`` parameterization to explicitly enable or
 disable the handling and rendering of result records.
 
 Developers should be aware that external callers will use command call parameterizations

--- a/docs/source/design/user_messaging.rst
+++ b/docs/source/design/user_messaging.rst
@@ -46,6 +46,10 @@ yield meaningful result records. If, in turn, the process itself receives a set 
 records from a sub-process, these should be inspected individually in order to identify result
 values that could require re-annotation or status re-classification.
 
+For user messaging purposes, result records can also be enriched with additional human-readable
+information on the nature of the result, via the ``message`` key, and human-readable hints to
+the user, via the ``hints`` key. Both of these are rendered via the `UI Module`_.
+
 
 Exception handling
 ------------------
@@ -86,7 +90,7 @@ cannot be used to control the logic or flow of a program.
 Importantly, logging should not be the primary user messaging method for command outcomes,
 Therefore:
 
-1. No command should rely solely on logging for user communication
+1. No interface should rely solely on logging for user communication
 2. Use logging for in-progress user communication via the mechanism for :ref:`progress reporting <chap_design_progress_reporting>`
 3. Use logging to inform debugging processes
 
@@ -98,7 +102,8 @@ The :mod:`~datalad.ui` module provides the means to communicate information
 to the user in a user-interface-specific manner, e.g. via a console, dialog, or an iPython interface.
 Internally, all DataLad results processed by the result renderer are passed through the UI module.
 
-Therefore: unless the criteria for logging apply, developers should let explicit user communication
+Therefore: unless the criteria for logging apply, and unless the message to be delivered to the user
+is specified via the ``message`` key of a result record, developers should let explicit user communication
 happen through the UI module as it provides the flexibility to adjust to the present UI.
 Specifically, :py:func:`datalad.ui.message` allows passing a simple message via the UI module.
 

--- a/docs/source/design/user_messaging.rst
+++ b/docs/source/design/user_messaging.rst
@@ -34,13 +34,13 @@ implement message passing by yielding :ref:`result records <chap_design_result_r
 that are associated with individual operations. Result records are routinely inspected throughout
 the code base and their annotations are used to inform general program flow and error handling.
 
-Command calls can include an ``on_failure`` parameterization to specify how to
+DataLad interface calls can include an ``on_failure`` parameterization to specify how to
 proceed with a particular operation if a returned result record is
-:ref:`classified as a failure result <target-result-status>`. Command calls can
+:ref:`classified as a failure result <target-result-status>`. DataLad interface calls can
 also include a ``result_renderer`` parameterization to explicitly enable or
 disable the rendering of result records.
 
-Developers should be aware that external callers will use command call parameterizations
+Developers should be aware that external callers will use DataLad interface call parameterizations
 that can selectively ignore or act on result records, and that the process should therefore
 yield meaningful result records. If, in turn, the process itself receives a set of result
 records from a sub-process, these should be inspected individually in order to identify result
@@ -61,7 +61,7 @@ More specifically, raise an exception when:
 
 1. A DataLad interface's parameter specifications are violated
 2. An additional requirement (beyond parameters) for the meaningful continuation of a
-   command, function, or process is not met
+   DataLad interface, function, or process is not met
 
 It must be made clear to the user/caller what the exact cause of the exception
 is, given the context within which the user/caller triggered the action.

--- a/docs/source/design/user_messaging.rst
+++ b/docs/source/design/user_messaging.rst
@@ -37,7 +37,7 @@ Command calls can include an ``on_failure`` parameterization to specify how to
 proceed with a particular operation if a returned result record is
 :ref:`classified as a failure result <target-result-status>`. Command calls can
 also include a ``result_renderer`` parameterization to explicitly enable or
-disable the handling and rendering of result records.
+disable the rendering of result records.
 
 Developers should be aware that external callers will use command call parameterizations
 that can selectively ignore or act on result records, and that the process should therefore

--- a/docs/source/design/user_messaging.rst
+++ b/docs/source/design/user_messaging.rst
@@ -1,0 +1,124 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_design_user_messaging:
+
+*******************************************************
+User messaging: result records vs exceptions vs logging
+*******************************************************
+
+.. topic:: Specification scope and status
+
+   This specification aims to delineate the applicable contexts for using result records,
+   exceptions, logging, or other types of user messaging methods.
+
+Motivation
+==========
+
+Design specifications exist for :ref:`chap_design_result_records`,
+:ref:`chap_design_exception_handling`, :ref:`chap_design_log_levels`, and 
+:ref:`chap_design_progress_reporting`, and an ideal yet elusive goal is the consistent
+application of these methods in the applicable contexts. 
+
+From a **developer's perspective**, a specification for the proper use of specific user
+messaging methods creates a best practice standard that simplifies the implementation
+process, minimizes code duplication, and ensures consistency in the code base. This
+applies both to development in DataLad core as well as in DataLad extensions.
+
+From a **user's perspective**, it is imperative to receive the most appropriate and
+unambiguous message relating to the current context or action.
+
+Discrepancies (on the development side) and resulting ambiguity (on the user side) arise
+when the chosen user messaging methods are implemented interchangeably, inconsistently,
+within contexts that do not warrant them, and in ways that do not inform users
+appropriately.
+
+Consequently, the motivation of this specification is to delineate the applicable
+contexts for using result records, exceptions, logging, or other types of
+user messaging processes.
+
+
+Specification
+=============
+
+Result records
+--------------
+
+**Result records are the standard and preferred return value** format for all
+DataLad commands. Result records are routinely inspected throughout the code base,
+and are used to inform generic error handling, as well as particular calling commands
+on how to proceed with a specific operation.
+
+Yield result records when:
+
+1. A generic and standard way of error handling is considered useful
+2. A process can reasonably be continued despite evident errors or shortcomings in
+   its subprocesses
+
+Based on the ``status`` field of a result record, a result is categorized into
+*success* (``ok``, ``notneeded``) and *failure* (``impossible``, ``error``).
+Depending on the ``on_failure`` parameterization of a command call (``on_failure='stop'``,
+``on_failure='continue'``, or ``on_failure='ignore'``), any failure-result
+emitted by a command can lead to an ``IncompleteResultsError`` being raised on command
+exit, or a non-zero exit code on the command line.
+
+
+Exception handling
+------------------
+
+In general, **exceptions should be raised when there is no way to ignore or recover from
+the offending action**.
+
+More specifically, raise an exception when:
+
+1. A command's parameter specifications are violated
+2. An additional requirement (beyond parameters) for the successful running of a
+   command, function, or process is not met
+
+It must be made clear to the user/caller what the exact cause of the exception
+is, given the context within which the user/caller triggered the action.
+This is achieved directly via a (re)raised exception, as opposed to logging messages or
+results records which could be ignored or unseen by the user.
+
+If the relevant caller receives a set of result records, these should be inspected
+individually in order to identify result status values that could require an exception
+to be raised to the user/caller. Depending on developer-defined logic, an exception can
+then be raised with an unambiguous message that excludes internal and intermediate
+result messages.
+
+Additionally, in the case of a complex set of dependent actions it could be expensive to
+confirm parameter violations. In such cases, initial sub-processes might already generate
+result records that have to be inspected by the caller, and it could be practically better
+to yield a result record (with ``status=[error|impossible]``) to communicate the failure.
+It would then be up to the upstream caller to decide whether to specify
+``on_failure='ignore'`` or whether to inspect individual result records and turn them
+into exceptions or not.
+
+
+Logging
+-------
+
+Logging provides developers with additional means to describe steps in a process,
+so as to **allow insight into the program flow during debugging** or analysis of e.g.
+usage patterns. Logging can be turned off externally, filtered, and redirected. Apart from
+the log-level and message, it is not inspectable and cannot be used to control the logic
+or flow of a program.
+
+Importantly, logging is not a user messaging method. Therefore:
+
+1. No command should rely on logging for user communication.
+
+
+UI Module
+---------
+
+.. note::
+   TODO
+
+
+
+Examples
+========
+
+.. note::
+   TODO


### PR DESCRIPTION
This PR:
- Aims to address https://github.com/datalad/datalad/issues/6613
- Adds a design specification "User messaging: result records vs exceptions vs logging"
- This specification aims to delineate the applicable contexts for using result records,  exceptions, logging, or other types of user messaging methods.

TODOs:
- [x] @datalad/developers: all please review the suggested design, since it will set the specification for future changes to the code base (+ extensions), as well as refactoring efforts
- [x] Examples to be added to help developers apply the design specifications to their own extension code or to core contributions
- [x] A description of the UI module and its use to be added
- [x] Add changelog entry