### PR TITLE
Do not render (empty) WTF report on other records

### DIFF
--- a/changelog.d/pr-7322.md
+++ b/changelog.d/pr-7322.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Do not render (empty) WTF report on other records.  [PR #7322](https://github.com/datalad/datalad/pull/7322) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/local/tests/test_wtf.py
+++ b/datalad/local/tests/test_wtf.py
@@ -135,6 +135,14 @@ def test_wtf(topdir=None):
     # check that wtf of an unavailable section yields impossible result (#6712)
     res = wtf(sections=['murkie'], on_failure='ignore')
     eq_(res[0]["status"], "impossible")
+    # and we do not get double WTF reporting, while still rendering other sections ok
+    with swallow_outputs() as cmo:
+        res = wtf(sections=['system', 'murkie', 'environment'], on_failure='ignore')
+        assert cmo.out.count('# WTF') == 1  # report produced only ones
+        # and we still have other sections requested before or after
+        assert cmo.out.count('## system') == 1
+        assert cmo.out.count('## environment') == 1
+    eq_(res[0]["status"], "impossible")
 
     # should result only in '# WTF'
     skip_if_no_module('pyperclip')

--- a/datalad/local/wtf.py
+++ b/datalad/local/wtf.py
@@ -510,7 +510,8 @@ class WTF(Interface):
     def custom_result_renderer(res, **kwargs):
         from datalad.ui import ui
         out = _render_report(res)
-        ui.message(out)
+        if out:
+            ui.message(out)
         # add any necessary hints afterwards
         maybe_show_hints(res)
 
@@ -532,6 +533,9 @@ def maybe_show_hints(res):
 
 def _render_report(res):
     report = u'# WTF'
+    if not (res.get('status') == 'ok' and 'infos' in res):
+        # some other record not intended to be rendered
+        return
 
     def _unwind(text, val, top):
         if isinstance(val, dict):


### PR DESCRIPTION
+  + strengthen the test for unavail section (will come handy for #7309 etc, doing here to avoid conflicts etc)

Otherwise we get

	❯ python -c "import datalad.api as dl; out = dl.wtf(sections=['murkie'])"
	# WTF
	# WTF
	Traceback (most recent call last):
	...
