### PR TITLE
Discontinue ConfigManager abuse for Git identity warning

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -105,9 +105,12 @@ except ImportError as e:
 # Other imports are interspersed with lgr.debug to ease troubleshooting startup
 # delays etc.
 
-from .config import ConfigManager
-
+from .config import (
+    ConfigManager,
+    warn_on_undefined_git_identity,
+)
 cfg = ConfigManager()
+warn_on_undefined_git_identity(cfg)
 
 
 # must come after config manager


### PR DESCRIPTION
DataLad warns about an undefined Git identity (user.name|email). It does that whether or not any Git identity is actually necessary or even anyhow considered. The `ConfigManager` constructor is (ab)used to trigger this warning, and a `ConfigManager` class member is used to prevent repeated warnings.

This changeset maintains the exact same behavior (warn on `datalad import`), but moves the associated code out of the `ConfigManager` class. This class is not involved in any Git repository manipulations. The warning is trigger in `datalad/__init__.py` directly, hence no protection against repeated execution is needed (Python does it automatically).