### PR TITLE
Boost python to 3.8 during extensions testing

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -39,10 +39,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install DataLad and dependencies
       run: |

--- a/changelog.d/pr-7413.md
+++ b/changelog.d/pr-7413.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Boost python to 3.8 during extensions testing.  [PR #7413](https://github.com/datalad/datalad/pull/7413) (by [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
Currently testing of datalad-next is failing (and has been for awhile) due to

	AttributeError: module 'gzip' has no attribute 'BadGzipFile'

and that one was added in 3.8.  I have not researched how come appveyor with 3.7 testing in datalad-next is not running into this.  As 3.7 is about to EOL, I think it is ok to start testing downstream extensions with the next 3.8.
