### PR TITLE
Replace %-interpolation in 3 log msgs to passing as arguments

### DIFF
--- a/datalad/core/local/resulthooks.py
+++ b/datalad/core/local/resulthooks.py
@@ -51,8 +51,8 @@ def get_jsonhooks_from_config(cfg):
         )
         if not call:
             lgr.warning(
-                'Incomplete result hook configuration %s in %s' % (
-                    hook_basevar, cfg))
+                'Incomplete result hook configuration %s in %s',
+                hook_basevar, cfg)
             continue
         # split command from any args
         call = call.split(maxsplit=1)

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -70,7 +70,7 @@ def link_file_load(src, dst, dry_run=False):
         # (e.g. Windows) will not cover scenarios where a particular
         # filesystem simply does not implement it on an otherwise
         # sane platform (e.g. exfat on Linux)
-        lgr.warning("Linking of %s failed (%s), copying file" % (src, e))
+        lgr.warning("Linking of %s failed (%s), copying file", src, e)
         shutil.copyfile(src_realpath, dst)
         shutil.copystat(src_realpath, dst)
     else:

--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -244,7 +244,7 @@ def retry_urlopen(url, retries=3):
         try:
             return __urlopen_requests(url)
         except URLError as e:
-            lgr.warning("Received exception while reading %s: %s" % (url, e))
+            lgr.warning("Received exception while reading %s: %s", url, e)
             if t == retries - 1:
                 # if we have reached allowed number of retries -- reraise
                 raise


### PR DESCRIPTION
This would be "more correct" although, as checked by going through logging code, as safe as before.  Detected those through trying pyupgrade which converted those to .format() invocations which triggered pylint to start complaining about

     W1202: Use lazy % or % formatting in logging functions (logging-format-interpolation)

which is still there.  Some elderly issue https://github.com/pylint-dev/pylint/issues/2395
has some extended discussion on either to keep that warning default or not. I think, since it does delay possible "str"-ification of passed args, it is a good thing since ideed might have notable (if str() is taking some time for some specific types) performance benefits.  But it also points to the need of having a CI run (like we do on travis) which has verbose logging enabled to smoke test all those code paths.

Due to very limited scope of the change, I do not think it warrants changelog.