### PR TITLE
Fix time_diff* and time_remove benchmarks to account for long RFed interfaces

### DIFF
--- a/benchmarks/api.py
+++ b/benchmarks/api.py
@@ -103,8 +103,10 @@ class supers(SampleSuperDatasetBenchmarks):
             self.ds.drop(subm["path"], recursive=True, what='all',
                          reckless='kill')
 
-    def time_remove(self):
-        self.ds.drop(what='all', reckless='kill', recursive=True)
+    # disabled since apparently setup is not running for each execution!
+    # TODO: fix up after hearing on https://github.com/airspeed-velocity/asv/issues/1347
+    #def time_remove(self):
+    #    self.ds.drop(what='all', reckless='kill', recursive=True)
 
     def time_diff(self):
         self.ds.diff(fr="HEAD^")

--- a/benchmarks/api.py
+++ b/benchmarks/api.py
@@ -104,13 +104,13 @@ class supers(SampleSuperDatasetBenchmarks):
                          reckless='kill')
 
     def time_remove(self):
-        drop(self.ds.path, what='all', reckless='kill', recursive=True)
+        self.ds.drop(what='all', reckless='kill', recursive=True)
 
     def time_diff(self):
-        diff(self.ds.path, revision="HEAD^")
+        self.ds.diff(fr="HEAD^")
 
     def time_diff_recursive(self):
-        diff(self.ds.path, revision="HEAD^", recursive=True)
+        self.ds.diff(fr="HEAD^", recursive=True)
 
     # Status must be called with the dataset, unlike diff
     def time_status(self):

--- a/changelog.d/pr-7502.md
+++ b/changelog.d/pr-7502.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Fix time_diff* and time_remove benchmarks to account for long RFed interfaces.  [PR #7502](https://github.com/datalad/datalad/pull/7502) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/tools/ci/benchmark-travis-pr.sh
+++ b/tools/ci/benchmark-travis-pr.sh
@@ -23,7 +23,7 @@ run_asv () {
     pip install -e .
     git show --no-patch --format="%H (%s)"
     configure_asv
-    asv run -E existing --set-commit-hash $(git rev-parse HEAD)
+    asv run -E existing --show-stderr --set-commit-hash $(git rev-parse HEAD)
 }
 
 pip install asv


### PR DESCRIPTION
Only with fresh asv 0.6.0 which started to exit with exit code 2 if any benchmark failed, we finally had to pay attention to those long failing benchmarks. We have removed the option 'revision' so long ago but first didn't mention and then just ignored. For that and time_remove I also made it into dataset method invocation since otherwise it was not finding the dataset any longer given the path to it (didn't investigate deeper).
