### PR TITLE
Add config datalad.ui.interactive and allow non-interactive special remotes

### DIFF
--- a/changelog.d/pr-7344.md
+++ b/changelog.d/pr-7344.md
@@ -1,0 +1,9 @@
+### 🚀 Enhancements and New Features
+
+- Introduce new config `datalad.ui.interactive` to allow users to overrule detection of interactive sessions.
+  Faulty detection could lead to stalling, especially when subprocesses like git-annex special remotes where involved.
+  Furthermore, detection now only happens in the top-most datalad process and passes its result down to subprocesses, reducing the cases that need such overruling in the first place.
+  Fixes [#7345](https://github.com/datalad/datalad/issues/7345)
+  Fixes [#7349](https://github.com/datalad/datalad/issues/7349) via
+  [PR #7344](https://github.com/datalad/datalad/pull/7344)
+  (by [@bpoldrack](https://github.com/bpoldrack))

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -15,6 +15,7 @@ From an interactive Python session, import `datalad.api` and inspect its
 documentation with `help`.
 """
 
+
 if not __debug__:
     raise RuntimeError(
         'DataLad cannot run in "optimized" mode, i.e. python -O')
@@ -118,11 +119,18 @@ __runtime_mode = 'library' \
     if cfg.getbool('datalad.runtime', 'librarymode', False) \
     else 'application'
 
+
 from datalad.utils import (
     get_encoding_info,
     get_envvars_info,
     getpwd,
+    # is_interactive is imported here and supposed to be imported from here, b/c
+    # anything importing and calling it (like log and ui), must do so only after
+    # datalad.cfg has been instantiated. Therefore, ensure the correct order
+    # right here.
+    is_interactive,
 )
+
 
 from .log import lgr
 

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -22,8 +22,8 @@ from textwrap import wrap
 from datalad import __version__
 # delay?
 from datalad.support.exceptions import CapturedException
+from datalad.ui import is_interactive
 from datalad.ui.utils import get_console_width
-from datalad.utils import is_interactive
 
 from platformdirs import AppDirs
 

--- a/datalad/cli/tests/test_utils.py
+++ b/datalad/cli/tests/test_utils.py
@@ -25,7 +25,7 @@ def test_setup_exceptionhook(interactive):
         post_mortem_tb.append(tb)
 
     with patch('sys.excepthook'), \
-            patch('datalad.utils.is_interactive', lambda: interactive), \
+            patch('datalad.is_interactive', lambda: interactive), \
             patch('pdb.post_mortem', our_post_mortem):
         setup_exceptionhook()
         our_exceptionhook = sys.excepthook

--- a/datalad/cli/utils.py
+++ b/datalad/cli/utils.py
@@ -2,8 +2,7 @@
 
 import sys
 
-from datalad.log import is_interactive
-
+from datalad import is_interactive
 
 _sys_excepthook = sys.excepthook  # Just in case we ever need original one
 

--- a/datalad/customremotes/__init__.py
+++ b/datalad/customremotes/__init__.py
@@ -56,7 +56,7 @@ class SpecialRemote(_SpecialRemote):
     def __init__(self, annex):
         super(SpecialRemote, self).__init__(annex=annex)
         # instruct annex backend UI to use this remote
-        if ui.backend == 'annex':
+        if ui.backend in ['annex', 'annex-no-dialog']:
             ui.set_specialremote(self)
 
     def message(self, msg, type='debug'):

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -30,7 +30,10 @@ from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,
 )
-from datalad.utils import on_windows
+from datalad.utils import (
+    is_interactive_failsafe,
+    on_windows,
+)
 
 lgr = logging.getLogger('datalad.interface.common_cfg')
 dirs = AppDirs("datalad", "datalad.org")
@@ -639,6 +642,19 @@ _definitions = {
                     "information."}),
         'default': 10,
         'type': EnsureInt(),
+    },
+    'datalad.ui.interactive': {
+        'ui': ('question', {
+            'title': 'Datalad user interface interactivity',
+            'text': "If enabled, datalad may prompt for user input. Disable for "
+                    "non-interactive usage. If not set, datalad will attempt to "
+                    "detect whether it is running in an interactive session "
+                    "based on python's sys.__stdXXX__.isatty(). This detection "
+                    "can be wrong, though, possibly making datalad wait for "
+                    "user input, even though it is impossible to receive such "
+                    "input."}),
+        'default': is_interactive_failsafe(),
+        'type': EnsureBool(),
     },
     'datalad.save.no-message': {
         'ui': ('question', {

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -23,7 +23,8 @@ from os.path import basename, dirname
 
 from collections import defaultdict
 
-from .utils import is_interactive, optional_args
+from .utils import optional_args
+from . import is_interactive
 from .support import ansi_colors as colors
 
 __all__ = [

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -35,7 +35,10 @@ from os.path import (
 )
 
 import datalad.utils as ut
-from datalad import ssh_manager
+from datalad import (
+    is_interactive,
+    ssh_manager,
+)
 from datalad.cmd import (
     BatchedCommand,
     GitWitlessRunner,
@@ -70,7 +73,6 @@ from datalad.utils import (
     ensure_unicode,
     generate_file_chunks,
     getpwd,
-    is_interactive,
     on_windows,
     optional_args,
     path_is_subpath,

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -18,10 +18,14 @@ from unittest.mock import patch
 
 import pytest
 
-from datalad import cfg as dl_cfg
+from datalad import (
+    cfg as dl_cfg,
+    is_interactive,
+)
 from datalad.api import create
 from datalad.cmd import CommandError
 from datalad.config import (
+    anything2bool,
     ConfigManager,
     _where_to_scope,
     parse_gitconfig_dump,

--- a/datalad/ui/__init__.py
+++ b/datalad/ui/__init__.py
@@ -17,17 +17,18 @@ lgr = getLogger('datalad.ui')
 
 lgr.log(5, "Starting importing ui")
 
+from datalad import is_interactive
 from .dialog import (
     ConsoleLog,
     DialogUI,
     IPythonUI,
+    NoDialogUnderAnnexUI,
     UnderAnnexUI,
     UnderTestsUI,
     SilentConsoleLog,
     QuietConsoleLog,
 )
 from ..utils import (
-    is_interactive,
     get_ipython_shell,
 )
 
@@ -36,6 +37,7 @@ KNOWN_BACKENDS = {
     'dialog': DialogUI,
     'ipython': IPythonUI,
     'annex': UnderAnnexUI,
+    'annex-no-dialog': NoDialogUnderAnnexUI,
     'tests': UnderTestsUI,
     'tests-noninteractive': QuietConsoleLog,
     'no-progress': SilentConsoleLog,
@@ -82,6 +84,8 @@ class _UI_Switcher(object):
                     backend = 'dialog'
             else:
                 backend = 'dialog' if is_interactive() else 'no-progress'
+        if not is_interactive() and backend == 'annex':
+            backend = 'annex-no-dialog'
         self._ui = KNOWN_BACKENDS[backend]()
         lgr.debug("UI set to %s", self._ui)
         self._backend = backend

--- a/datalad/ui/tests/test_base.py
+++ b/datalad/ui/tests/test_base.py
@@ -15,15 +15,21 @@ from unittest.mock import patch
 from ...tests.utils_pytest import (
     assert_equal,
     assert_false,
+    assert_is_instance,
     assert_not_equal,
     assert_raises,
     with_testsui,
 )
-from .. import _UI_Switcher
+from .. import (
+    _UI_Switcher,
+    is_interactive
+)
 from ..dialog import (
     ConsoleLog,
     DialogUI,
     IPythonUI,
+    NoDialogUnderAnnexUI,
+    UnderAnnexUI,
 )
 
 
@@ -41,6 +47,11 @@ def test_ui_switcher():
         ui.yesno
 
     ui.set_backend('annex')
+    if is_interactive():
+        assert_is_instance(ui._ui, UnderAnnexUI)
+    else:
+        assert_is_instance(ui._ui, NoDialogUnderAnnexUI)
+    assert_equal(is_interactive(), ui._ui.is_interactive)
 
     # Let's pretend we are under IPython
     class ZMQInteractiveShell(object):

--- a/datalad/ui/tests/test_dialog.py
+++ b/datalad/ui/tests/test_dialog.py
@@ -35,6 +35,8 @@ from ..dialog import (
     ConsoleLog,
     DialogUI,
     IPythonUI,
+    NoDialogUnderAnnexUI,
+    SilentConsoleLog,
 )
 
 
@@ -169,12 +171,13 @@ def test_IPythonUI():
     assert_in('notebook', str(pbar._tqdm))
 
 
-def test_silent_question():
+@pytest.mark.parametrize("backend", [SilentConsoleLog, NoDialogUnderAnnexUI])
+def test_silent_question(backend):
     # SilentConsoleLog must not be asked questions.
     # If it is asked, RuntimeError would be thrown with details to help
     # troubleshooting WTF is happening
-    from ..dialog import SilentConsoleLog
-    ui = SilentConsoleLog()
+
+    ui = backend()
     with assert_raises(RuntimeError) as cme:
         ui.question("could you help me", title="Pretty please")
     assert_in('question: could you help me. Title: Pretty please.', str(cme.value))


### PR DESCRIPTION
- Makes `is_interactive` configurable via `datalad.ui.interactive`. Defaults to current behavior of detection via `isatty()`. The detection result is propagated to datalad subprocesses via env var (ping #7352).
- Adds a non-dialog annex backend variant and makes the UISwitcher use it, based on `is_interactive` when asked to set the `annex` backend.

Closes #7345
Closes #7349