### PR TITLE
Honor the copy parameter _get_adjusted_env()

### DIFF
--- a/changelog.d/pr-7399.md
+++ b/changelog.d/pr-7399.md
@@ -1,0 +1,5 @@
+### 🏠 Internal
+
+- Copy an adjusted environment only if requested to do so.
+  [PR #7399](https://github.com/datalad/datalad/pull/7399)
+  (by [@christian-monch](https://github.com/christian-monch))

--- a/datalad/runner/runner.py
+++ b/datalad/runner/runner.py
@@ -63,14 +63,33 @@ class WitlessRunner(object):
     def _get_adjusted_env(self,
                           env: dict | None = None,
                           cwd: str | PathLike | None = None,
-                          copy: bool = True):
-        """Return an adjusted copy of an execution environment
+                          copy: bool = True
+                          ) -> dict | None:
+        """Return an adjusted execution environment
 
-        Or return an unaltered copy of the environment, if no adjustments
-        need to be made.
+        This method adjusts the environment provided in `env` to
+        reflect the configuration of the runner. It returns
+        an altered copy or an altered original, if `copy` is
+        `False`.
+
+        Parameters
+        ----------
+        env: dict
+          The environment that should be adjusted
+
+        cwd: str | PathLike | None (default: None)
+          If not None, the content of this variable will be
+          put into the environment variable 'PWD'.
+
+        copy: bool (default: True)
+          if True, the returned environment will be a
+          copy of `env`. Else the passed in environment
+          is modified. Note: if `env` is not `None` and
+          `cwd` is `None` and `copy` is `True`, the
+          returned dictionary is still a copy
         """
-        env = env.copy() if env else None
-        if cwd and env is not None:
+        env = env.copy() if env is not None and copy is True else env
+        if cwd is not None and env is not None:
             # If an environment and 'cwd' is provided, ensure the 'PWD' in the
             # environment is set to the value of 'cwd'.
             env['PWD'] = str(cwd)

--- a/datalad/runner/runner.py
+++ b/datalad/runner/runner.py
@@ -74,7 +74,7 @@ class WitlessRunner(object):
 
         Parameters
         ----------
-        env: dict
+        env
           The environment that should be adjusted
 
         cwd: str | PathLike | None (default: None)

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -353,14 +353,15 @@ def test_env_copying() -> None:
                 if original_env is None:
                     assert adjusted_env is None
                 else:
+                    assert adjusted_env is not None
                     if do_copy is True:
                         assert adjusted_env is not original_env
                     else:
                         assert adjusted_env is original_env
                     if cwd is None:
-                        assert 'PWD' not in (adjusted_env or {})
+                        assert 'PWD' not in adjusted_env
                     else:
-                        assert 'PWD' in (adjusted_env or {})
+                        assert 'PWD' in adjusted_env
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -336,6 +336,33 @@ def test_path_to_str_conversion() -> None:
     assert str(test_path) == adjusted_env['PWD']
 
 
+def test_env_copying() -> None:
+    # Regression test to ensure environments are only copied
+    # if `copy=True` is given to `Runner._get_adjusted_env.`
+    # Test also for path adjustments, if not-`None` `pwd`-value
+    # is given to `Runner._get_adjusted_env`.
+    runner = Runner()
+    for original_env in (None, dict(some_key='value')):
+        for cwd in (None, Path('a/b/c')):
+            for do_copy in (True, False):
+                adjusted_env = runner._get_adjusted_env(
+                    cwd=cwd,
+                    env=original_env,
+                    copy=do_copy
+                )
+                if original_env is None:
+                    assert adjusted_env is None
+                else:
+                    if do_copy is True:
+                        assert adjusted_env is not original_env
+                    else:
+                        assert adjusted_env is original_env
+                    if cwd is None:
+                        assert 'PWD' not in adjusted_env
+                    else:
+                        assert 'PWD' in adjusted_env
+
+
 @with_tempfile(mkdir=True)
 def test_environment(temp_dir_path: str = "") -> None:
     # Ensure that the subprocess sees a string in `$PWD`, even if a Path-object

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -358,9 +358,9 @@ def test_env_copying() -> None:
                     else:
                         assert adjusted_env is original_env
                     if cwd is None:
-                        assert 'PWD' not in adjusted_env
+                        assert 'PWD' not in (adjusted_env or {})
                     else:
-                        assert 'PWD' in adjusted_env
+                        assert 'PWD' in (adjusted_env or {})
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -332,6 +332,7 @@ def test_path_to_str_conversion() -> None:
         cwd=test_path,
         env=dict(some_key="value")
     )
+    assert adjusted_env is not None
     assert str(test_path) == adjusted_env['PWD']
 
 


### PR DESCRIPTION
This PR modifies `WitlessRunner._get_adjusted_env()` to honor the `copy`-parameter and perform a copy only if `copy` is `True`.
In addition, it improves the docstring of the method.
