### PR TITLE
Allow stderr for git-annex subprocess with records generator

### DIFF
--- a/changelog.d/pr-7329.md
+++ b/changelog.d/pr-7329.md
@@ -1,0 +1,6 @@
+### 🐛 Bug Fixes
+
+- Fixed a bug where changing DataLad's log level could lead to failing git-annex calls.
+  Fixes [#7328](https://github.com/datalad/datalad/issues/7328) via
+  [PR #7329](https://github.com/datalad/datalad/pull/7329)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1166,7 +1166,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         list(dict)
           List of parsed result records.
         """
-        protocol_class = GeneratorAnnexJsonNoStderrProtocol
+        protocol_class = GeneratorAnnexJsonProtocol
 
         args = args[:] + ['--json', '--json-error-messages']
         if progress:


### PR DESCRIPTION
The previous assertion that there's no stderr output to be expected is
wrong. This function is calling git-annex commands, which in turn may
involve arbitrary special remotes. DataLad can not know whether there is
anything to expect on stderr and if such would indicate an error. We
should be able to rely on git-annex returning non-zero.

Closes #7328