### PR TITLE
Enhance `run()` placeholder substitutions to honor configuration defaults

### DIFF
--- a/changelog.d/pr-7509.md
+++ b/changelog.d/pr-7509.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Enhance `run()` placeholder substitutions to honor configuration defaults.  [PR #7509](https://github.com/datalad/datalad/pull/7509) (by [@mih](https://github.com/mih))

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -38,6 +38,7 @@ from datalad.interface.base import (
     build_doc,
     eval_results,
 )
+from datalad.interface.common_cfg import definitions as cfg_defs
 from datalad.interface.common_opts import (
     jobs_opt,
     save_message_opt,
@@ -623,7 +624,12 @@ def format_command(dset, command, **kwds):
     command = normalize_command(command)
     sfmt = SequenceFormatter()
 
-    for k, v in dset.config.items("datalad.run.substitutions"):
+    for k in set(cfg_defs.keys()).union(dset.config.keys()):
+        v = dset.config.get(
+            k,
+            # pull a default from the config definitions
+            # if we have no value, but a key
+            cfg_defs.get(k, {}).get('default', None))
         sub_key = k.replace("datalad.run.substitutions.", "")
         if sub_key not in kwds:
             kwds[sub_key] = v

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -625,6 +625,8 @@ def format_command(dset, command, **kwds):
     sfmt = SequenceFormatter()
 
     for k in set(cfg_defs.keys()).union(dset.config.keys()):
+        if not k.startswith("datalad.run.substitutions."):
+            continue
         v = dset.config.get(
             k,
             # pull a default from the config definitions

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -17,6 +17,7 @@ import logging
 from os import environ
 from os.path import expanduser
 from os.path import join as opj
+import sys
 import time
 
 from platformdirs import AppDirs
@@ -545,6 +546,13 @@ _definitions = {
                'text': 'Specifies the repository version for git-annex to be used by default'}),
         'type': EnsureInt(),
         'default': 8,
+    },
+    'datalad.run.substitutions.python': {
+        'ui': ('question', {
+               'title': 'Substitution for {python} placeholder',
+               'text': 'Path to a Python interpreter executable'}),
+        'type': EnsureStr(),
+        'default': sys.executable,
     },
     'datalad.runtime.max-annex-jobs': {
         'ui': ('question', {


### PR DESCRIPTION
Previously, `run()` would not recognize configuration defaults for placeholder substitution. This means that any placeholders globally declared in `datalad.interface.common_cfg`, or via `register_config()` in DataLad extensions would not be effective.

This changeset makes run's `format_command()` helper include such defaults explicitly, and thereby enable the global declaration of substitution defaults.

Moreoever a `{python}` placeholder is now defined via this mechanism, and points to the value of `sys.executable` by default. This particular placeholder was found to be valueable for improving the portability of run-recording across (specific) Python versions, or across different (virtual) environments. See
https://github.com/datalad/datalad-container/issues/224 for an example use case.

A corresponding test is included.

The ability to keep run-records paramterizable, in particular, for interpreters can also aid longevity (think platform-specific choices to call a system Python executable `python3` for some years, and then switch back.

Related https://github.com/datalad/datalad-container/pull/250