### PR TITLE
add singularity dependency to installation script

### DIFF
--- a/tools/ci/install-singularity.sh
+++ b/tools/ci/install-singularity.sh
@@ -5,6 +5,6 @@ codename="$(lsb_release -cs)"
 arch="$(dpkg --print-architecture)"
 wget -O /tmp/singularity-ce.deb "https://github.com/sylabs/singularity/releases/download/$release/singularity-ce_${release#v}-${codename}_$arch.deb"
 set -x
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y uidmap libfuse2
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y uidmap libfuse2 fuse2fs
 sudo dpkg -i /tmp/singularity-ce.deb
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -f


### PR DESCRIPTION
Recently (e.g., https://github.com/datalad/datalad/pull/7559), Singularity installations failed with
```
sudo dpkg -i /tmp/singularity-ce.deb
Selecting previously unselected package singularity-ce. (Reading database ... 282869 files and directories currently installed.) Preparing to unpack /tmp/singularity-ce.deb ...
Unpacking singularity-ce (4.1.1-jammy) ...
dpkg: dependency problems prevent configuration of singularity-ce:
 singularity-ce depends on fuse2fs; however:
  Package fuse2fs is not installed.

dpkg: error processing package singularity-ce (--install):
 dependency problems - leaving unconfigured
Processing triggers for man-db (2.10.2-1) ...
```
This patch adds the missing dependency.
