### PR TITLE
ENH(TST): add DATALAD_TESTS_CREDENTIALS=system for known credentials to be used during tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -581,6 +581,8 @@ Refer datalad/config.py for information on how to add these environment variable
   decorator may be removed/reconsidered).
 - *DATALAD_TESTS_GITCONFIG*:
   Additional content to add to `~/.gitconfig` in the tests `HOME` environment. `\n` is replaced with `os.linesep`.
+- *DATALAD_TESTS_CREDENTIALS*:
+  Set to `system` to allow for credentials possibly present in the user/system wide environment to be used.
 - *DATALAD_CMD_PROTOCOL*:
   Specifies the protocol number used by the Runner to note shell command or python function call times and allows for dry runs.
   'externals-time' for ExecutionTimeExternalsProtocol, 'time' for ExecutionTimeProtocol and 'null' for NullProtocol.

--- a/datalad/conftest.py
+++ b/datalad/conftest.py
@@ -67,15 +67,21 @@ def setup_package():
                 }
             )
         )
-        m.enter_context(
-            patch.dict(
-                os.environ,
-                {
-                    'PYTHON_KEYRING_BACKEND':
-                        'keyrings.alt.file.PlaintextKeyring'
-                }
+        cred_cfg = cfg.obtain('datalad.tests.credentials')
+        if cred_cfg == 'plaintext':
+            m.enter_context(
+                patch.dict(
+                    os.environ,
+                    {
+                        'PYTHON_KEYRING_BACKEND':
+                            'keyrings.alt.file.PlaintextKeyring'
+                    }
+                )
             )
-        )
+        elif cred_cfg == 'system':
+            pass
+        else:
+            raise ValueError(cred_cfg)
 
         def prep_tmphome():
             # re core.askPass:

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -417,6 +417,18 @@ _definitions = {
         'destination': 'global',
         'default_fn': lambda: opj(dirs.user_cache_dir, 'tests')
     },
+    'datalad.tests.credentials': {
+        'ui': ('question', {
+            'title': 'Credentials to use during tests',
+            'text': 'Which credentials should be available while running tests? If "plaintext" (default), '
+                    'a new plaintext keyring would be created in tests temporary HOME. If "system", '
+                    'no custom configuration would be passed to keyring and known to system credentials '
+                    'could be used.'
+                    }),
+        'destination': 'global',
+        'type': EnsureChoice('plaintext', 'system'),
+        'default': "plaintext"
+    },
     'datalad.log.level': {
         'ui': ('question', {
             'title': 'Used for control the verbosity of logs printed to '


### PR DESCRIPTION
We hardcoded to set it to a plain text keyring in
d8d538ae77ee8740ee2ca44e2b33f99b73a4ec3c of
https://github.com/datalad/datalad/pull/7209 to completely disable possible attempt of keyring to interact with user e.g. to establish a new keyring. That was done to address #6623 which came up during debian package building.

But the need for older behavior was realized while approaching #7340 where interactions with s3 were replaced to use boto3 but to test I needed credentials, but we were just skipping the tests since credentials were not present in that fake keyring.

With this patch I could run

  DATALAD_TESTS_CREDENTIALS=system python3 -m pytest -s -v datalad/downloaders/tests/test_s3.py

and see tests to interact with S3.  Test relating to NDA were failing since most likely NDA broke the "flow" of how to access data there.

Might be of interest to @mslw 