### PR TITLE
Load extensions in annex remote entrypoint

### DIFF
--- a/changelog.d/20240416_194511_michael.hanke_remote_extension.md
+++ b/changelog.d/20240416_194511_michael.hanke_remote_extension.md
@@ -1,0 +1,6 @@
+### 🏠 Internal
+
+- The main entrypoint for annex remotes now also runs the standard extension
+  load hook. This enables extensions to alter annex remote implementation
+  behavior in the same way than other DataLad components.
+  (by [@mih](https://github.com/mih))

--- a/datalad/customremotes/main.py
+++ b/datalad/customremotes/main.py
@@ -60,6 +60,13 @@ def _main(args, cls):
 
 def main(args=None, cls=None, remote_name=None, description=None):
     import sys
+    from datalad.support.entrypoints import load_extensions
+    # load extensions requested by configuration
+    # analog to what coreapi is doing for a Python session
+    # importantly, load them prior to parser construction, such
+    # that CLI tuning is also within reach for extensions
+    load_extensions()
+
     parser = setup_parser(remote_name, description)
     # parse cmd args
     args = parser.parse_args(args)


### PR DESCRIPTION
The main entrypoint for annex remotes now also runs the standard extension load hook. This enables extensions to alter annex remote implementation behavior in the same way than other DataLad components.

I see no reason why this code should be an exception.