### PR TITLE
Update also version: field in CITATION.cff  upon release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,5 +39,6 @@ jobs:
           pypi-token: ${{ secrets.PYPI_TOKEN }}
           pre-tag: |
             make update-changelog
-            git add docs/source/changelog.rst
-            git commit -m '[skip ci] Update docs/source/changelog.rst'
+            perl -pli -e "s/^version:.*/version: $new_version/" CITATION.cff
+            git add docs/source/changelog.rst CITATION.cff
+            git commit -m '[skip ci] Update docs/source/changelog.rst and CITATION.cff'


### PR DESCRIPTION
Ideally we should also update it using con/tributors on the list of authors etc, but that is yet to be developed in con/tributors.

For now custom version boost following instructions by @jwodder in https://github.com/datalad/release-action/issues/52
