### PR TITLE
Stop testing on Python 3.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -168,9 +168,9 @@ environment:
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
 
     # Test alternative Python versions
-    - ID: Ubu20P37a
+    - ID: Ubu20P311a
       # ~35min
-      PY: 3.7
+      PY: 3.11
       DTS: >
           datalad.cli
           datalad.core
@@ -183,9 +183,9 @@ environment:
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
       INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
-    - ID: Ubu20P37b
+    - ID: Ubu20P311b
       # ~25min
-      PY: 3.7
+      PY: 3.11
       DTS: >
           datalad.downloaders
           datalad.interface

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,10 +26,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -13,10 +13,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -30,10 +30,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -25,10 +25,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.11
 
     - name: Install git-annex
       run: |

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |

--- a/changelog.d/pr-7585.md
+++ b/changelog.d/pr-7585.md
@@ -1,0 +1,7 @@
+### 🧪 Tests
+
+- Stop testing on Python 3.7. Switch MacOS tests to 3.11, include 3.11
+  in Appveyor, and use 3.8 for other tests.
+  Fixes [#7584](https://github.com/datalad/datalad/issues/7584)
+  via [PR #7585](https://github.com/datalad/datalad/pull/7585)
+  (by [@mslw](https://github.com/mslw))


### PR DESCRIPTION
This switches all tests which still used Python 3.7 to use Python 3.8 (or, in Appveyor, 3.11 - see below).

The only exception, and potentially controversial change, is Appveyor, where I went from 3.7 to 3.11 in e52e761. A move to 3.8 would sound logical, but... if I'm seeing correctly, the only difference between Ubu20P37a & Ubu20P37b versus Ubu20core & Ubu20a1 is that the former had "PY: 3.7", while the latter did not set PY at all. And if I'm reading the logs of the latest Appveyor run correctly, Ubu20core & Ubu20a1 run (implicitly?) on Python 3.8.10. I cound not find confirmation that this is the default, but it seems to be.

An alternative (for Appveyor) would be to set PY for Ubu20core & Ubu20a1 to the newest supported (3.11) and use the other two to test oldest supported (3.8). But maybe appveyor tends to stay on the lowest non-EOL version when PY is not specified, in which case the current setup would be preferred (just a guess - couldn't find confirmation)? Please advise.

Note: We still officially support Python 3.7 (`python_requires>=3.7` in setup.py) but I feel a change there is overdue, too, and an easy candidate for a next PR to main.

Fixes #7584 (where tests on latest macOS started failing outright on Python setup).
Follows in the footsteps of #7413.
Addresses part of #7400.
