### PR TITLE
Relax condition in `test_force_checkdatapresent` to avoid flaky test failures

### DIFF
--- a/changelog.d/pr-7581.md
+++ b/changelog.d/pr-7581.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Relax condition in `test_force_checkdatapresent` to avoid flaky test failures.  [PR #7581](https://github.com/datalad/datalad/pull/7581) (by [@christian-monch](https://github.com/christian-monch))

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -499,11 +499,8 @@ def test_force_checkdatapresent(srcpath=None, dstpath=None):
         # before then -- we would report that update was pushed since update had a
         # slightly different git-annex timestamp locally from the remote, and thus commits
         # were different
-        if external_versions['cmd:annex'] < '10.20231212':
-            assert_in_results(res, action='publish', status='ok',
-                              refspec='refs/heads/git-annex:refs/heads/git-annex')
-        else:
-            raise
+        assert_in_results(res, action='publish', status='ok',
+                          refspec='refs/heads/git-annex:refs/heads/git-annex')
 
     assert_in_results(res, status='ok',
                       path=str(src.pathobj / 'test_mod_annex_file'),


### PR DESCRIPTION
This commit changes the code of `datalad.core.distributed.tests.test_push::test_force_checkdatapresent` to no longer assume identical timestamps in the local and the remote git-annex branch.

This addresses the occasional failing of  `datalad.core.distributed.tests.test_push::test_force_checkdatapresent`.