### PR TITLE
Skip test_system_ssh_version if no ssh found + split parsing into separate test

### DIFF
--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -100,8 +100,7 @@ def test_runner_stdout_capture() -> None:
     ok_(not res['stderr'])
 
 
-@with_tempfile(mkdir=True)
-def test_runner_failure(dir_: str = "") -> None:
+def test_runner_failure() -> None:
     runner = Runner()
     with assert_raises(CommandError) as cme:
         runner.run(

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -108,6 +108,10 @@ def test_runner_failure() -> None:
         )
     eq_(53, cme.value.code)
 
+    # but we bubble up FileNotFoundError if executable does not exist at all
+    with assert_raises(FileNotFoundError) as cme:
+        runner.run(['dne1l2k3j4'])  # be damned the one who makes such a command
+
 
 @with_tempfile(mkdir=True)
 def test_runner_fix_PWD(path: str = "") -> None:

--- a/datalad/support/tests/test_external_versions.py
+++ b/datalad/support/tests/test_external_versions.py
@@ -11,6 +11,7 @@ import logging
 from os import linesep
 
 from datalad import __version__
+from datalad.cmd import StdOutErrCapture, WitlessRunner
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import (
     CommandError,
@@ -231,9 +232,15 @@ def test_list_tuple():
 
 
 def test_system_ssh_version():
+    try:
+        WitlessRunner().run(['ssh', '-V'], protocol=StdOutErrCapture)
+    except FileNotFoundError as exc:
+        raise SkipTest(f"no ssh binary available: {exc}")
     ev = ExternalVersions()
     assert ev['cmd:system-ssh']  # usually we have some available at boxes we test
 
+
+def test_ssh_versions():
     for s, v in [
         ('OpenSSH_7.4p1 Debian-6, OpenSSL 1.0.2k  26 Jan 2017', '7.4p1'),
         ('OpenSSH_8.1p1, LibreSSL 2.7.3', '8.1p1'),


### PR DESCRIPTION
There is some auxiliary commits as well which would have more information.

Part to address 3rd failing test on conda #7421 