### PR TITLE
Copy script to install singularity from datalad-container and use it in the workflow

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -76,14 +76,7 @@ jobs:
         pip install ./__extension__[devel]
 
     - name: Install Singularity
-      run: |
-        release="$(curl -fsSL https://api.github.com/repos/sylabs/singularity/releases/latest | jq -r .tag_name)"
-        codename="$(lsb_release -cs)"
-        arch="$(dpkg --print-architecture)"
-        cd /tmp
-        wget -O singularity-ce.deb https://github.com/sylabs/singularity/releases/download/$release/singularity-ce_${release#v}-${codename}_$arch.deb
-        sudo dpkg -i singularity-ce.deb
-        sudo apt-get install -f
+      run: tools/ci/install-singularity.sh
       if: env.DL_NEED_SINGULARITY == '1'
 
     - name: Install additional dependencies and prepare for testing

--- a/tools/ci/install-singularity.sh
+++ b/tools/ci/install-singularity.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex -o pipefail
+release="$(curl -fsSL https://api.github.com/repos/sylabs/singularity/releases/latest | jq -r .tag_name)"
+codename="$(lsb_release -cs)"
+arch="$(dpkg --print-architecture)"
+wget -O /tmp/singularity-ce.deb "https://github.com/sylabs/singularity/releases/download/$release/singularity-ce_${release#v}-${codename}_$arch.deb"
+set -x
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y uidmap libfuse2
+sudo dpkg -i /tmp/singularity-ce.deb
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -f


### PR DESCRIPTION
That script now installs also libfuse2 library needed by singularity-ce, which lead to failed installations in this repo CI.

Ideally we should establish central collection of CI tools at some point to reuse across various extensions and derivative projects. ATM we will have 3 copies of this script: here, in datalad-container and datalad-extensions.
