### PR TITLE
Fix testing assumption - do create pure GitRepo superdataset and test against it

### DIFF
--- a/changelog.d/pr-7353.md
+++ b/changelog.d/pr-7353.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Fix testing assumption - do create pure GitRepo superdataset and test against it.  [PR #7353](https://github.com/datalad/datalad/pull/7353) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -45,7 +45,7 @@ def test_save_basics(path=None):
 
 
 def _test_save_all(path, repocls):
-    ds = get_convoluted_situation(path, GitRepo)
+    ds = get_convoluted_situation(path, repocls)
     orig_status = ds.repo.status(untracked='all')
     # TODO test the results when the are crafted
     res = ds.repo.save()

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1663,7 +1663,8 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
     #        'reason unknown')
     repo = repocls(path, create=True)
     # use create(force) to get an ID and config into the empty repo
-    ds = Dataset(path).create(force=True, **ckwa)
+    # Pass explicit `annex` to ensure that GitRepo does get .noannex
+    ds = Dataset(path).create(force=True, annex=repocls is AnnexRepo, **ckwa)
     # base content
     create_tree(
         ds.path,


### PR DESCRIPTION
While preparing unittest to demonstrate #7351 problem I found that the good old "parametric" test copied long time from revolution was actually not parametrized at all and thus pretty much causing running the same testing (with AnnexRepo) twice.  This PR in this shape just fixes that  and must not result in new failures.

As a result we do get differential timing for those two tests:

```
11.45s call     datalad/support/tests/test_repo_save.py::test_annexrepo_save_all
8.14s call     datalad/support/tests/test_repo_save.py::test_gitrepo_save_all
```

from original idential

```
13.86s call     datalad/support/tests/test_repo_save.py::test_gitrepo_save_all
13.83s call     datalad/support/tests/test_repo_save.py::test_annexrepo_save_all
```

;)