### PR TITLE
Pass branch option into recursive call within Install - for the cases whenever install is invoked with URL(s)

### DIFF
--- a/changelog.d/pr-7463.md
+++ b/changelog.d/pr-7463.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Pass branch option into recursive call within Install - for the cases whenever install is invoked with URL(s).  Fixes [#7461](https://github.com/datalad/datalad/issues/7461) via [PR #7463](https://github.com/datalad/datalad/pull/7463) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -269,6 +269,7 @@ class Install(Interface):
                         result_renderer='disabled',
                         result_xfm=None,
                         result_filter=None,
+                        branch=branch,
                         **common_kwargs):
                     # no post-processing of the installed content on disk
                     # should be necessary here, all done by code further


### PR DESCRIPTION
Happens whenever install is invoked with a URL and --branch option. Closes #7461.

TODO:

- [x] test that case, so far tests had explicit  "source" specified and thus did not trigger this code path