### PR TITLE
Make ORA remote more aware of the remote OS when using SSH

### DIFF
--- a/changelog.d/pr-7549.md
+++ b/changelog.d/pr-7549.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- Correct remote OS detection when working with RIA (ORA) stores: this
+  should enable RIA operations, including push, from Mac clients to
+  Linux hosts (and likely vice versa).
+  Fixes [#7536](https://github.com/datalad/datalad/issues/7536)
+  via [PR #7549](https://github.com/datalad/datalad/pull/7549) (by [@mslw](https://github.com/mslw))

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -474,9 +474,12 @@ class SSHRemoteIO(IOBase):
         """
 
         path = sh_quote(str(path))
-        # remember original mode -- better than to prescribe a fixed mode
 
-        if on_osx:
+        # remember original mode -- better than to prescribe a fixed mode
+        # format depends on remote OS, use uname (works on Linux and macOS)
+        uname_out = self._run("uname -s", no_output=False, check=True).rstrip()
+
+        if uname_out == "Darwin":
             format_option = "-f%Dp"
             # on macOS this would return decimal representation of mode (same
             # as python's stat().st_mode


### PR DESCRIPTION
The ORA remote (more specifically, its `SSHRemoteIO.ensure_writeable` context manager) runs the `stat` command on the remote end to check file permissions. The command format and its output differ between macOS and Linux ("It doesn't even think about a windows server").

Previously, the format was chosen based on the *local* OS, which makes no sense for a command that is executed on the *remote* end. This led to situations where it was impossible to push data from Mac to Linux because the stat command errored out, and permissions were left incorrect, when moving a file from `transfer` to its desired location - see #7536 

With this change, the ORA remote will run `uname -S` on the remote end (of an SSH connection) to determine where it is operating, if it needs to. To the best of my knowledge (https://en.wikipedia.org/wiki/Uname), checking for "Darwin" should be sufficient to detect macOS.

This PR adds `remote_uname` as a lazy property of ORA remote's `SSHRemoteIO` class, which is accessed before running said `stat` commands (replacing a *locally operating* check of `on_osx`).

Having access to the property avoids re-running `uname` for every file that needs to be touched, and having the property lazily
resolved avoids running `uname` for operations which don't need it.

This should fix #7536 