### PR TITLE
ENH: push - delist hint if there is only one value

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -271,6 +271,10 @@ class Push(Interface):
                     p for p in ensure_list(path) if p in sr
                 ]
             if potential_remote:
+                if len(potential_remote) == 1:
+                    # present as a single value to make hint even more human
+                    # friendly
+                    potential_remote = potential_remote[0]
                 hint = "{} matches a sibling name and not a path. " \
                       "Forgot --to?".format(potential_remote)
                 yield dict(


### PR DESCRIPTION
So instead of

	1: ['datasets.datalad.org'] matches a sibling name and not a path. Forgot --to?

user gets

    1: datasets.datalad.org matches a sibling name and not a path. Forgot --to?
