### PR TITLE
OPT: parse_gitconfig_dump() origin path processing

### DIFF
--- a/datalad/config.py
+++ b/datalad/config.py
@@ -32,7 +32,10 @@ from datalad.runner import (
     KillOutput,
     StdOutErrCapture,
 )
-from datalad.utils import on_windows
+from datalad.utils import (
+    getpwd,
+    on_windows,
+)
 
 lgr = logging.getLogger('datalad.config')
 
@@ -144,7 +147,7 @@ def parse_gitconfig_dump(dump, cwd=None, multi_value=True):
       For actual files a Path object is included in the set, for a git-blob
       a Git blob ID prefixed with 'blob:' is reported.
     """
-    cwd = Path.cwd() if cwd is None else Path(cwd)
+    cwd = Path(getpwd() if cwd is None else cwd)
     dct = {}
     fileset = set()
     for line in dump.split('\0'):


### PR DESCRIPTION
Instead of doing this once per config item (many), do it once per path (few). On my system with 161 config items this leads to a 6x speed-up.

Before:

```
838 µs ± 8.54 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

After:

```
142 µs ± 7.69 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Code:

```py
>>> import subprocess; dump=subprocess.run(['git', 'config', '-z', '--list', '--show-origin'], capture_output=True, text=True).stdout; from datalad.config import parse_gitconfig_dump
>>>  timeit p=parse_gitconfig_dump(dump)
```