### PR TITLE
Fix example, filepath must be optional

### DIFF
--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -1113,7 +1113,7 @@ def with_tempfile(t, **tkwargs):
     ::
 
         @with_tempfile
-        def test_write(tfile):
+        def test_write(tfile=None):
             open(tfile, 'w').write('silly test')
     """
 


### PR DESCRIPTION
Driveby PR warning:  I didn't really dig into what was actually going on under the hood, so I might be totally wrong.

I was trying to use the `@with_tempfile` test decorator, but it wasn't working using the example syntax.

```
@with_tempfile                                                                                                                                                                                
    def test__singularity_version_nofile(path):
        pass 
```

Fails with the following traceback: 

```
file /home/asmacdo/devel/datalad-container/datalad_container/extractors/tests/test_metalad_container.py, line 30
  @with_tempfile
  def test__singularity_version_nofile(path):
E       fixture 'path' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, cov, doctest_namespace, monkeypatch, no_cover, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, setup_package, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```

Other usages around the codebase use it as an optional arg with default. This worked for me.