### PR TITLE
Remove `__init__()` from `GeneratorMixIn` and `AssemblingDecoderMixIn` to convert them to "proper" mixin-classes

### DIFF
--- a/changelog.d/pr-7346.md
+++ b/changelog.d/pr-7346.md
@@ -1,3 +1,4 @@
 ### 🏠 Internal
 
 - Remove `__init__()` from `GeneratorMixIn` and `AssemblingDecoderMixIn` to convert them to "proper" mixin-classes.  [PR #7346](https://github.com/datalad/datalad/pull/7346) (by [@christian-monch](https://github.com/christian-monch))
+- Fix spelling errors and add `includeds` to codespell's ignore words list .  [PR #7346](https://github.com/datalad/datalad/pull/7346) (by [@christian-monch](https://github.com/christian-monch))

--- a/changelog.d/pr-7346.md
+++ b/changelog.d/pr-7346.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Remove `__init__()` from `GeneratorMixIn` and `AssemblingDecoderMixIn` to convert them to "proper" mixin-classes.  [PR #7346](https://github.com/datalad/datalad/pull/7346) (by [@christian-monch](https://github.com/christian-monch))

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -146,14 +146,13 @@ def _readline_rstripped(stdout):
     return stdout.readline().rstrip()
 
 
-class BatchedCommandProtocol(GeneratorMixIn, StdOutErrCapture):
+class BatchedCommandProtocol(StdOutErrCapture, GeneratorMixIn):
     def __init__(self,
                  batched_command: "BatchedCommand",
                  done_future: Any = None,
                  encoding: Optional[str] = None,
                  output_proc: Optional[Callable] = None,
                  ):
-        GeneratorMixIn.__init__(self)
         StdOutErrCapture.__init__(self, done_future, encoding)
         self.batched_command = batched_command
         self.output_proc = output_proc

--- a/datalad/dataset/gitrepo.py
+++ b/datalad/dataset/gitrepo.py
@@ -313,17 +313,12 @@ class GitRepo(RepoInterface, metaclass=PathBasedFlyweight):
         CommandError if the call exits with a non-zero status.
         """
 
-        class GeneratorStdOutErrCapture(GeneratorMixIn,
-                                        AssemblingDecoderMixIn,
-                                        StdOutErrCapture):
+        class GeneratorStdOutErrCapture(StdOutErrCapture,
+                                        GeneratorMixIn,
+                                        AssemblingDecoderMixIn):
             """
             Generator-runner protocol that captures and yields stdout and stderr.
             """
-            def __init__(self):
-                GeneratorMixIn.__init__(self)
-                AssemblingDecoderMixIn.__init__(self)
-                StdOutErrCapture.__init__(self)
-
             def pipe_data_received(self, fd, data):
                 if fd in (1, 2):
                     self.send_result((fd, self.decode(fd, data, self.encoding)))

--- a/datalad/runner/protocol.py
+++ b/datalad/runner/protocol.py
@@ -31,7 +31,7 @@ lgr = logging.getLogger('datalad.runner.protocol')
 class GeneratorMixIn:
     """ Protocol mix in that will instruct runner.run to return a generator
 
-    When this class is in the parent of a protocol given to runner.run (and
+    When this class is a parent of a protocol given to runner.run (and
     some other functions/methods) the run-method will return a `Generator`,
     which yields whatever the protocol callbacks send to the `Generator`,
     via the `send_result`-method of this class.
@@ -41,9 +41,17 @@ class GeneratorMixIn:
         for result in runner.run(...):
             # do something, for example write to stdin of the subprocess
 
+
+    Example usage to create a generator-version of teh StdOutCapture protocol:
+
+        class GeneratorStdOutCapture(StdOutCapture, GeneratorMixIn):
+            pass
     """
-    def __init__(self):
-        self.result_queue = deque()
+    @property
+    def result_queue(self):
+        if not hasattr(self, "_result_queue"):
+            self._result_queue = deque()
+        return self._result_queue
 
     def send_result(self, result):
         self.result_queue.append(result)

--- a/datalad/runner/protocol.py
+++ b/datalad/runner/protocol.py
@@ -42,10 +42,13 @@ class GeneratorMixIn:
             # do something, for example write to stdin of the subprocess
 
 
-    Example usage to create a generator-version of the StdOutCapture protocol:
+    Example for creating a generator-version of the StdOutCapture protocol, that
+    will yield tuples of (fd, data):
 
         class GeneratorStdOutCapture(StdOutCapture, GeneratorMixIn):
-            pass
+            def pipe_data_received(self, fd, data):
+                self.send_result((fd, data))
+
     """
     @property
     def result_queue(self):

--- a/datalad/runner/protocol.py
+++ b/datalad/runner/protocol.py
@@ -42,7 +42,7 @@ class GeneratorMixIn:
             # do something, for example write to stdin of the subprocess
 
 
-    Example usage to create a generator-version of teh StdOutCapture protocol:
+    Example usage to create a generator-version of the StdOutCapture protocol:
 
         class GeneratorStdOutCapture(StdOutCapture, GeneratorMixIn):
             pass

--- a/datalad/runner/tests/test_generatormixin.py
+++ b/datalad/runner/tests/test_generatormixin.py
@@ -26,19 +26,9 @@ from ..runner import WitlessRunner
 from .utils import py2cmd
 
 
-class TestProtocol(GeneratorMixIn, StdOutErrCapture):
+class TestProtocol(StdOutErrCapture, GeneratorMixIn):
 
     __test__ = False  # class is not a class of tests
-
-    def __init__(self,
-                 done_future: Any = None,
-                 encoding: Optional[str] = None) -> None:
-
-        StdOutErrCapture.__init__(
-            self,
-            done_future=done_future,
-            encoding=encoding)
-        GeneratorMixIn.__init__(self)
 
     def pipe_data_received(self, fd: int, data: bytes) -> None:
         self.send_result((fd, data.decode()))
@@ -76,11 +66,7 @@ def test_generator_mixin_runner() -> None:
 def test_post_pipe_callbacks() -> None:
     # Expect that the process_exited and connection_lost callbacks
     # are also called in a GeneratorMixIn protocol
-    class TestPostPipeProtocol(GeneratorMixIn, StdOutErrCapture):
-        def __init__(self) -> None:
-            GeneratorMixIn.__init__(self)
-            StdOutErrCapture.__init__(self)
-
+    class TestPostPipeProtocol(StdOutErrCapture, GeneratorMixIn):
         def process_exited(self) -> None:
             self.send_result(1)
             self.send_result(2)
@@ -99,11 +85,7 @@ def test_file_number_activity_detection() -> None:
     # empty output queue without active threads
     # waits for the process and progresses the generator state
     # to `_ResultGenerator.GeneratorState.process_exited`.
-    class TestFNADProtocol(GeneratorMixIn, NoCapture):
-        def __init__(self) -> None:
-            GeneratorMixIn.__init__(self)
-            NoCapture.__init__(self)
-
+    class TestFNADProtocol(NoCapture, GeneratorMixIn):
         def process_exited(self) -> None:
             self.send_result(3)
 
@@ -127,10 +109,8 @@ def test_file_number_activity_detection() -> None:
 
 
 def test_failing_process():
-    class TestProtocol(GeneratorMixIn, NoCapture):
-        def __init__(self) -> None:
-            GeneratorMixIn.__init__(self)
-            NoCapture.__init__(self)
+    class TestProtocol(NoCapture, GeneratorMixIn):
+        pass
 
     try:
         for _ in run_command(py2cmd("exit(1)"),

--- a/datalad/runner/tests/test_gitrunner.py
+++ b/datalad/runner/tests/test_gitrunner.py
@@ -9,7 +9,7 @@ from datalad.tests.utils_pytest import assert_equal
 from ..gitrunner import GitWitlessRunner
 
 
-class TestGeneratorProtocol(GeneratorMixIn, StdOutErrCapture):
+class TestGeneratorProtocol(StdOutErrCapture, GeneratorMixIn):
 
     __test__ = False  # class is not a class of tests
 

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -69,34 +69,16 @@ from .utils import py2cmd
 
 
 # Protocol classes used for a set of generator tests later
-class GenStdoutStderr(GeneratorMixIn, StdOutErrCapture):
-    def __init__(self,
-                 done_future: Any = None,
-                 encoding: Optional[str] = None) -> None:
-
-        StdOutErrCapture.__init__(
-            self,
-            done_future=done_future,
-            encoding=encoding)
-        GeneratorMixIn.__init__(self)
-
+class GenStdoutStderr(StdOutErrCapture, GeneratorMixIn):
     def timeout(self, fd: Optional[int]) -> bool:
         return True
 
 
-class GenNothing(GeneratorMixIn, NoCapture):
-    def __init__(self,
-                 done_future: Any = None,
-                 encoding: Optional[str] = None) -> None:
-
-        NoCapture.__init__(
-            self,
-            done_future=done_future,
-            encoding=encoding)
-        GeneratorMixIn.__init__(self)
+class GenNothing(NoCapture, GeneratorMixIn):
+    pass
 
 
-class GenStdoutLines(GeneratorMixIn, StdOutCapture):
+class GenStdoutLines(StdOutCapture, GeneratorMixIn):
     """A generator-based protocol yielding individual subprocess' stdout lines
 
     This is a simple implementation that is good enough for tests, i.e. with
@@ -111,7 +93,6 @@ class GenStdoutLines(GeneratorMixIn, StdOutCapture):
             self,
             done_future=done_future,
             encoding=encoding)
-        GeneratorMixIn.__init__(self)
         self.line_splitter = LineSplitter()
 
     def timeout(self, fd: Optional[int]) -> bool:

--- a/datalad/runner/tests/test_threadsafety.py
+++ b/datalad/runner/tests/test_threadsafety.py
@@ -16,18 +16,12 @@ from ..protocol import (
 from .utils import py2cmd
 
 
-class MinimalGeneratorProtocol(GeneratorMixIn, StdOutCapture):
-    def __init__(self) -> None:
-        StdOutCapture.__init__(self)
-        GeneratorMixIn.__init__(self)
+class MinimalGeneratorProtocol(StdOutCapture, GeneratorMixIn):
+    pass
 
 
-class MinimalStdOutGeneratorProtocol(GeneratorMixIn, StdOutCapture):
-    def __init__(self) -> None:
-        StdOutCapture.__init__(self)
-        GeneratorMixIn.__init__(self)
-
-    def pipe_data_received(self, fd: int, data: bytes) -> None:
+class MinimalStdOutGeneratorProtocol(StdOutCapture, GeneratorMixIn):
+    def pipe_data_received(self, fd, data) -> None:
         for line in data.decode().splitlines():
             self.send_result((fd, line))
 

--- a/datalad/runner/utils.py
+++ b/datalad/runner/utils.py
@@ -121,10 +121,13 @@ class AssemblingDecoderMixIn:
     combine it with additional data, that is delivered later,  and
     decodes the combined data.
 
-    Any un-decoded data is stored in the 'remaining_data'-attribute.
+    Any un-decoded data is stored in the 'remaining_data'-property.
     """
-    def __init__(self) -> None:
-        self.remaining_data: dict[int, bytes] = defaultdict(bytes)
+    @property
+    def remaining_data(self) -> dict[int, bytes]:
+        if not hasattr(self, "_remaining_data"):
+            self._remaining_data: dict[int, bytes] = defaultdict(bytes)
+        return self._remaining_data
 
     def decode(self,
                fd: int,

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1356,14 +1356,9 @@ class AnnexRepo(GitRepo, RepoInterface):
         ------
         See `_call_annex()` for information on Exceptions.
         """
-        class GeneratorStdOutErrCapture(GeneratorMixIn,
-                                        AssemblingDecoderMixIn,
-                                        StdOutErrCapture):
-            def __init__(self):
-                GeneratorMixIn.__init__(self)
-                AssemblingDecoderMixIn.__init__(self)
-                StdOutErrCapture.__init__(self)
-
+        class GeneratorStdOutErrCapture(StdOutErrCapture,
+                                        GeneratorMixIn,
+                                        AssemblingDecoderMixIn):
             def pipe_data_received(self, fd, data):
                 if fd == 1:
                     self.send_result(
@@ -3925,13 +3920,7 @@ class AnnexJsonProtocol(WitlessProtocol):
         super().process_exited()
 
 
-class GeneratorAnnexJsonProtocol(GeneratorMixIn, AnnexJsonProtocol):
-    def __init__(self,
-                 done_future=None,
-                 total_nbytes=None):
-        GeneratorMixIn.__init__(self)
-        AnnexJsonProtocol.__init__(self, done_future, total_nbytes)
-
+class GeneratorAnnexJsonProtocol(AnnexJsonProtocol, GeneratorMixIn):
     def add_to_output(self, json_object):
         self.send_result(json_object)
 
@@ -3940,7 +3929,6 @@ class GeneratorAnnexJsonNoStderrProtocol(GeneratorAnnexJsonProtocol):
     def __init__(self,
                  done_future=None,
                  total_nbytes=None):
-        GeneratorMixIn.__init__(self)
         AnnexJsonProtocol.__init__(self, done_future, total_nbytes)
         self.stderr_output = bytearray()
 

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -3952,7 +3952,6 @@ class AnnexInitOutput(WitlessProtocol, AssemblingDecoderMixIn):
 
     def __init__(self, done_future=None, encoding=None):
         WitlessProtocol.__init__(self, done_future, encoding)
-        AssemblingDecoderMixIn.__init__(self)
 
     def pipe_data_received(self, fd, byts):
         line = self.decode(fd, byts, self.encoding)


### PR DESCRIPTION
This PR removes the `__init__()`-methods from the classes `GeneratorMixIn` and `AssemblingDecoderMixIn` in order to convert them to proper mixin-classes.

The PR also adds `includeds`, which stands for "include dataset(s)" to the words that are ignored by codespell.
