### PR TITLE
Inform asv that there should be no warmup runs for time_remove benchmark

### DIFF
--- a/benchmarks/api.py
+++ b/benchmarks/api.py
@@ -103,10 +103,8 @@ class supers(SampleSuperDatasetBenchmarks):
             self.ds.drop(subm["path"], recursive=True, what='all',
                          reckless='kill')
 
-    # disabled since apparently setup is not running for each execution!
-    # TODO: fix up after hearing on https://github.com/airspeed-velocity/asv/issues/1347
-    #def time_remove(self):
-    #    self.ds.drop(what='all', reckless='kill', recursive=True)
+    def time_remove(self):
+       self.ds.drop(what='all', reckless='kill', recursive=True)
 
     def time_diff(self):
         self.ds.diff(fr="HEAD^")
@@ -120,3 +118,6 @@ class supers(SampleSuperDatasetBenchmarks):
 
     def time_status_recursive(self):
         self.ds.status(recursive=True)
+
+
+supers.time_remove.warmup_time = 0

--- a/changelog.d/pr-7505.md
+++ b/changelog.d/pr-7505.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Inform asv that there should be no warmup runs for time_remove benchmark.  [PR #7505](https://github.com/datalad/datalad/pull/7505) (by [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
Return the `time_remove` benchmark back.

Thanks to @trexfeathers for the RTFM pointers in
https://github.com/airspeed-velocity/asv/issues/1347#issuecomment-1752652351

