### PR TITLE
Fix save to not force committing into git if reference dataset is pure git (not git-annex)

### DIFF
--- a/changelog.d/pr-7355.md
+++ b/changelog.d/pr-7355.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Fix save to not force committing into git if reference dataset is pure git (not git-annex).  Fixes [#7351](https://github.com/datalad/datalad/issues/7351) via [PR #7355](https://github.com/datalad/datalad/pull/7355) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -314,7 +314,7 @@ class Save(Interface):
                         # calls
                         paths=None,
                         # prevent whining of GitRepo
-                        git=True if not hasattr(ds.repo, 'uuid')
+                        git=True if not hasattr(pds_repo, 'uuid')
                         else to_git,
                         # we are supplying the full status already, do not
                         # detect anything else

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -45,7 +45,7 @@ def test_save_basics(path=None):
 
 
 def _test_save_all(path, repocls):
-    ds = get_convoluted_situation(path, GitRepo)
+    ds = get_convoluted_situation(path, repocls)
     orig_status = ds.repo.status(untracked='all')
     # TODO test the results when the are crafted
     res = ds.repo.save()

--- a/datalad/support/tests/test_repo_save.py
+++ b/datalad/support/tests/test_repo_save.py
@@ -68,6 +68,20 @@ def _test_save_all(path, repocls):
     for f, p in saved_status.items():
         if p.get('state', None) != 'clean':
             assert f.match('subds_modified'), f
+
+    # Since we already have rich filetree, now save at dataset level
+    # recursively and introspect some known gotchas
+    resr = ds.save(recursive=True)
+
+    # File within subdataset got committed to git-annex, which was not the
+    # case for GitRepo parent https://github.com/datalad/datalad/issues/7351
+    assert_in_results(
+        resr,
+        status='ok',
+        path=str(ds.pathobj / 'subds_modified' / 'someds' / 'dirtyds' / 'file_untracked'),
+        # if key is None -- was committed to git which should have not happened!
+        key="MD5E-s14--2c320e0c56ed653384a926292647f226")
+
     return ds
 
 

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1663,7 +1663,8 @@ def get_convoluted_situation(path, repocls=AnnexRepo):
     #        'reason unknown')
     repo = repocls(path, create=True)
     # use create(force) to get an ID and config into the empty repo
-    ds = Dataset(path).create(force=True, **ckwa)
+    # Pass explicit `annex` to ensure that GitRepo does get .noannex
+    ds = Dataset(path).create(force=True, annex=repocls is AnnexRepo, **ckwa)
     # base content
     create_tree(
         ds.path,


### PR DESCRIPTION
Sits on top of #7353 to reuse existing testing setup. Actual fix is few character change in `save.py` and is present in the last non-changelog commit.

Closes #7351 