### PR TITLE
BF(TST): Relax matching of git-annex error message about unsafe drop, which was changed in 10.20231129-18-gfd0b510573

### DIFF
--- a/changelog.d/pr-7541.md
+++ b/changelog.d/pr-7541.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- BF(TST): Relax matching of git-annex error message about unsafe drop, which was changed in 10.20231129-18-gfd0b510573.  [PR #7541](https://github.com/datalad/datalad/pull/7541) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -419,9 +419,7 @@ def test_safetynet(otherpath=None, origpath=None, clonepath=None):
 
     res = cloneds.drop(what='all', on_failure='ignore')
     assert_in_results(res, action="drop", status="error")
-    ok_(res[0]['message'].startswith(
-        "unsafe\nCould only verify the existence of "
-        "0 out of 1 necessary"),
+    ok_(res[0]['message'].startswith("unsafe\nCould"),
         msg=f"Results were {res}")
     ok_(cloneds.is_installed())
 


### PR DESCRIPTION
What matters really is that we fail and that there is "unsafe" and some message from git-annex.  In [10.20231129-18-gfd0b510573](https://git.kitenet.net/index.cgi/git-annex.git/commit/?id=fd0b5105731b17899d79cade82436320ab85cb56) git-annex changed message to become better but I do not think we should overcomplicate test ot match both messages exactly since who knows what other improvements might come later again.

Marking it for release so we bring CI of git-annex builds back into green