### PR TITLE
Fix failing testing on CI: Use sample S3 url DANDI archive, our copy of old .deb, specific miniconda installer for py 3.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,7 +79,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
     # Windows core tests
     - ID: WinP39core
       # ~35 min
@@ -119,7 +119,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
     - ID: WinP39a1
       # ~40min
       DTS: >
@@ -182,7 +182,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
     - ID: Ubu20P37b
       # ~25min
       PY: 3.7
@@ -198,7 +198,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
     - DATALAD_DATASETS_TOPURL=https://datasets-tests.datalad.org
     # How/which git-annex we install.  conda's build would be the fastest, but it must not
     # get ahead in PATH to not shadow travis' python
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20201007 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20201007 -m conda"
 
 matrix:
   include:
@@ -87,13 +87,13 @@ matrix:
     - PYTEST_SELECTION_OP=not
     - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
     - DATALAD_RUNTIME_PATHSPEC__FROM__FILE=always
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=10.20220525 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=10.20220525 -m conda"
   - python: 3.7
     env:
     - PYTEST_SELECTION_OP=""
     - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
     - DATALAD_RUNTIME_PATHSPEC__FROM__FILE=always
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20210310 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20210310 -m conda"
     # To test https://github.com/datalad/datalad/pull/4342 fix in case of no "not" for pytest.
     # From our testing in that PR seems to have no effect, but kept around since should not hurt.
     - LANG=bg_BG.UTF-8
@@ -158,7 +158,7 @@ matrix:
   - if: type = cron
     python: 3.7
     env:
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20200309 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20200309 -m conda"
   # Run with git's master branch rather the default one on the system.
   - if: type = cron
     python: 3.7

--- a/changelog.d/pr-7379.md
+++ b/changelog.d/pr-7379.md
@@ -1,3 +1,7 @@
 ### 🧪 Tests
 
-- Fix failing testing on CI: Use sample S3 url DANDI archive, our copy of old .deb, specific miniconda installer for py 3.7.  [PR #7379](https://github.com/datalad/datalad/pull/7379) (by [@yarikoptic](https://github.com/yarikoptic))
+- Fix failing testing on CI 
+  [PR #7379](https://github.com/datalad/datalad/pull/7379) (by [@yarikoptic](https://github.com/yarikoptic))
+  - use sample S3 url DANDI archive, 
+  - use our copy of old .deb from datasets.datalad.org instead of snapshots.d.o
+  - use specific miniconda installer for py 3.7.

--- a/changelog.d/pr-7379.md
+++ b/changelog.d/pr-7379.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Fix failing testing on CI: Use sample S3 url DANDI archive, our copy of old .deb, specific miniconda installer for py 3.7.  [PR #7379](https://github.com/datalad/datalad/pull/7379) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -96,7 +96,7 @@ def test_get_versioned_url():
 def test_get_versioned_url_anon():
     # The one without any authenticator, was crashing.
     # Also it triggered another bug about having . in the bucket name
-    url_on = "http://openneuro.org.s3.amazonaws.com/ds000001/dataset_description.json"
+    url_on = "http://dandiarchive.s3.amazonaws.com/ros3test.nwb"
     url_on_versioned = get_versioned_url(url_on)
     ok_startswith(url_on_versioned, url_on + "?versionId=")
 


### PR DESCRIPTION
In this PR I decided to absorb all fixes to get our CI green again

1. ref: https://github.com/OpenNeuroOrg/openneuro/issues/2809   - prior one stopped allowing for ListObjectVersions

I have better "control" over what happens on DANDI bucket, and this URL we share with other projects for testing ROS3 driver, so used in other projects tests

This test started to fail Apr 28th, taints other tests failures, so should be merged asap

2. Use our mirror for .deb instead of snapshots (replaces #7381)
3. Use specific version of miniconda installer (avail with fresh 0.12.0 datalad-installer)