### PR TITLE
Make github workflow which would ensure that PR against master would have everything from maint merged

### DIFF
--- a/.github/workflows/test-label.yml
+++ b/.github/workflows/test-label.yml
@@ -35,5 +35,35 @@ jobs:
             || contains(github.event.pull_request.labels.*.name, 'semver-performance')
             || contains(github.event.pull_request.labels.*.name, 'semver-tests')
           }}
+  check-sync:
+    name: Check that "master" contains everything from "maint" if PR against "master" is marked for a release
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Code'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all branches to perform the comparison
+
+      - name: 'Check for "release" Label'
+        id: check_label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prLabels = context.payload.pull_request.labels.map(label => label.name);
+            core.setOutput('has_release_label', prLabels.includes('release'));
+
+      - name: 'Check Branch Sync'
+        if: steps.check_label.outputs.has_release_label == 'true' && github.event.pull_request.base.ref == 'master'
+        run: |
+          # Fetch the "maint" branch
+          git fetch origin maint:maint
+ 
+          # Check if "maint" is already merged into "master"
+          if git merge-base --is-ancestor maint master; then
+            echo "All commits from 'maint' are already merged into 'master'."
+          else
+            echo "The 'master' branch is missing commits from 'maint'. Please merge the branches before proceeding."
+            exit 1
+          fi
 
 # vim:set sts=2:

--- a/.github/workflows/test-label.yml
+++ b/.github/workflows/test-label.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           # Fetch the "maint" branch
           git fetch origin maint:maint
+          git fetch origin master:master
  
           # Check if "maint" is already merged into "master"
           if git merge-base --is-ancestor maint master; then

--- a/.github/workflows/test-label.yml
+++ b/.github/workflows/test-label.yml
@@ -38,6 +38,7 @@ jobs:
   check-sync:
     name: Check that "master" contains everything from "maint" if PR against "master" is marked for a release
     runs-on: ubuntu-latest
+    if: github.repository == 'datalad/datalad'
     steps:
       - name: 'Checkout Code'
         uses: actions/checkout@v4

--- a/changelog.d/pr-7590.md
+++ b/changelog.d/pr-7590.md
@@ -1,3 +1,3 @@
 ### 🏠 Internal
 
-- Make github workflow which would ensure that PR against master would have everything from maint merged.  [PR #7590](https://github.com/datalad/datalad/pull/7590) (by [@yarikoptic](https://github.com/yarikoptic))
+- Make github workflow which would ensure that a "release" PR against `master` would have everything from `maint` merged.  [PR #7590](https://github.com/datalad/datalad/pull/7590) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/changelog.d/pr-7590.md
+++ b/changelog.d/pr-7590.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Make github workflow which would ensure that PR against master would have everything from maint merged.  [PR #7590](https://github.com/datalad/datalad/pull/7590) (by [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
I think we should retain the habit of releasing minor (or eventually next major) versions from `master` while patch fixes from `maint` (we might even keep releasing patch fixes for the prior minor I guess... but probably we shouldn't).

This way we can 'stage' for next minor release while releasing patch releases without bottleneck/force to release miors.

With this PR I want to make sure that when we do release next minor, we do include all fixes from `maint`.

As only pertinent to master branch -- I positioned it against master. Also would make it easier to check
 
### PR checklist

- [x] Provide an overview of the changes you're making and explain why you're proposing them.
- [x] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title;
  or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).
- Sophisticate workflow to trigger also on any other push to `master` or `maint` so it stays "up to date" even if no changes to PR happen -- decided to postpone for later... would need more work.

edit: I canceled appveyor since unrelated