### PR TITLE
Set minimal version of typing_extensions to be 3.10.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requires = {
         'packaging',
         'patool>=1.7',
         'tqdm',
-        'typing_extensions; python_version < "3.10"',
+        'typing_extensions>=3.10.0.0; python_version < "3.10"',
         'annexremote',
         'looseversion',
     ],


### PR DESCRIPTION
For ParamSpec.  Closes #7358
