### PR TITLE
docs: add workaround for theme issues (search not working)

### DIFF
--- a/changelog.d/pr-7385.md
+++ b/changelog.d/pr-7385.md
@@ -1,0 +1,7 @@
+### 📝 Documentation
+
+- Added a workaround for an issue with documentation theme (search
+  function not working on Read the Docs).
+  Fixes [#7374](https://github.com/datalad/datalad/issues/7374) via
+  [PR #7385](https://github.com/datalad/datalad/pull/7385)
+  (by [@mslw](https://github.com/mslw))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,8 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    # github.com/readthedocs/sphinx_rtd_theme/issues/1452 (rm next line when fixed)
+    'sphinxcontrib.jquery',
 ]
 
 # for the module reference


### PR DESCRIPTION
This is a recommended workaround for search function & flyout menu not working on Read the Docs with a combination of sphinx-6.2.1 & sphinx-rtd-theme-1.2.0. It is likely to be fixed with sphinx-rtd-theme v1.3, at which point the change can be reverted (or we can try to wait it out).

There is no additional dependency to install, since the theme already installs `sphinxcontrib.jquery`.

Fixes #7374 