### PR TITLE
ENH: add --cfg-proc to install, clone, and get

### DIFF
--- a/changelog.d/20260407_cfg_proc_install.md
+++ b/changelog.d/20260407_cfg_proc_install.md
@@ -1,0 +1,5 @@
+### 🚀 Enhancements and New Features
+
+- Add `--cfg-proc` option to `install`, `clone`, and `get` to run configuration procedures on datasets post-installation.
+  Fixes [#7468](https://github.com/datalad/datalad/issues/7468) via [PR #7477](https://github.com/datalad/datalad/pull/7477)
+  (by [@bpinsard](https://github.com/bpinsard))

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -217,6 +217,15 @@ class Clone(Interface):
             because both a regular branch and the git-annex branch are
             required. Note that a version in a RIA URL takes precedence over
             '--branch'."""),
+        cfg_proc=Parameter(
+            args=("-c", "--cfg-proc"),
+            metavar="PROC",
+            action='append',
+            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
+            on the installed dataset. Use
+            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
+            to get a list of available procedures, such as cfg_text2git.
+            """),
         description=location_description,
         reckless=reckless_opt,
         message=save_message_opt,
@@ -234,6 +243,7 @@ class Clone(Interface):
             description=None,
             reckless=None,
             message=None,
+            cfg_proc=None,
         ):
         # did we explicitly get a dataset to install into?
         # if we got a dataset, path will be resolved against it.
@@ -327,6 +337,7 @@ class Clone(Interface):
                 result_props,
                 cfg=None if ds is None else ds.config,
                 clone_opts=git_clone_opts,
+                cfg_proc=cfg_proc,
                 ):
             if r['status'] in ['error', 'impossible']:
                 clone_failure = True
@@ -412,7 +423,8 @@ def clone_dataset(
         result_props=None,
         cfg=None,
         checkout_gitsha=None,
-        clone_opts=None):
+        clone_opts=None,
+        cfg_proc=None):
     """Internal helper to perform cloning without sanity checks (assumed done)
 
     This helper does not handle any saving of subdataset modification or adding
@@ -445,6 +457,8 @@ def clone_dataset(
       Options passed to git-clone. Note that for RIA URLs, the version is
       translated to a --branch argument, and that will take precedence over a
       --branch argument included in this value.
+    cfg_proc : list of str, optional
+      List of procedures to be run on the cloned datasets.
 
     Yields
     ------
@@ -542,6 +556,15 @@ def clone_dataset(
         )
         rmtree(destds.path, children_only=dest_path_existed)
         return
+
+    from datalad.local.run_procedure import _get_proc_configs
+    cfg_proc_specs = _get_proc_configs(cfg_proc, destds) if cfg_proc else []
+    for cfg_proc_spec in cfg_proc_specs:
+        yield from destds.run_procedure(
+            cfg_proc_spec,
+            result_renderer='disabled',
+            return_type='generator',
+        )
 
     # yield successful clone of the base dataset now, as any possible
     # subdataset clone down below will not alter the Git-state of the

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -557,6 +557,7 @@ def clone_dataset(
         rmtree(destds.path, children_only=dest_path_existed)
         return
 
+    # import in function to circumvent circular import issue
     from datalad.local.run_procedure import _get_proc_configs
     cfg_proc_specs = _get_proc_configs(cfg_proc, destds) if cfg_proc else []
     for cfg_proc_spec in cfg_proc_specs:

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -28,6 +28,7 @@ from datalad.interface.base import (
     eval_results,
 )
 from datalad.interface.common_opts import (
+    cfg_proc_opt,
     location_description,
     reckless_opt,
     save_message_opt,
@@ -217,15 +218,7 @@ class Clone(Interface):
             because both a regular branch and the git-annex branch are
             required. Note that a version in a RIA URL takes precedence over
             '--branch'."""),
-        cfg_proc=Parameter(
-            args=("-c", "--cfg-proc"),
-            metavar="PROC",
-            action='append',
-            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
-            on the installed dataset. Use
-            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
-            to get a list of available procedures, such as cfg_text2git.
-            """),
+        cfg_proc=cfg_proc_opt,
         description=location_description,
         reckless=reckless_opt,
         message=save_message_opt,

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1754,6 +1754,14 @@ def test_url_mapping_specs():
 
 
 @with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_clone_withcfg(src_path=None, dest=None):
+    src = create(src_path)
+    ds = clone(src_path, dest, cfg_proc=['yoda'])
+    assert (ds.pathobj / 'README.md').exists()
+
+
+@with_tempfile(mkdir=True)
 def test_clone_self_referential_remote(path=None):
     """Test that cloning doesn't recurse infinitely when a remote points to itself
 

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -341,25 +341,8 @@ class Create(Interface):
             yield res
             return
 
-        # Check if specified cfg_proc(s) can be discovered, storing
-        # the results so they can be used when the time comes to run
-        # the procedure. If a procedure cannot be found, raise an
-        # error to prevent creating the dataset.
-        cfg_proc_specs = []
-        if cfg_proc:
-            discovered_procs = tbds.run_procedure(
-                discover=True,
-                result_renderer='disabled',
-                return_type='list',
-            )
-            for cfg_proc_ in cfg_proc:
-                for discovered_proc in discovered_procs:
-                    if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
-                        cfg_proc_specs.append(discovered_proc)
-                        break
-                else:
-                    raise ValueError("Cannot find procedure with name "
-                                     "'%s'" % cfg_proc_)
+        from datalad.local.run_procedure import _get_proc_configs
+        cfg_proc_specs = _get_proc_configs(cfg_proc, tbds) if cfg_proc else []
 
         if initopts is not None and isinstance(initopts, list):
             initopts = {'_from_cmdline_': initopts}

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -40,6 +40,7 @@ from datalad.interface.common_opts import (
     location_description,
     save_message_opt,
 )
+from datalad.local.run_procedure import _get_proc_configs
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureKeyChoice,
@@ -341,7 +342,6 @@ class Create(Interface):
             yield res
             return
 
-        from datalad.local.run_procedure import _get_proc_configs
         cfg_proc_specs = _get_proc_configs(cfg_proc, tbds) if cfg_proc else []
 
         if initopts is not None and isinstance(initopts, list):

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -37,6 +37,7 @@ from datalad.interface.base import (
     eval_results,
 )
 from datalad.interface.common_opts import (
+    cfg_proc_opt,
     location_description,
     save_message_opt,
 )
@@ -175,16 +176,7 @@ class Create(Interface):
             doc="""Configure the repository to use fake dates. The date for a
             new commit will be set to one second later than the latest commit
             in the repository. This can be used to anonymize dates."""),
-        cfg_proc=Parameter(
-            args=("-c", "--cfg-proc"),
-            metavar="PROC",
-            action='append',
-            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
-            on the created dataset. Use
-            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
-            to get a list of available procedures, such as cfg_text2git.
-            """
-        ),
+        cfg_proc=cfg_proc_opt,
         message=save_message_opt,
     )
 

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -402,7 +402,7 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
 
 
 def _install_necessary_subdatasets(
-        ds, path, reckless, refds_path, description=None):
+        ds, path, reckless, refds_path, description=None, cfg_proc=None):
     """Installs subdatasets of `ds`, that are necessary to obtain in order
     to have access to `path`.
 
@@ -438,7 +438,8 @@ def _install_necessary_subdatasets(
                 Dataset(cur_subds['parentds']),
                 cur_subds,
                 reckless=reckless,
-                description=description):
+                description=description,
+                cfg_proc=cfg_proc):
             if res.get('action', None) == 'install':
                 if res['status'] == 'ok':
                     # report installation, whether it helped or not
@@ -472,7 +473,8 @@ def _install_necessary_subdatasets(
 
 
 def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=None,
-                 refds_path=None, description=None, jobs=None, producer_only=False):
+                 refds_path=None, description=None, jobs=None, producer_only=False,
+                 cfg_proc=None):
     if isinstance(recursion_limit, int) and recursion_limit <= 0:
         return
     # install using helper that give some flexibility regarding where to
@@ -511,7 +513,8 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
         else:
             # TODO: here we need another "ds"!  is it within "sub"?
             yield from _install_subds_from_flexible_source(
-                Dataset(ds_path), sub, reckless=reckless, description=description)
+                Dataset(ds_path), sub, reckless=reckless, description=description,
+                cfg_proc=cfg_proc)
 
         if not subds.is_installed():
             # an error result was emitted, and the external consumer can decide
@@ -528,6 +531,7 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
                 reckless=reckless,
                 refds_path=refds_path,
                 jobs=jobs,
+                cfg_proc=cfg_proc,
                 producer_only=True  # we will be adding to producer queue
         ):
             producer_consumer.add_to_producer_queue(res)
@@ -557,6 +561,7 @@ def _install_targetpath(
         refds_path,
         description,
         jobs=None,
+        cfg_proc=None,
 ):
     """Helper to install as many subdatasets as needed to verify existence
     of a target path
@@ -588,7 +593,12 @@ def _install_targetpath(
     else:
         # we don't have it yet. is it in a subdataset?
         for res in _install_necessary_subdatasets(
-                ds, target_path, reckless, refds_path, description=description):
+                ds,
+                target_path,
+                reckless,
+                refds_path,
+                description=description,
+                cfg_proc=cfg_proc):
             if (target_path.is_symlink() or target_path.exists()):
                 # this dataset brought the path, mark for annex
                 # processing outside
@@ -645,6 +655,7 @@ def _install_targetpath(
             refds_path=refds_path,
             description=description,
             jobs=jobs,
+            cfg_proc=cfg_proc,
     ):
         # yield immediately so errors could be acted upon
         # outside, before we continue
@@ -866,6 +877,15 @@ class Get(Interface):
             doc="""whether to obtain data for all file handles. If disabled, `get`
             operations are limited to dataset handles.[CMD:  This option prevents data
             for file handles from being obtained CMD]"""),
+        cfg_proc=Parameter(
+            args=("-c", "--cfg-proc"),
+            metavar="PROC",
+            action='append',
+            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
+            on the installed subdataset. Use
+            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
+            to get a list of available procedures, such as cfg_text2git.
+            """),
         description=location_description,
         reckless=reckless_opt,
         jobs=jobs_opt)
@@ -881,6 +901,7 @@ class Get(Interface):
             recursive=False,
             recursion_limit=None,
             get_data=True,
+            cfg_proc=None,
             description=None,
             reckless=None,
             jobs='auto',
@@ -950,6 +971,7 @@ class Get(Interface):
                             refds_path,
                             description,
                             jobs=jobs,
+                            cfg_proc=cfg_proc,
                     ):
                         # fish out the datasets that 'contains' a targetpath
                         # and store them for later
@@ -994,6 +1016,7 @@ class Get(Interface):
                         refds_path,
                         description,
                         jobs=jobs,
+                        cfg_proc=cfg_proc,
                 ):
                     known_ds = res['path'] in content_by_ds
                     if res.get('status', None) in ('ok', 'notneeded') and \

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -29,6 +29,7 @@ from datalad.interface.base import (
     eval_results,
 )
 from datalad.interface.common_opts import (
+    cfg_proc_opt,
     jobs_opt,
     location_description,
     reckless_opt,
@@ -877,15 +878,7 @@ class Get(Interface):
             doc="""whether to obtain data for all file handles. If disabled, `get`
             operations are limited to dataset handles.[CMD:  This option prevents data
             for file handles from being obtained CMD]"""),
-        cfg_proc=Parameter(
-            args=("-c", "--cfg-proc"),
-            metavar="PROC",
-            action='append',
-            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
-            on the installed subdataset. Use
-            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
-            to get a list of available procedures, such as cfg_text2git.
-            """),
+        cfg_proc=cfg_proc_opt,
         description=location_description,
         reckless=reckless_opt,
         jobs=jobs_opt)

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -177,6 +177,15 @@ class Install(Interface):
             args=("-g", "--get-data",),
             doc="""if given, obtain all data content too""",
             action="store_true"),
+        cfg_proc=Parameter(
+            args=("-c", "--cfg-proc"),
+            metavar="PROC",
+            action='append',
+            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
+            on the installed dataset. Use
+            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
+            to get a list of available procedures, such as cfg_text2git.
+            """),
         description=location_description,
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
@@ -198,6 +207,7 @@ class Install(Interface):
             recursion_limit=None,
             reckless=None,
             jobs="auto",
+            cfg_proc=None,
             branch=None):
 
         # normalize path argument to be equal when called from cmdline and
@@ -222,6 +232,7 @@ class Install(Interface):
             # annex_opts=annex_opts,
             reckless=reckless,
             jobs=jobs,
+            cfg_proc=cfg_proc,
         )
 
         # did we explicitly get a dataset to install into?
@@ -234,6 +245,9 @@ class Install(Interface):
             common_kwargs['dataset'] = dataset
         # pre-compute for results below
         refds_path = ds if ds is None else ds.path
+
+        # assure cfg_proc is a list (relevant if used via Python API)
+        cfg_proc = ensure_list(cfg_proc)
 
         # switch into the two scenarios without --source:
         # 1. list of URLs
@@ -389,7 +403,8 @@ class Install(Interface):
             return_type='generator',
             result_renderer='disabled',
             result_filter=None,
-            on_failure='ignore')
+            on_failure='ignore',
+            cfg_proc=cfg_proc,)
         # helper
         as_ds = YieldDatasets()
         destination_dataset = None
@@ -422,6 +437,7 @@ class Install(Interface):
                     **common_kwargs):
                 r['refds'] = refds_path
                 yield r
+
         # at this point no further post-processing should be necessary,
         # `clone` and `get` must have done that (incl. parent handling)
         # if not, bugs should be fixed in those commands

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -27,6 +27,7 @@ from datalad.interface.base import (
     eval_results,
 )
 from datalad.interface.common_opts import (
+    cfg_proc_opt,
     jobs_opt,
     location_description,
     reckless_opt,
@@ -177,15 +178,7 @@ class Install(Interface):
             args=("-g", "--get-data",),
             doc="""if given, obtain all data content too""",
             action="store_true"),
-        cfg_proc=Parameter(
-            args=("-c", "--cfg-proc"),
-            metavar="PROC",
-            action='append',
-            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
-            on the installed dataset. Use
-            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
-            to get a list of available procedures, such as cfg_text2git.
-            """),
+        cfg_proc=cfg_proc_opt,
         description=location_description,
         recursive=recursion_flag,
         recursion_limit=recursion_limit,

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -902,3 +902,15 @@ def test_get_non_existing(origin_path=None, clone_path=None):
 
     assert_result_count(res, 1, status="impossible",
                         message="path does not exist")
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_get_recursive_withcfg(src_path=None, dest=None):
+    src = create(src_path)
+    subds = src.create('subds')
+    subsubds = src.create('subds/subsubds')
+    ds = clone(src_path, dest)
+    ds.get('subds', recursive=True, cfg_proc=['yoda'])
+    assert (ds.pathobj / 'subds' / 'README.md').exists()
+    assert (ds.pathobj / 'subds' / 'subsubds' / 'README.md').exists()

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -1057,3 +1057,22 @@ def test_install_recursive_github(path=None):
     ]):
         ds = install(source=url, path=opj(path, "clone%i" % i), recursive=True)
         eq_(len(ds.subdatasets(recursive=True, state='present')), 2)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_install_withcfg(src_path=None, dest=None):
+    src = create(src_path)
+    ds = install(path=dest, source=src_path, cfg_proc=['yoda'])
+
+    assert (ds.pathobj / 'README.md').exists()
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_recursive_install_withcfg(src_path=None, dest=None):
+    src = create(src_path)
+    src.create('subds')
+    ds = install(path=dest, source=src_path, recursive=True, cfg_proc=['yoda'])
+
+    assert (ds.pathobj / 'README.md').exists()
+    assert (ds.pathobj / 'subds' / 'README.md').exists()

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -1061,14 +1061,6 @@ def test_install_recursive_github(path=None):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-def test_install_withcfg(src_path=None, dest=None):
-    src = create(src_path)
-    ds = install(path=dest, source=src_path, cfg_proc=['yoda'])
-
-    assert (ds.pathobj / 'README.md').exists()
-
-@with_tempfile(mkdir=True)
-@with_tempfile(mkdir=True)
 def test_recursive_install_withcfg(src_path=None, dest=None):
     src = create(src_path)
     src.create('subds')

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -154,6 +154,16 @@ save_message_opt = Parameter(
     doc="""a description of the state or the changes made to a dataset.""",
     constraints=EnsureStr() | EnsureNone())
 
+cfg_proc_opt = Parameter(
+    args=("-c", "--cfg-proc"),
+    metavar="PROC",
+    action='append',
+    doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
+    on the dataset. Use
+    [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
+    to get a list of available procedures, such as cfg_text2git.
+    """)
+
 message_file_opt = Parameter(
     args=("-F", "--message-file"),
     doc="""take the commit message from this file. This flag is

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -515,3 +515,25 @@ class RunProcedure(Interface):
 
         else:
             generic_result_renderer(res)
+
+
+def _get_proc_configs(names, ds):
+    """Get specifications for discovered procedures.
+
+     If not a single procedure found, raises `ValueError`
+     """
+    cfg_proc_specs = []
+    discovered_procs = ds.run_procedure(
+        discover=True,
+        result_renderer='disabled',
+        return_type='list',
+    )
+    for cfg_proc_ in names:
+        for discovered_proc in discovered_procs:
+            if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
+                cfg_proc_specs.append(discovered_proc)
+                break
+        else:
+            raise ValueError("Cannot find procedure with name "
+                             "'%s'" % cfg_proc_)
+    return cfg_proc_specs


### PR DESCRIPTION
Adds the `--cfg-proc` option to install command to allow running commands on dataset post-installation. see #7468 
It runs procedure after recursive install.

It does not call the procedure recursively for now (recursion can be coded in the procedure itself).
Making it recursive would require way more changes to `get` and other parts of the code. 

### PR checklist

- [x] Write tests.
- [x] fix tests
- [x] refactor code for harmonious helper name/interface
- [x] @yarikoptic to add changelog entry later on
