### PR TITLE
Allow for reckless=ephemeral clone using relative path for the original location

### DIFF
--- a/changelog.d/pr-7472.md
+++ b/changelog.d/pr-7472.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Allow for reckless=ephemeral clone using relative path for the original location.  Fixes [#7469](https://github.com/datalad/datalad/issues/7469) via [PR #7472](https://github.com/datalad/datalad/pull/7472) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/clone_ephemeral.py
+++ b/datalad/core/distributed/clone_ephemeral.py
@@ -92,6 +92,10 @@ def _setup_ephemeral_annex(ds: Dataset, remote: str):
                 # If origin isn't local, we have nothing to do.
                 origin_git_path = Path(RI(origin_annex_url).localpath)
 
+                if not origin_git_path.is_absolute():
+                    # relative path would be relative to the ds, not pwd!
+                    origin_git_path = ds.pathobj / origin_git_path
+
                 # we are local; check for a bare repo first to not mess w/
                 # the path
                 if GitRepo(origin_git_path, create=False).bare:

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1365,8 +1365,10 @@ def test_ria_http_storedataladorg(path=None):
 @with_tempfile
 @with_tempfile
 @with_tempfile
+@with_tempfile
 def test_ephemeral(origin_path=None, bare_path=None,
-                   clone1_path=None, clone2_path=None, clone3_path=None):
+                   clone1_path=None, clone2_path=None,
+                   clone3_path=None, clone4_path=None):
     can_symlink = has_symlink_capability()
 
     file_test = Path('ds') / 'test.txt'
@@ -1449,6 +1451,12 @@ def test_ephemeral(origin_path=None, bare_path=None,
         eph_annex = eph_from_bare.repo.dot_git / 'annex'
         ok_(eph_annex.is_symlink())
         ok_(eph_annex.resolve().samefile(Path(bare_path) / 'annex'))
+
+    # 5. ephemeral clone using relative path
+    # https://github.com/datalad/datalad/issues/7469
+    with chpwd(op.dirname(origin_path)):
+        clone4 = clone(op.basename(origin_path), op.basename(clone4_path), reckless='ephemeral')
+    check_clone(clone4)
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
The last commit is actual fix + test, and prior one is just RFing test to avoid duplication and then reuse common testing logic in the fix.  That fix fixes #7469 