### PR TITLE
Remove surrounding quotes in output filenames even for newer version of annex

### DIFF
--- a/changelog.d/pr-7443.md
+++ b/changelog.d/pr-7443.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Remove surrounding quotes in output filenames even for newer version of annex.  Fixes [#7440](https://github.com/datalad/datalad/issues/7440) via [PR #7443](https://github.com/datalad/datalad/pull/7443) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -579,14 +579,12 @@ class AnnexRepo(GitRepo, RepoInterface):
         if respected == 'no':
             return s
         quoted = s.startswith('"') and s.endswith('"')
-        if respected == 'maybe':
+        if respected in ('maybe', 'yes'):
             # not necessarily correct if e.g. filename has "" around it originally
             # but this is a check only for a range of development versions, so mostly
             # for local/CI runs ATM
             if not quoted:
                 return s
-        elif respected == 'yes':
-            assert quoted
         else:
             raise RuntimeError(f"Got unknown {respected}")
         return s[1:-1].replace(r'\"', '"')


### PR DESCRIPTION
Lead to a failure on Windows.
Apparently with core.quotepath=false we would not get simple filenames quoted, so we should decide to remove or not quotes "dynamically" on whether we find them

Closes #7440