### PR TITLE
ENH: add a debug msg while setting/changing specialremote of UnderAnnexUI

### DIFF
--- a/datalad/ui/dialog.py
+++ b/datalad/ui/dialog.py
@@ -346,6 +346,7 @@ class UnderAnnexUI(DialogUI):
         self.specialremote = specialremote
 
     def set_specialremote(self, specialremote):
+        lgr.debug("Setting specialremote of UI %s to %s", self, specialremote)
         self.specialremote = specialremote
 
     def get_progressbar(self, *args, **kwargs):


### PR DESCRIPTION
To gather more forensics (now and possibly in the future) on how things work in relation to

   I am not sure where the UnderAnnexUI is supposed to learn about the special remote instance.

of https://github.com/datalad/datalad/issues/7382 .  With this we get

	❯ DATALAD_LOG_TRACEBACK=100 DATALAD_LOG_LEVEL=debug git annex addurl --json --json-progress s3://dandiarchive/blobs/082/8f8/0828f847-62e9-443f-8241-3960985ddab3 2>&1 | grep -e UI -e progress
	[DEBUG] git-annex-remote-datalad:8>datalad:116>main:68>ui.__init__:86  UI set to UnderAnnexUI(out=<TextIOWrapper>, specialremote=None)
	[DEBUG] git-annex-remote-datalad:8>datalad:116>main:78,53>datalad:37>customremotes.base:36>customremotes.__init__:60>dialog:349  Setting specialremote of UI UnderAnnexUI(out=<TextIOWrapper>, specialremote=None) to <datalad.customremotes.datalad.DataladAnnexCustomRemote object at 0x7fd8a81953d0>
	{"action":{"command":"addurl","file":"dandiarchive_blobs_082_8f8_0828f847-62e9-443f-8241-3960985ddab3/blobs_082_8f8_0828f847-62e9-443f-8241-3960985ddab3","input":["s3://dandiarchive/blobs/082/8f8/0828f847-62e9-443f-8241-3960985ddab3"],"note":"from datalad\nto dandiarchive_blobs_082_8f8_0828f847-62e9-443f-8241-3960985ddab3/blobs_082_8f8_0828f847-62e9-443f-8241-3960985ddab3"},"byte-progress":45129728,"percent-progress":"1.01%","total-size":4467208992}
    ...

so it gets set from `SpecialRemote.__init__`, so any subclass of `SpecialRemote` (with a proper call to `super`) should do it I guess.  
