### PR TITLE
BF: GitRepo.merge do not allow merging unrelated unconditionally

### DIFF
--- a/changelog.d/pr-7312.md
+++ b/changelog.d/pr-7312.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: GitRepo.merge do not allow merging unrelated unconditionally.  [PR #7312](https://github.com/datalad/datalad/pull/7312) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -490,6 +490,23 @@ def test_multiway_merge(path=None):
     assert_status('impossible', ds.update(merge=True, on_failure='ignore'))
 
 
+def test_unrelated_history_merge(tmp_path):
+    # prepare two independent datasets and try merging one into another
+    ds = Dataset(tmp_path / 'ds').create()
+    repo = AnnexRepo(tmp_path / 'repo')
+    f = (tmp_path / 'repo' / 'file.dat')
+    f.write_text("data")
+    repo.add(str(f))
+    repo.commit()
+    # ATM we do not do any checks and allow such addition
+    assert_status('ok', ds.siblings(action='add', name='repo', url=repo.path))
+    res = ds.update(how='merge', on_failure='ignore')
+    # ATM we do not have any special handling, just that the first result record
+    # would have that error in "message" field
+    assert_status('error', res[0])
+    assert_in('refusing to merge unrelated histories', res[0]['message'])
+
+
 # `git annex sync REMOTE` rather than `git merge TARGET` is used on an
 # adjusted branch, so we don't give an error if TARGET can't be
 # determined.

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2246,7 +2246,8 @@ class GitRepo(CoreGitRepo):
             options = []
         if msg:
             options = options + ["-m", msg]
-        options += ['--allow-unrelated-histories']
+        if allow_unrelated:
+            options += ['--allow-unrelated-histories']
         self.call_git(
             ['merge'] + options + [name],
             **kwargs


### PR DESCRIPTION
As @bpoldrack identified in
https://github.com/datalad/datalad/issues/7291#issuecomment-1456147953 the 629e575628ba8b53bf073392837c9e4b49444838 which was part of the #4650 concerning introduction of minimal git version to be 2.19.1, and not removing that condition was was combined with argument to the merge function. That commit was released within good old 0.13.4.

This change merely reintroduces "if" statement BUT unfortunately that allow_unrelated nowhere exposed in the API really, and used only once with allow_unrelated=True in some single test. So I expect some tests to fail here and most likely us needing to introduce similar option in "update" to finalize this PR.
