### PR TITLE
BF?: add more obscure parts into filename -- [] could be used in globs

### DIFF
--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1452,7 +1452,7 @@ with_parametric_batch = pytest.mark.parametrize("batch", [False, True])
 # filesystems across different OSs.  Start with the most obscure
 OBSCURE_PREFIX = os.getenv('DATALAD_TESTS_OBSCURE_PREFIX', '')
 # Those will be tried to be added to the base name if filesystem allows
-OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5', '{}', "'", '"', '<', '>']
+OBSCURE_FILENAME_PARTS = [' ', '/', '|', ';', '&', '%b5', '{}', "'", '"', '<', '>', '[', ']', '[12]']
 UNICODE_FILENAME = u"ΔЙקم๗あ"
 
 # OSX is exciting -- some I guess FS might be encoding differently from decoding


### PR DESCRIPTION
With @michael-sun we ran into some odd case with git-annex, where a file

Yarik[8910].ssh.txt  failed to be  git annex get"ed  which gave me idea to test for these extra cases in the most obscure filename case
