### PR TITLE
BF: do not include (by default) dead special remotes in get_special_remotes

### DIFF
--- a/datalad/core/distributed/clone_utils.py
+++ b/datalad/core/distributed/clone_utils.py
@@ -843,7 +843,7 @@ def _check_autoenable_special_remotes(repo: AnnexRepo):
             CapturedException(e)
             lgr.warning(
                 'Failed to process "autoenable" value %r for sibling %s in '
-                'dataset %s as bool.'
+                'dataset %s as bool. '
                 'You might need to enable it later manually and/or fix it up '
                 'to avoid this message in the future.',
                 sr_autoenable, sr_name, repo.path)

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -748,7 +748,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return remotes
 
-    def get_special_remotes(self, include_dead:bool =False) -> dict[str, dict]:
+    def get_special_remotes(self, include_dead:bool = False) -> dict[str, dict]:
         """Get info about all known (not just enabled) special remotes.
 
         The present implementation is not able to report on special remotes

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -30,6 +30,7 @@ from os.path import (
     lexists,
     normpath,
 )
+from typing import Dict
 from weakref import (
     WeakValueDictionary,
     finalize,
@@ -748,7 +749,7 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return remotes
 
-    def get_special_remotes(self, include_dead:bool = False) -> dict[str, dict]:
+    def get_special_remotes(self, include_dead:bool = False) -> Dict[str, dict]:
         """Get info about all known (not just enabled) special remotes.
 
         The present implementation is not able to report on special remotes

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -748,12 +748,17 @@ class AnnexRepo(GitRepo, RepoInterface):
         else:
             return remotes
 
-    def get_special_remotes(self):
+    def get_special_remotes(self, include_dead:bool =False) -> dict[str, dict]:
         """Get info about all known (not just enabled) special remotes.
 
         The present implementation is not able to report on special remotes
         that have only been configured in a private annex repo
         (annex.private=true).
+
+        Parameters
+        ----------
+        include_dead: bool, optional
+          Whether to include remotes announced dead.
 
         Returns
         -------
@@ -821,6 +826,21 @@ class AnnexRepo(GitRepo, RepoInterface):
                 else:
                     sr_info["name"] = name
             srs[sr_id] = sr_info
+
+        # remove dead ones
+        if not include_dead:
+            # code largely copied from drop.py:_detect_nondead_annex_at_remotes
+            # but not using -p and rather blob as above
+            try:
+                for line in self.call_git_items_(
+                        ['cat-file', 'blob', 'git-annex:trust.log']):
+                    columns = line.split()
+                    if columns[1] == 'X':
+                        # .pop if present
+                        srs.pop(columns[0], None)
+            except CommandError as e:
+                # this is not a problem per-se, probably file is not there, just log
+                CapturedException(e)
         return srs
 
     def _call_annex(self, args, files=None, jobs=None, protocol=StdOutErrCapture,


### PR DESCRIPTION
This closes #7366 but also since I did announce "datalad" to be dead for ///repronim/containers, it should address currently present across the board fail of the test `test_autoenabled_remote_msg` since `datalad` remote is no longer autoenabled and user does receive a message about that. Ideally that test should be redone on some other repo to not rely on "properties" of external to it `///repronim/containers`

NB also fixed one unrelated but close by string formatting gotcha I spotted