### PR TITLE
Update isort in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort


### PR DESCRIPTION
The older version was broken due to https://github.com/PyCQA/isort/issues/2077.