### PR TITLE
RF: Provide typing.Self verbatim for older pythons to avoid needing more recent version of typing_extensions

### DIFF
--- a/datalad/typing.py
+++ b/datalad/typing.py
@@ -8,12 +8,32 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import sys
+import typing
 from typing import TypeVar
 
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
-    from typing_extensions import Self
+    # needs typing_extensions >= 4
+    # from typing_extensions import Self
+
+    # to make packagers life easier - just duplicating verbatim
+    @typing._SpecialForm
+    def Self(self, params):
+        """Used to spell the type of "self" in classes.
+
+        Example::
+
+          from typing import Self
+
+          class ReturnsSelf:
+              def parse(self, data: bytes) -> Self:
+                  ...
+                  return self
+
+        """
+
+        raise TypeError(f"{self} is not subscriptable")
 
 if sys.version_info >= (3, 10):
     from typing import (

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requires = {
         'packaging',
         'patool>=1.7',
         'tqdm',
-        'typing_extensions>=4.0.0; python_version < "3.11"',
+        'typing_extensions>=3.10.0.0; python_version < "3.10"',
         'annexremote',
         'looseversion',
     ],


### PR DESCRIPTION
Debian stable (soon oldstable) has only 3.10.0.2 ATM, and backporting shows some challenges.

Closes #7419 
