### PR TITLE
RF(TST): use setup_method and teardown_method in TestAddArchiveOptions

### DIFF
--- a/changelog.d/pr-7488.md
+++ b/changelog.d/pr-7488.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- RF(TST): use setup_method and teardown_method in TestAddArchiveOptions.  [PR #7488](https://github.com/datalad/datalad/pull/7488) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/local/tests/test_add_archive_content.py
+++ b/datalad/local/tests/test_add_archive_content.py
@@ -494,7 +494,7 @@ class TestAddArchiveOptions():
     # few tests bundled with a common setup/teardown to minimize boiler plate
     # nothing here works on windows, no even teardown(), prevent failure at the
     # origin
-    def setup(self):
+    def setup_method(self):
         repo_path = tempfile.mkdtemp(**get_tempfile_kwargs(prefix="tree"))
         create_tree(
             repo_path,
@@ -506,7 +506,7 @@ class TestAddArchiveOptions():
         # Let's add first archive to the annex so we could test
         ds.save('1.tar', message="added 1.tar")
 
-    def teardown(self):
+    def teardown_method(self):
         # so we close any outstanding batch process etc
         self.annex.precommit()
         rmtemp(self.ds.path)


### PR DESCRIPTION
Prior one is coming from "nose support" layer which is about to be deprecated. So we were getting flood of warnings like

   local/tests/test_add_archive_content.py::TestAddArchiveOptions::test_override_existing_under_git
  /Users/runner/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/_pytest/fixtures.py:911: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  local/tests/test_add_archive_content.py::TestAddArchiveOptions::test_override_existing_under_git is using nose-specific method: `teardown(self)`
  To remove this warning, rename it to `teardown_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
    next(it)

for a while but didn't spot them.  I think that is the only place in core.
