### PR TITLE
ENH: minor tune up of addurls to be more tollerant and "informative"

### DIFF
--- a/changelog.d/pr-7388.md
+++ b/changelog.d/pr-7388.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- ENH: minor tune up of addurls to be more tolerant and "informative".  [PR #7388](https://github.com/datalad/datalad/pull/7388) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -305,8 +305,7 @@ class AnnexKeyParser(object):
         try:
             key = self.format_fn(self.format_string, row)
         except KeyError as exc:
-            ce = CapturedException(exc)
-            lgr.debug("Row missing fields for --key: %s", ce)
+            lgr.warning("Row missing fields for --key: %s", exc)
             return {}
 
         if key == self.empty:

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -779,8 +779,13 @@ def extract(rows, colidx_to_name=None,
     info_fns = []
     if formats_meta:
         def set_meta_args(info, row):
-            info["meta_args"] = clean_meta_args(fmt(row)
-                                                for fmt in formats_meta)
+            formatted = []
+            for fmt in formats_meta:
+                try:
+                    formatted.append(fmt(row))
+                except KeyError as exc:
+                    lgr.warning("Row is missing a key to add a metadata field: %s", exc)
+            info["meta_args"] = clean_meta_args(formatted)
         info_fns.append(set_meta_args)
     if key:
         key_parser = AnnexKeyParser(fmt.format, key)


### PR DESCRIPTION
I was trying addurls on a file from https://gpt4all.io/models/models.json  . 

First

```
datalad  addurls -t json --key 'et:MD5-s{size}--{md5sum}' models.json 'https://gpt4all.io/models/{filename}' '{filename}'
```

was just crashing since not all records have some fields.  I could have excluded them using `-x` regex, but I thought it would be suboptimal since that would result in not recording some metadata. So I decided just to issue a warning and proceed adding all other fields which have metadata present.

Then, surprisingly the `--key` simply had no effect and no warning of any kind was issued.  It was since I used `size` instead of `filesize`.  DEBUG level message was likely there but IMHO it is too much of a user mistake to just silently ignore since IMHO it is most likely a misspecification of the `--key`. So I decided to issue a warning there too. And I did not really see the point for CapturedException there, so removed that part.