### PR TITLE
Increase minimal Git version to 2.25

### DIFF
--- a/changelog.d/pr-7431.md
+++ b/changelog.d/pr-7431.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- Increase minimal Git version to 2.25.  Fixes [#7389](https://github.com/datalad/datalad/issues/7389) via [PR #7431](https://github.com/datalad/datalad/pull/7431) (by [@adswa](https://github.com/adswa))

--- a/datalad/core/local/tests/test_diff.py
+++ b/datalad/core/local/tests/test_diff.py
@@ -373,12 +373,9 @@ def test_path_diff(_path=None, linkpath=None):
     eq_(plain_recursive, ds.diff(path=['.', '.'], recursive=True, annex='all',
                                  result_renderer='disabled'))
     # neither do nested paths
-    if not "2.24.0" <= ds.repo.git_version < "2.25.0":
-        # Release 2.24.0 contained a regression that was fixed with 072a231016
-        # (2019-12-10).
-        eq_(plain_recursive,
-            ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all',
-                    result_renderer='disabled'))
+    eq_(plain_recursive,
+        ds.diff(path=['.', 'subds_modified'], recursive=True, annex='all',
+                result_renderer='disabled'))
     # when invoked in a subdir of a dataset it still reports on the full thing
     # just like `git status`, as long as there are no paths specified
     with chpwd(op.join(path, 'directory_untracked')):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -834,7 +834,7 @@ class GitRepo(CoreGitRepo):
     # should do it once
     _config_checked = False
 
-    GIT_MIN_VERSION = "2.19.1"
+    GIT_MIN_VERSION = "2.25"
     git_version = None
 
     @classmethod

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -388,25 +388,8 @@ def normalize_paths(func, match_return_type=True, map_filenames_back=False,
 
     return  _wrap_normalize_paths
 
-
-if "2.24.0" <= external_versions["cmd:git"] < "2.25.0":
-    # An unintentional change in Git 2.24.0 led to `ls-files -o` traversing
-    # into untracked submodules when multiple pathspecs are given, returning
-    # repositories that are deeper than the first level. This helper filters
-    # these deeper levels out so that save_() doesn't fail trying to add them.
-    #
-    # This regression fixed with upstream's 072a231016 (2019-12-10).
-    def _prune_deeper_repos(repos: list[Path]) -> list[Path]:
-        firstlevel_repos = []
-        prev = None
-        for repo in sorted(repos):
-            if not (prev and str(repo).startswith(prev)):
-                prev = str(repo)
-                firstlevel_repos.append(repo)
-        return firstlevel_repos
-else:
-    def _prune_deeper_repos(repos: list[Path]) -> list[Path]:
-        return repos
+def _prune_deeper_repos(repos: list[Path]) -> list[Path]:
+    return repos
 
 
 class GitProgress(WitlessProtocol):
@@ -2949,14 +2932,6 @@ class GitRepo(CoreGitRepo):
             inf: dict[str, str | int | None] = {}
             props = props_re.match(line)
             if not props:
-                # Kludge: Filter out paths starting with .git/ to work around
-                # an `ls-files -o` bug that was fixed in Git 2.25.
-                #
-                # TODO: Drop this condition when GIT_MIN_VERSION is at least
-                # 2.25.
-                if line.startswith(".git/"):
-                    lgr.debug("Filtering out .git/ file: %s", line)
-                    continue
                 # not known to Git, but Git always reports POSIX
                 path = ut.PurePosixPath(line)
                 inf['gitshasum'] = None


### PR DESCRIPTION
This PR raises the minimal Git version to 2.25. It fixes issue #7389, and removes a number of kludges that worked around certain Git versions below 2.25. I had only a few minutes on the train to look for kludges, so I think its unlikely I found them all. 