### PR TITLE
adjust for new error message in git cat-file

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -829,7 +829,8 @@ class AnnexRepo(GitRepo, RepoInterface):
         except CommandError as e:
             if (
                 ('Not a valid object name git-annex:remote.log' in e.stderr) or  # e.g. git 2.30.2
-                ("fatal: path 'remote.log' does not exist in 'git-annex'" in e.stderr)  # e.g. 2.35.1+next.20220211-1
+                ("fatal: path 'remote.log' does not exist in 'git-annex'" in e.stderr) or # e.g. 2.35.1+next.20220211-1
+                ("fatal: invalid object name 'git-annex'" in e.stderr) # e.g., 2.43.0
             ):
                 # no special remotes configured - might still be in the journal
                 pass


### PR DESCRIPTION
Since at least Git 2.39.2, the error reads:

❱ git cat-file -p git-annex:remote.log
fatal: invalid object name 'git-annex'.

This change adjusts for this in a similar way it has so far been accounted for

