### PR TITLE
Robustify update target detection for adjusted mode datasets

### DIFF
--- a/changelog.d/20231025_194118_michael.hanke_bf_7507.md
+++ b/changelog.d/20231025_194118_michael.hanke_bf_7507.md
@@ -1,0 +1,6 @@
+### 🐛 Bug Fixes
+
+- Update target detection for adjusted mode datasets has been improved.
+  Fixes [#7507](https://github.com/datalad/datalad/issues/7507) via
+  [PR #7522](https://github.com/datalad/datalad/pull/7522)
+  (by [@mih](https://github.com/mih))

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -481,7 +481,7 @@ def _choose_update_target(repo, branch, remote, cfg_remote):
         # branch.*.merge value, but that assumes a value for remote.*.fetch.
         target = repo.call_git_oneline(
             ["rev-parse", "--symbolic-full-name", "--abbrev-ref=strict",
-             "@{upstream}"],
+             f"{repo.get_corresponding_branch(branch) or ''}" "@{upstream}"],
             read_only=True)
     elif branch:
         remote_branch = "{}/{}".format(remote, branch)


### PR DESCRIPTION
The true cause of the problem is not well understood. https://github.com/datalad/datalad/issues/7507 documents that I was not able to capture the breakage in a test, despite approaching it from different angles.

Only the original reproducer documents that this patch fixes the problem. However, the involved datasets are too heavy to be used in an already overloaded test battery. Hence this fix is proposed without a corresponding test.

Closes #7507