### PR TITLE
Doc subdataset candidates

### DIFF
--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -752,16 +752,20 @@ class Get(Interface):
     cost is given in parenthesis, higher values indicate higher cost, and thus
     lower priority:
 
+    - A datalad URL recorded in `.gitmodules` (cost 590). This allows for
+      datalad URLs that require additional handling/resolution by datalad, like
+      ria-schemes (ria+http, ria+ssh, etc.)
+
+    - A URL or absolute path recorded for git in `.gitmodules` (cost 600).
+
     - URL of any configured superdataset remote that is known to have the
       desired submodule commit, with the submodule path appended to it.
-      There can be more than one candidate (cost 500).
+      There can be more than one candidate (cost 650).
 
     - In case `.gitmodules` contains a relative path instead of a URL,
       the URL of any configured superdataset remote that is known to have the
       desired submodule commit, with this relative path appended to it.
-      There can be more than one candidate (cost 500).
-
-    - A URL or absolute path recorded in `.gitmodules` (cost 600).
+      There can be more than one candidate (cost 650).
 
     - In case `.gitmodules` contains a relative path as a URL, the absolute
       path of the superdataset, appended with this relative path (cost 900).

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -146,7 +146,7 @@ def _get_flexible_source_candidates_for_submodule(ds, sm):
     under the shortened name `id`.
 
     Additionally, the URL of any configured remote that contains the respective
-    submodule commit is available as `remote-<name>` properties, where `name`
+    submodule commit is available as `remoteurl-<name>` property, where `name`
     is the configured remote name.
 
     Lastly, all candidates are sorted according to their cost (lower values
@@ -784,7 +784,7 @@ class Get(Interface):
     under the shortened name `id`.
 
     Additionally, the URL of any configured remote that contains the respective
-    submodule commit is available as `remote-<name>` properties, where `name`
+    submodule commit is available as `remoteurl-<name>` property, where `name`
     is the configured remote name.
 
     Hence, such a template could be `http://example.org/datasets/{id}` or


### PR DESCRIPTION
This docstring-only PR:

- fixes the name of a property that can be used in subdataset source candidate configuration (`remoteurl-<name>` → `remoteurl-<name>`, matching the code)
- updates the default source candidate priorities listed in `get` docstring (i.e. manpage for get), so that they are the same as in the helper function docstring (`_get_flexible_source_candidates_for_submodule()`.

Regarding the latter: The doctrings for `get` and its helper function seem to have diverged w.r.t. the default costs for subdataset source candidates. Some changes to cost values happened e.g. in 9138af04fe06682aca3caa45f696c3f1fef03f4b. After a cursory look, I am under the impression that the values reported in helper function's docstring match its code (or at least are closer to truth), and as long as they aren't modified elsewhere these would be the valid ones for get.

Fixes #7458 