### PR TITLE
Log warning if AnnexRepo is found to have unsupported sharedRepository config

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -288,7 +288,12 @@ class AnnexRepo(GitRepo, RepoInterface):
                 self,
                 "datalad.repo.direct configuration instructs to use direct mode"
             )
-
+        shared = config.get("core.sharedrepository", "")
+        if shared.isnumeric():
+            lgr.warning(
+                "%s found to have numeric specification %r of shared mode which is not supported by git-annex. "
+                "See https://git-annex.branchable.com/todo/sharedRepository_mode_not_supported_by_git-annex/",
+                self, shared)
         self._batched = BatchedAnnexes(
             batch_size=batch_size, git_options=self._ANNEX_GIT_COMMON_OPTIONS)
 


### PR DESCRIPTION
See https://git-annex.branchable.com/todo/sharedRepository_mode_not_supported_by_git-annex/ and https://github.com/psychoinformatics-de/knowledge-base/issues/15 

now it would look like

```
❯ datalad clone ///openneuro ds --config core.sharedRepository=0600
[WARNING] AnnexRepo(/tmp/ds) found to have numeric specification '0600' of shared mode which is not supported by git-annex. See https://git-annex.branchable.com/todo/sharedRepository_mode_not_supported_by_git-annex/                                           
install(ok): /tmp/ds (dataset)
```