### PR TITLE
Add the "http_token" authentication mechanism which provides 'Authentication: Token {TOKEN}' header

### DIFF
--- a/changelog.d/pr-7551.md
+++ b/changelog.d/pr-7551.md
@@ -1,3 +1,3 @@
-### 🐛 Bug Fixes
+### 🚀 Enhancements and New Features
 
 - Add the "http_token" authentication mechanism which provides 'Authentication: Token {TOKEN}' header.  [PR #7551](https://github.com/datalad/datalad/pull/7551) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/changelog.d/pr-7551.md
+++ b/changelog.d/pr-7551.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Add the "http_token" authentication mechanism which provides 'Authentication: Token {TOKEN}' header.  [PR #7551](https://github.com/datalad/datalad/pull/7551) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/downloaders/http.py
+++ b/datalad/downloaders/http.py
@@ -387,10 +387,14 @@ class HTTPDigestAuthAuthenticator(HTTPRequestsAuthenticator):
 
 @auto_repr
 class HTTPBearerTokenAuthenticator(HTTPRequestsAuthenticator):
-    """Authenticate via HTTP Authorization header
+    """Authenticate via HTTP 'Authorization: Bearer TOKEN' header
+
+    E.g. as defined for OAuth2 in RFC 6750
+    https://datatracker.ietf.org/doc/html/rfc6750
     """
 
     DEFAULT_CREDENTIAL_TYPE = 'token'
+    AUTH_KEYWORD = 'Bearer'
 
     def __init__(self, **kwargs):
         # so we have __init__ solely for a custom docstring
@@ -398,7 +402,18 @@ class HTTPBearerTokenAuthenticator(HTTPRequestsAuthenticator):
 
     def _post_credential(self, credentials, post_url, session):
         # we do not need to post anything, just inject token into the session
-        session.headers['Authorization'] = "Bearer %s" % credentials['token']
+        session.headers['Authorization'] = f"{self.AUTH_KEYWORD} {credentials['token']}"
+
+
+class HTTPTokenAuthenticator(HTTPBearerTokenAuthenticator):
+    """Authenticate via HTTP 'Authorization: Token TOKEN' header
+
+    It is pretty much the "Bearer TOKEN" method but which uses different keyword
+    "Token".  It is e.g. the one provided by Django REST Framework.
+    GitHub allows for both 'Bearer' and 'Token' keywords:
+    https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28
+    """
+    AUTH_KEYWORD = 'Token'
 
 
 @auto_repr

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -26,6 +26,7 @@ from .http import (
     HTTPDigestAuthAuthenticator,
     HTTPBearerTokenAuthenticator,
     HTTPDownloader,
+    HTTPTokenAuthenticator,
 )
 from .s3 import S3Authenticator, S3Downloader
 from .shub import SHubDownloader
@@ -51,6 +52,7 @@ AUTHENTICATION_TYPES = {
     'http_auth': HTTPAuthAuthenticator,
     'http_basic_auth': HTTPBasicAuthAuthenticator,
     'http_digest_auth': HTTPDigestAuthAuthenticator,
+    'http_token': HTTPTokenAuthenticator,
     'bearer_token': HTTPBearerTokenAuthenticator,
     'bearer_token_anon': HTTPAnonBearerTokenAuthenticator,
     'aws-s3': S3Authenticator,  # TODO: check if having '-' is kosher

--- a/datalad/downloaders/tests/test_http.py
+++ b/datalad/downloaders/tests/test_http.py
@@ -39,6 +39,7 @@ from ..http import (
     HTTPBaseAuthenticator,
     HTTPBearerTokenAuthenticator,
     HTTPDownloader,
+    HTTPTokenAuthenticator,
     process_www_authenticate,
 )
 
@@ -739,6 +740,11 @@ def test_HTTPBearerTokenAuthenticator(d=None):
 
     content = read_file(fpath)
     assert_equal(content, "correct body")
+
+    # While having this test case setup, test the the odd brother
+    downloader = HTTPDownloader(credential=credential, authenticator=HTTPTokenAuthenticator())
+    downloader.download(url, path=d, overwrite=True)
+    assert_equal(request_get_callback.req.headers['Authorization'], "Token testtoken")
 
 
 class FakeLorisCredential(Token):


### PR DESCRIPTION
It is pretty much the "Bearer TOKEN" method but which uses different keyword "Token".  It is e.g. the one provided by Django REST Framework. GitHub allows for both 'Bearer' and 'Token' keywords: https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28

In our case of DANDI we ran into it only now that we decided to add handling of embargoed datasets, for which we need to authenticate to access the files.  We are using Django REST Framework and insofar decision was made to retain current approach (and fix WWW-Authentication header response), instead of an alternative to allow for both  'Bearer' and 'Token' as was suggested in https://github.com/dandi/dandi-archive/pull/1830

As it is ad-hoc (nothing AFAIK in W3C standard) Authentication response I do not think some automation would ever be created based on WWW-Authentication but we will be able to support such providers.

### PR checklist

- [x] Provide an overview of the changes you're making and explain why you're proposing them.
- [x] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title;
  or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).
