### PR TITLE
No custom logger in library mode

### DIFF
--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -81,6 +81,13 @@ def enable_librarymode():
     # export into the environment for child processes to inherit
     os.environ['DATALAD_RUNTIME_LIBRARYMODE'] = '1'
 
+    # disable custom datalad logging handler
+    lgr_handlers = lgr.handlers
+    if lgr_handlers:  # were not removed yet!
+        for h in lgr_handlers:
+            lgr.debug("Enabling library mode: removing datalad specific handler %s", h)
+            lgr.removeHandler(h)
+
 
 # For reproducible demos/tests
 _seed = os.environ.get('DATALAD_SEED', None)

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -122,7 +122,7 @@ def main(args=sys.argv):
         # added new ones to consider
         load_extensions()
 
-    if 'datalad.runtime.librarymode' in datalad.cfg:
+    if datalad.cfg.getbool('datalad.runtime', 'librarymode', False):
         datalad.enable_librarymode()
 
     if cmdlineargs.change_path is not None:

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -622,7 +622,7 @@ class LoggerHelper(object):
         logging.Logger
         """
         import datalad
-        if 'datalad.runtime.librarymode' in datalad.cfg:
+        if datalad.cfg.getbool('datalad.runtime', 'librarymode', False):
             return self.lgr
 
         if not logtarget:

--- a/datalad/log.py
+++ b/datalad/log.py
@@ -621,6 +621,10 @@ class LoggerHelper(object):
         -------
         logging.Logger
         """
+        import datalad
+        if 'datalad.runtime.librarymode' in datalad.cfg:
+            return self.lgr
+
         if not logtarget:
             logtarget = self._get_config('target', 'stderr')
 


### PR DESCRIPTION
Has 2 commits, but it is the first one which is most important, and its commit message describes it:

Remove custom datalad log handlers while enable library mode

ATM, if there is a root level logger set by Python application, which is a
logical thing to do for an application, then datalad log messages end up
duplicated -- once they are provided by the root level log handler and then by
our very own one.  E.g. this script

        import logging

        ## The simplest and documented way to enable logging for a Python app
        logging.basicConfig(level=logging.INFO,
                                                format='%(name)s : %(asctime)s - %(levelname)s - %(message)s')

        # Alternative way to enable some root level logging
        # which surprised me
        #logging.info('This is an info message')

        import datalad.support.gitrepo as r

        r.lgr.info("datalad logger talking")

        datalad_lgr = logging.getLogger("datalad")

        print(f"logging has handlers: {logging.getLogger().handlers}")
        print(f"DataLad has handlers: {datalad_lgr.handlers}"

would produce following output:

        ❯ python simplest_app2.py
        [INFO   ] datalad logger talking
        datalad.gitrepo : 2023-10-24 16:27:02,703 - INFO    - datalad logger talking
        logging has handlers: [<StreamHandler <stderr> (NOTSET)>]
        DataLad has handlers: [<ProgressHandler (NOTSET)>]

so you see our log line duplicated!   With the proposed change, we will
explicitly remove all assigned handlers when enabling library mode, and
if we add to above script the  datalad.enable_librarymode() we get

        ❯ python simplest_app2.py
        datalad.gitrepo : 2023-10-24 16:29:25,478 - INFO - datalad logger talking
        logging has handlers: [<StreamHandler <stderr> (NOTSET)>]
        DataLad has handlers: []

We also have to respect config variable so we could handle properly the
DATALAD_RUNTIME_LIBRARYMODE environment variable.


TODOs:

- [ ] decide to may be to position against `maint`???
- [ ] decide to  may be go more drastic: no custom logging handling unless in CLI or somehow explicitly instructed