### PR TITLE
Update `pytest_ignore_collect()` for pytest 8.0

### DIFF
--- a/changelog.d/pr-7546.md
+++ b/changelog.d/pr-7546.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Update `pytest_ignore_collect()` for pytest 8.0.  [PR #7546](https://github.com/datalad/datalad/pull/7546) (by [@jwodder](https://github.com/jwodder))


### PR DESCRIPTION
[Pytest 8.0 is coming](https://github.com/pytest-dev/pytest/releases/tag/8.0.0rc1), and one of the breaking changes is [the removal of the `py.path.local` arguments to various hooks](https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path), such as `pytest_ignore_collect()`.  This PR updates our use of that hook.