### PR TITLE
Fix datalad special remote error reporting

### DIFF
--- a/changelog.d/pr-7333.md
+++ b/changelog.d/pr-7333.md
@@ -1,0 +1,6 @@
+### 🐛 Bug Fixes
+
+- Fix an issue with uninformative error reporting by the datalad special remote.
+  Fixes [#7332](https://github.com/datalad/datalad/issues/7332) via
+  [PR #7333](https://github.com/datalad/datalad/pull/7333)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -52,12 +52,10 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
                 return
             except Exception as exc:
                 ce = CapturedException(exc)
-                cause = getattr(exc, '__cause__', None)
-                debug_msg = f"Failed to download {url} for key {key}: {ce}"
-                if cause:
-                    debug_msg += f' [{cause}]'
+                debug_msg = f"Failed to download {url} for key {key}: " \
+                            f"{ce.format_with_cause()}"
                 self.message(debug_msg)
-                error_causes.append(cause)
+                error_causes.append(ce.format_with_cause())
 
         error_msg = f"Failed to download from any of {len(urls)} locations"
         if error_causes:


### PR DESCRIPTION
Utilize `CapturedException.format_with_cause` instead of a custom solution, potentially leading to an error message containing an uninformative `[None]`.
This would also include more than just the first-level `__cause__` (all the way down and include potential `__context__` as well)

Closes #7332


With this change the output reported in #7332 (`Failed to download from any of 2 locations [None]`) changes to:

```
[{'action': 'get',
  'annexkey': 'MD5E-s994556226--ffc1353e08d640c7ba3154d963573732.nii.gz',
  'error_message': 'Failed to download from any of 2 locations ["Failed to '
                   'acquire lock to establish download session at '
                   '/home/<REDACTED>.cache/datalad/locks/downloader-auth.lck '
                   'in 3 attempts.Check following process: PID=2946262 '
                   'CWD=/var/lib/condor/execute/dir_2944629/tmpwoojnx0_/datadir/HCP1200/567052/MNINonLinear '
... <REDACTED>
```

So, much more telling.