### PR TITLE
Use our mirror instead of snapshot

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,7 +79,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
     # Windows core tests
     - ID: WinP39core
       # ~35 min
@@ -119,7 +119,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
     - ID: WinP39a1
       # ~40min
       DTS: >
@@ -182,7 +182,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
     - ID: Ubu20P37b
       # ~25min
       PY: 3.7
@@ -198,7 +198,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
     - DATALAD_DATASETS_TOPURL=https://datasets-tests.datalad.org
     # How/which git-annex we install.  conda's build would be the fastest, but it must not
     # get ahead in PATH to not shadow travis' python
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20201007 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20201007 -m conda"
 
 matrix:
   include:
@@ -87,13 +87,13 @@ matrix:
     - PYTEST_SELECTION_OP=not
     - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
     - DATALAD_RUNTIME_PATHSPEC__FROM__FILE=always
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=10.20220525 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=10.20220525 -m conda"
   - python: 3.7
     env:
     - PYTEST_SELECTION_OP=""
     - DATALAD_SSH_MULTIPLEX__CONNECTIONS=0
     - DATALAD_RUNTIME_PATHSPEC__FROM__FILE=always
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20210310 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20210310 -m conda"
     # To test https://github.com/datalad/datalad/pull/4342 fix in case of no "not" for pytest.
     # From our testing in that PR seems to have no effect, but kept around since should not hurt.
     - LANG=bg_BG.UTF-8
@@ -158,7 +158,7 @@ matrix:
   - if: type = cron
     python: 3.7
     env:
-    - _DL_ANNEX_INSTALL_SCENARIO="miniconda --python-match minor --batch git-annex=8.20200309 -m conda"
+    - _DL_ANNEX_INSTALL_SCENARIO="miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20200309 -m conda"
   # Run with git's master branch rather the default one on the system.
   - if: type = cron
     python: 3.7


### PR DESCRIPTION
Although snapshots might be more "official" and thus more "reliably present" than our own server,  snapshots. has all kinds of throttling settings which delay download or even cause it to fail:
https://github.com/datalad/datalad-installer/issues/154

although datalad-installer should retry now (after it gets upgraded within appveyor setup see https://github.com/datalad/datalad/issues/7380) if size changes, I think it would still be more robust to just get it from our server.

I also made a note in
https://github.com/datalad/datalad-installer/issues/160 so may be we gain possibility to specify multiple URLs thus to robustify.
