### PR TITLE
MNT: remove leftover distutils import

### DIFF
--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -13,7 +13,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 import os
-from distutils.version import LooseVersion
 from os.path import curdir
 import shlex
 from os.path import join as opj


### PR DESCRIPTION
Originally, #6839 replaced usage of distutils with Looseversion as a fix for #6307. Somehow, this one isolated import of distutils seems to have made it back. This is a quick PR to remove it.
A changelog entry shouldn't be needed for this. 