### PR TITLE
Skip with_sameas_remote when rsync and annex are incompatible

### DIFF
--- a/changelog.d/pr-7342.md
+++ b/changelog.d/pr-7342.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Skip with_sameas_remote when rsync and annex are incompatible.  Fixes [#7320](https://github.com/datalad/datalad/issues/7320) via [PR #7342](https://github.com/datalad/datalad/pull/7342) (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/distribution/tests/test_siblings.py
+++ b/datalad/distribution/tests/test_siblings.py
@@ -397,7 +397,6 @@ def test_arg_missing(path=None, path2=None):
         annex_groupwanted='whatever')
 
 
-@pytest.mark.xfail(on_appveyor, reason="https://github.com/datalad/datalad/issues/7320")
 @with_sameas_remote
 @with_tempfile(mkdir=True)
 def test_sibling_enable_sameas(repo=None, clone_path=None):

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -36,7 +36,10 @@ from datalad import utils
 from datalad.consts import ARCHIVES_TEMP_DIR
 from datalad.dochelpers import borrowkwargs
 
-from datalad.support.external_versions import external_versions
+from datalad.support.external_versions import (
+    external_versions,
+    get_rsync_version,
+)
 from datalad.support.keyring_ import MemoryKeyring
 from datalad.support.network import RI
 from datalad.support.vcr_ import *
@@ -1123,6 +1126,16 @@ def with_sameas_remote(func, autoenabled=False):
         if external_versions['cmd:system-ssh'] < '7.4' and \
            '8.20200522' < external_versions['cmd:annex'] < '8.20200720':
             pytest.skip("Test known to hang")
+
+        # A fix in rsync 3.2.4 broke compatibility with older annex versions.
+        # To make things a bit more complicated, ubuntu pulled that fix into
+        # their rsync package for 3.1.3-8.
+        # Issue: gh-7320
+        rsync_ver = get_rsync_version()
+        rsync_fixed = rsync_ver >= "3.1.3-8ubuntu" or rsync_ver >= "3.2.4"
+        if rsync_fixed and external_versions['cmd:annex'] < "10.20220504":
+            pytest.skip(f"rsync {rsync_ver} and git-annex "
+                        f"{external_versions['cmd:annex']} incompatible")
 
         sr_path, repo_path = args[-2:]
         fn_args = args[:-2]


### PR DESCRIPTION
A fix in rsync 3.2.4 broke compatibility with older annex versions.
To make things a bit more complicated, ubuntu pulled that fix into
their rsync package for 3.1.3-8.
    
Adjust the test wrapper's existing skip conditions in accordingly and
reenable the test.
    
Closes #7320