### PR TITLE
Address gitlab API special character restrictions

### DIFF
--- a/changelog.d/pr-7407.md
+++ b/changelog.d/pr-7407.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- Address gitlab API special character restrictions.  [PR #7407](https://github.com/datalad/datalad/pull/7407) (by [@jsheunis](https://github.com/jsheunis))

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -407,9 +407,9 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
             "Unknown site access '{}' given or configured, "
             "known ones are: {}".format(access, known_access_labels))
 
-    pathsep = ds.config.get("datalad.gitlab-default-pathseparator", None) or "-"
+    pathsep = ds.config.get("datalad.gitlab-default-pathseparator", "-")
     project_stub = \
-        ds.config.get("datalad.gitlab-default-projectname", None) or "project"
+        ds.config.get("datalad.gitlab-default-projectname", "project")
     project_var = 'datalad.gitlab-{}-project'.format(site)
     process_root = refds == ds
     if project is None:

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -79,19 +79,22 @@ class CreateSiblingGitlab(Interface):
 
     "hierarchy"
       Each dataset is placed into its own group, and the actual GitLab
-      project for a dataset is put in a project named "_repo_" inside
-      this group. Using this layout, arbitrarily deep hierarchies of
+      project for a dataset is put in a project named "project" inside
+      this group. This project name is configurable (see Configuration).
+      Using this layout, arbitrarily deep hierarchies of
       nested datasets can be represented, while the hierarchical structure
       is reflected in the project path. This is the default layout, if
       no project path is specified.
     "flat"
       All datasets are placed in the same group. The name of a project
       is its relative path within the root dataset, with all path separator
-      characters replaced by '--'.
+      characters replaced by '-'. This path separator is configurable
+      (see Configuration).
     "collection"
-      This is a hybrid layout, where the root dataset is placed in a "_repo_"
+      This is a hybrid layout, where the root dataset is placed in a "project"
       project inside a group, and all nested subdatasets are represented
-      inside the group using a "flat" layout.
+      inside the group using a "flat" layout. The project name is configurable
+      (see Configuration).
 
     GitLab cannot host dataset content. However, in combination with
     other data sources (and siblings), publishing a dataset to GitLab can
@@ -100,7 +103,7 @@ class CreateSiblingGitlab(Interface):
 
     *Configuration*
 
-    All configuration switches and options for GitLab sibling creation can
+    Many configuration switches and options for GitLab sibling creation can
     be provided arguments to the command. However, it is also possible to
     specify a particular setup in a dataset's configuration. This is
     particularly important when managing large collections of datasets.
@@ -119,6 +122,15 @@ class CreateSiblingGitlab(Interface):
         Project location/path used for a datasets at GitLab instance
         SITENAME (see --project). Configuring this is useful for deriving
         project paths for subdatasets, relative to superdataset.
+    "datalad.gitlab-default-projectname"
+        The hierarchy and collection layouts publish (sub)datasets as projects
+        with a custom name. The default name "project" can be overridden with
+        this configuration.
+    "datalad.gitlab-default-pathseparator"
+        The flat and collection layout represent subdatasets with project names
+        that correspond to the path, with the regular path separator replaced
+        with a "-": superdataset-subdataset. This configuration can override
+        this default separator.
 
     This command can be configured with
     "datalad.create-sibling-ghlike.extra-remote-settings.NETLOC.KEY=VALUE" in

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -104,7 +104,7 @@ class CreateSiblingGitlab(Interface):
     *Configuration*
 
     Many configuration switches and options for GitLab sibling creation can
-    be provided arguments to the command. However, it is also possible to
+    be provided as arguments to the command. However, it is also possible to
     specify a particular setup in a dataset's configuration. This is
     particularly important when managing large collections of datasets.
     Configuration options are:
@@ -119,17 +119,17 @@ class CreateSiblingGitlab(Interface):
     "datalad.gitlab-SITENAME-access"
         Access method used for the GitLab instance SITENAME (see --access)
     "datalad.gitlab-SITENAME-project"
-        Project location/path used for a datasets at GitLab instance
+        Project location/path used for datasets at GitLab instance
         SITENAME (see --project). Configuring this is useful for deriving
-        project paths for subdatasets, relative to superdataset.
+        project paths for subdatasets, relative to a superdataset.
     "datalad.gitlab-default-projectname"
-        The hierarchy and collection layouts publish (sub)datasets as projects
+        The hierarchy and collection layouts publish (super)datasets as projects
         with a custom name. The default name "project" can be overridden with
         this configuration.
     "datalad.gitlab-default-pathseparator"
         The flat and collection layout represent subdatasets with project names
-        that correspond to the path, with the regular path separator replaced
-        with a "-": superdataset-subdataset. This configuration can override
+        that correspond to their path within the superdataset, with the regular path separator replaced
+        with a "-": superdataset-subdataset. This configuration can be used to override
         this default separator.
 
     This command can be configured with

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -395,6 +395,9 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
             "Unknown site access '{}' given or configured, "
             "known ones are: {}".format(access, known_access_labels))
 
+    pathsep = ds.config.get("datalad.gitlab-default-pathseparator", None) or "-"
+    project_stub = \
+        ds.config.get("datalad.gitlab-default-projectname", None) or "project"
     project_var = 'datalad.gitlab-{}-project'.format(site)
     process_root = refds == ds
     if project is None:
@@ -403,7 +406,7 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
 
     if project and process_root and layout == 'collection':
         # the root of a collection
-        project = '{}/repo'.format(project)
+        project = f'{project}/{project_stub}'
     elif project is None and not process_root:
         # check if we can build one from the refds config
         ref_project = refds.config.get(project_var, None)
@@ -412,15 +415,15 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
             # the reference dataset configuration
             rproject = ds.pathobj.relative_to(refds.pathobj).as_posix()
             if layout == 'hierarchy':
-                project = '{}/{}/repo'.format(ref_project, rproject)
+                project = f'{ref_project}/{rproject}/{project_stub}'
             elif layout == 'collection':
                 project = '{}/{}'.format(
                     ref_project,
-                    rproject.replace('/', '-'))
+                    rproject.replace('/', pathsep))
             else:
                 project = '{}-{}'.format(
                     ref_project,
-                    rproject.replace('/', '-'))
+                    rproject.replace('/', pathsep))
 
     if project is None:
         yield dict(

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -433,8 +433,9 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
                     ref_project,
                     rproject.replace('/', pathsep))
             else:
-                project = '{}-{}'.format(
+                project = '{}{}{}'.format(
                     ref_project,
+                    pathsep,
                     rproject.replace('/', pathsep))
 
     if project is None:

--- a/datalad/distributed/create_sibling_gitlab.py
+++ b/datalad/distributed/create_sibling_gitlab.py
@@ -403,7 +403,7 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
 
     if project and process_root and layout == 'collection':
         # the root of a collection
-        project = '{}/_repo_'.format(project)
+        project = '{}/repo'.format(project)
     elif project is None and not process_root:
         # check if we can build one from the refds config
         ref_project = refds.config.get(project_var, None)
@@ -412,15 +412,15 @@ def _proc_dataset(refds, ds, site, project, remotename, layout, existing,
             # the reference dataset configuration
             rproject = ds.pathobj.relative_to(refds.pathobj).as_posix()
             if layout == 'hierarchy':
-                project = '{}/{}/_repo_'.format(ref_project, rproject)
+                project = '{}/{}/repo'.format(ref_project, rproject)
             elif layout == 'collection':
                 project = '{}/{}'.format(
                     ref_project,
-                    rproject.replace('/', '--'))
+                    rproject.replace('/', '-'))
             else:
-                project = '{}--{}'.format(
+                project = '{}-{}'.format(
                     ref_project,
-                    rproject.replace('/', '--'))
+                    rproject.replace('/', '-'))
 
     if project is None:
         yield dict(

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -40,7 +40,7 @@ def _get_nested_collections(path):
     return dict(
         root=ds,
         c1=c1,
-        c1s1=c1s2,
+        c1s1=c1s1,
         c1s2=c1s2,
         c2=c2,
         c2s1=c2s1,

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -265,6 +265,55 @@ def test_dryrun(path=None):
             'secret-subdir-collection1-sub2',
         ],
     )
+    # test that the configurations work
+    ctlg['root'].config.set("datalad.gitlab-default-projectname", 'myownname')
+    ctlg['c1s1'].config.set("datalad.gitlab-default-pathseparator", '+')
+    #import pdb; pdb.set_trace()
+    res = ctlg['root'].create_sibling_gitlab(
+        recursive=True, layout='flat', dry_run=True)
+    assert_result_count(res, len(ctlg))
+    eq_(
+        sorted(r['project'] for r in res),
+        [
+            'secret',
+            'secret-collection2',
+            'secret-collection2-sub1',
+            'secret-collection2-sub1-deepsub1',
+            'secret-subdir+collection1+sub1',
+            'secret-subdir-collection1',
+            'secret-subdir-collection1-sub2',
+        ],
+    )
+    res = ctlg['root'].create_sibling_gitlab(
+        recursive=True, layout='collection', dry_run=True)
+    assert_result_count(res, len(ctlg))
+    eq_(
+        sorted(r['project'] for r in res),
+        [
+            'secret/collection2',
+            'secret/collection2-sub1',
+            'secret/collection2-sub1-deepsub1',
+            'secret/myownname',
+            'secret/subdir+collection1+sub1',
+            'secret/subdir-collection1',
+            'secret/subdir-collection1-sub2',
+        ],
+    )
+    ctlg['c1s1'].config.set("datalad.gitlab-default-projectname", 'myownname')
+    res = ctlg['root'].create_sibling_gitlab(recursive=True, dry_run=True)
+    assert_result_count(res, len(ctlg))
+    eq_(
+        sorted(r['project'] for r in res),
+        [
+            'secret',
+            'secret/collection2/project',
+            'secret/collection2/sub1/deepsub1/project',
+            'secret/collection2/sub1/project',
+            'secret/subdir/collection1/project',
+            'secret/subdir/collection1/sub1/myownname',
+            'secret/subdir/collection1/sub2/project',
+        ]
+    )
 
 
 class _FakeGitLab(object):

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -276,10 +276,10 @@ def test_dryrun(path=None):
         sorted(r['project'] for r in res),
         [
             'secret',
+            'secret+subdir+collection1+sub1',
             'secret-collection2',
             'secret-collection2-sub1',
             'secret-collection2-sub1-deepsub1',
-            'secret-subdir+collection1+sub1',
             'secret-subdir-collection1',
             'secret-subdir-collection1-sub2',
         ],

--- a/datalad/distributed/tests/test_create_sibling_gitlab.py
+++ b/datalad/distributed/tests/test_create_sibling_gitlab.py
@@ -160,10 +160,10 @@ def test_dryrun(path=None):
         site='theone', sibling='dieter',
         # hierarchical setup: directories becomes groups
         # which implies each dataset is in its own group
-        # project itself is placed at '_repo'_ to give URLs like
-        # http://site/dir/dir/dir/_repo_.git
+        # project itself is placed at 'project' to give URLs like
+        # http://site/dir/dir/dir/project.git
         # as a balance between readability and name conflict minimization
-        project='secret/{}/_repo_'.format(
+        project='secret/{}/project'.format(
             ctlg['c1'].pathobj.relative_to(ctlg['root'].pathobj).as_posix()),
     )
     # we get the same result with an explicit layout request
@@ -176,27 +176,27 @@ def test_dryrun(path=None):
         path='subdir', dry_run=True)
     assert_result_count(
         res, 1, path=ctlg['c1'].path, type='dataset', status='ok',
-        # http://site/group/dir--dir--dir--name.git
+        # http://site/group/dir-dir-dir-name.git
         project='secret/{}'.format(str(
             ctlg['c1'].pathobj.relative_to(ctlg['root'].pathobj)).replace(
-                os.sep, '--')),
+                os.sep, '-')),
     )
     # make sure the reference dataset does not conflict with its group in this
     # case
     res = ctlg['root'].create_sibling_gitlab(dry_run=True)
     assert_result_count(
         res, 1, path=ctlg['root'].path, type='dataset', status='ok',
-        project='secret/_repo_')
+        project='secret/project')
     # "flat" does GitHub-style
     ctlg['root'].config.set('datalad.gitlab-theone-layout', 'flat')
     res = ctlg['root'].create_sibling_gitlab(
         path='subdir', dry_run=True)
     assert_result_count(
         res, 1, path=ctlg['c1'].path, type='dataset', status='ok',
-        # http://site/base--dir--dir--dir--name.git
-        project='secret--{}'.format(str(
+        # http://site/base-dir-dir-dir-name.git
+        project='secret-{}'.format(str(
             ctlg['c1'].pathobj.relative_to(ctlg['root'].pathobj)).replace(
-                os.sep, '--')),
+                os.sep, '-')),
     )
 
     # the results do not depend on explicitly given datasets, if we just enter
@@ -227,12 +227,12 @@ def test_dryrun(path=None):
         sorted(r['project'] for r in res),
         [
             'secret',
-            'secret/collection2/_repo_',
-            'secret/collection2/sub1/_repo_',
-            'secret/collection2/sub1/deepsub1/_repo_',
-            'secret/subdir/collection1/_repo_',
-            'secret/subdir/collection1/sub1/_repo_',
-            'secret/subdir/collection1/sub2/_repo_',
+            'secret/collection2/project',
+            'secret/collection2/sub1/deepsub1/project',
+            'secret/collection2/sub1/project',
+            'secret/subdir/collection1/project',
+            'secret/subdir/collection1/sub1/project',
+            'secret/subdir/collection1/sub2/project',
         ]
     )
     res = ctlg['root'].create_sibling_gitlab(
@@ -241,13 +241,13 @@ def test_dryrun(path=None):
     eq_(
         sorted(r['project'] for r in res),
         [
-            'secret/_repo_',
             'secret/collection2',
-            'secret/collection2--sub1',
-            'secret/collection2--sub1--deepsub1',
-            'secret/subdir--collection1',
-            'secret/subdir--collection1--sub1',
-            'secret/subdir--collection1--sub2',
+            'secret/collection2-sub1',
+            'secret/collection2-sub1-deepsub1',
+            'secret/project',
+            'secret/subdir-collection1',
+            'secret/subdir-collection1-sub1',
+            'secret/subdir-collection1-sub2',
         ],
     )
     res = ctlg['root'].create_sibling_gitlab(
@@ -257,12 +257,12 @@ def test_dryrun(path=None):
         sorted(r['project'] for r in res),
         [
             'secret',
-            'secret--collection2',
-            'secret--collection2--sub1',
-            'secret--collection2--sub1--deepsub1',
-            'secret--subdir--collection1',
-            'secret--subdir--collection1--sub1',
-            'secret--subdir--collection1--sub2',
+            'secret-collection2',
+            'secret-collection2-sub1',
+            'secret-collection2-sub1-deepsub1',
+            'secret-subdir-collection1',
+            'secret-subdir-collection1-sub1',
+            'secret-subdir-collection1-sub2',
         ],
     )
 


### PR DESCRIPTION
The main change is from `_repo_` to `repo`. This PR serves as a space to brainstorm an effective solution.

Closes #6681