### PR TITLE
Cache value of the has_symlink_capability to spare some cycles

### DIFF
--- a/changelog.d/pr-7471.md
+++ b/changelog.d/pr-7471.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Cache value of the has_symlink_capability to spare some cycles.  [PR #7471](https://github.com/datalad/datalad/pull/7471) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1443,7 +1443,6 @@ def test_ephemeral(origin_path=None, bare_path=None,
     runner.run(['git', 'annex', 'init'], cwd=bare_path)
 
     eph_from_bare = clone(bare_path, clone3_path, reckless='ephemeral')
-    can_symlink = has_symlink_capability()
 
     if can_symlink:
         # Bare repo uses dirhashlower by default, while a standard repo uses

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -15,6 +15,7 @@ import multiprocessing.queues
 import ssl
 import textwrap
 from difflib import unified_diff
+from functools import lru_cache
 from http.server import (
     HTTPServer,
     SimpleHTTPRequestHandler,
@@ -1898,6 +1899,7 @@ def maybe_adjust_repo(repo):
         repo.adjust()
 
 
+@lru_cache()
 @with_tempfile
 @with_tempfile
 def has_symlink_capability(p1, p2):


### PR DESCRIPTION
We have about 15 invocations, each one would redo that check for no good reason.