### PR TITLE
Do not map (leave as is) trailing / or \ in github URLs.

### DIFF
--- a/changelog.d/pr-7418.md
+++ b/changelog.d/pr-7418.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Do not map (leave as is) trailing / or \ in github URLs.  [PR #7418](https://github.com/datalad/datalad/pull/7418) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1727,6 +1727,10 @@ def test_url_mapping_specs():
             ({},
              'https://github.com/datalad/testrepo_gh/sub _1',
              'https://github.com/datalad/testrepo_gh-sub__1'),
+            # trailing slash is not mapped
+            ({},
+             'https://github.com/datalad/testrepo_gh/sub _1/',
+             'https://github.com/datalad/testrepo_gh-sub__1/'),
             # and on deep subdataset too
             ({},
              'https://github.com/datalad/testrepo_gh/sub _1/d/sub_-  1',

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -180,7 +180,7 @@ _definitions = {
             # take any github project URL apart into <org>###<identifier>
             r',https?://github.com/([^/]+)/(.*)$,\1###\2',
             # replace any (back)slashes with a single dash
-            r',[/\\]+,-',
+            r',[/\\]+(?!$),-',
             # replace any whitespace (include urlquoted variant)
             # with a single underscore
             r',\s+|(%2520)+|(%20)+,_',


### PR DESCRIPTION
Otherwise we would fail to clone (git would start asking for password since there is no such repo) github repositories while including trailing / which should be perfectly fine and which git handles just fine:

	❯ datalad -l debug clone https://github.com/datasets-mila/datasets--robotcar/
	[DEBUG  ] Command line args 1st pass for DataLad 0.18.4+21.g560dc910e. Parsed: Namespace() Unparsed: ['clone', 'https://github.com/datasets-mila/datasets--robotcar/']
	[DEBUG  ] Building doc for <class 'datalad.core.distributed.clone.Clone'>
	[DEBUG  ] Parsing known args among ['/home/yoh/proj/datalad/datalad-maint/venvs/dev3/bin/datalad', '-l', 'debug', 'clone', 'https://github.com/datasets-mila/datasets--robotcar/']
	[DEBUG  ] Determined class of decorated function: <class 'datalad.core.distributed.clone.Clone'>
	[DEBUG  ] Determined clone target path from source
	[DEBUG  ] Resolved clone target path to: '/tmp/datasets--robotcar'
	[DEBUG  ] Apply ephemeral patch to clone.py:_pre_annex_init_processing_
	[DEBUG  ] Apply ephemeral patch to clone.py:_post_annex_init_processing_
	[DEBUG  ] Apply RIA patch to clone.py:_post_git_init_processing_
	[DEBUG  ] Apply RIA patch to clone.py:_pre_final_processing_
	[DEBUG  ] URL substitution: 'https://github.com/datasets-mila/datasets--robotcar/' -> 'https://github.com/datasets-mila/datasets--robotcar-'
	[DEBUG  ] Git clone from https://github.com/datasets-mila/datasets--robotcar- to /tmp/datasets--robotcar
	[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', 'clone', '--progress', 'https://github.com/datasets-mila/datasets--robotcar-', '/tmp/datasets--robotcar'] (protocol_class=GitProgress) (cwd=None)
	[DEBUG  ] Non-progress stderr: b"Cloning into '/tmp/datasets--robotcar'...\n"
	Cloning:  50%|███████████████████████████████████████████████                                               | 1.00/2.00 [00:00<00:00, 534 candidates/s]Username for 'https://github.com':

The fix consists of adding negative lookahead that the final (back)slash is not at the end of the string.  I was not sure why (how do we get one) we are to map any backslash so did not introduce any special handling for it, so it just follows the same rule -- the last one would not be mapped.
