### PR TITLE
Refactor loading of extensions: load all by default but allow for configuration

### DIFF
--- a/datalad/api.py
+++ b/datalad/api.py
@@ -43,7 +43,7 @@ if not datalad.in_librarymode():
 def _generate_extension_api():
     """Auto detect all available extensions and generate an API from them
     """
-    from datalad.support.entrypoints import iter_entrypoints
+    from datalad.support.entrypoints import iter_extensions
     from datalad.interface.base import (
         get_api_name,
         load_interface,
@@ -52,8 +52,7 @@ def _generate_extension_api():
     import logging
     lgr = logging.getLogger('datalad.api')
 
-    for ename, _, (grp_descr, interfaces) in iter_entrypoints(
-            'datalad.extensions', load=True):
+    for ename, _, (grp_descr, interfaces) in iter_extensions(load=True):
         for intfspec in interfaces:
             # turn the interface spec into an instance
             intf = load_interface(intfspec[:2])

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -187,8 +187,8 @@ class LogLevelAction(argparse.Action):
 
 
 def add_entrypoints_to_interface_groups(interface_groups):
-    from datalad.support.entrypoints import iter_entrypoints
-    for name, _, spec in iter_entrypoints('datalad.extensions', load=True):
+    from datalad.support.entrypoints import iter_extensions
+    for name, _, spec in iter_extensions(load=True):
         if len(spec) < 2 or not spec[1]:
             # entrypoint identity was logged by the iterator already
             lgr.debug('Extension does not provide a command suite')

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -158,9 +158,9 @@ def _get_procedure_implementation(name='*', ds=None):
                 yield m, n, f, h
 
     # 3. check extensions for procedure
-    from datalad.support.entrypoints import iter_entrypoints
+    from datalad.support.entrypoints import iter_extensions
 
-    for epname, epmodule, _ in iter_entrypoints('datalad.extensions'):
+    for epname, epmodule, _ in iter_extensions():
         res = files(epmodule) / "resources" / "procedures"
         if res.is_dir():
             with as_file(res) as p:

--- a/datalad/support/entrypoints.py
+++ b/datalad/support/entrypoints.py
@@ -68,20 +68,27 @@ def iter_entrypoints(group, load=False):
 def load_extensions():
     """Load entrypoint for any configured extension package
 
-    Log a warning in case a requested extension is not available, or if
-    a requested extension fails on load.
+    By default, all extensions are loaded.  'datalad.extensions.load'
+    can be used to configure which specific extensions to load.
+    An explicitly set empty value avoids loading any extension.
 
-    Extensions to load are taken from the 'datalad.extensions.load'
-    configuration item.
+    Logs a warning in case a requested extension is not available, or if
+    an extension fails on load.
     """
     from datalad import cfg
     load_extensions = cfg.get('datalad.extensions.load', get_all=True)
-    if load_extensions:
+    if load_extensions == '':
+        # empty value is an explicit way to disable loading any extension
+        lgr.debug("Not loading any extensions as requested")
+    else:
         from datalad.utils import ensure_list
         exts = {
             ename: eload
             for ename, _, eload in iter_entrypoints('datalad.extensions')
         }
+        if load_extensions is None:
+            # no explicit list of extensions was requested - load all
+            load_extensions = exts
         for el in ensure_list(load_extensions):
             if el not in exts:
                 lgr.warning('Requested extension %r is not available', el)

--- a/datalad/support/entrypoints.py
+++ b/datalad/support/entrypoints.py
@@ -65,36 +65,71 @@ def iter_entrypoints(group, load=False):
     lgr.debug("Done processing entrypoints")
 
 
-def load_extensions():
-    """Load entrypoint for any configured extension package
+def iter_extensions(load=False):
+    """Iterate over all entrypoints of the 'datalad.extensions' group
 
-    By default, all extensions are loaded.  'datalad.extensions.load'
-    can be used to configure which specific extensions to load.
-    An explicitly set empty value avoids loading any extension.
+    By default, iterates over all extensions. 'datalad.extensions.load'
+    configuration item can be used to configure which specific
+    extensions to consider. An explicitly set empty value avoids
+    considering any extension.
 
     Logs a warning in case a requested extension is not available, or if
     an extension fails on load.
+
+    Parameters
+    ----------
+    load: bool, optional
+      Whether to execute the entry point loader internally in a
+      protected manner that only logs a possible exception and emits
+      a warning, but otherwise skips over "broken" entrypoints.
+      If False, the loader callable is returned unexecuted.
+
+    Yields
+    -------
+    (name, module, load(r|d))
+      The first item in each yielded tuple is the entry point name (str).
+      The second is the name of the module that contains the entry point
+      (str). The type of the third items depends on the load parameter.
+      It is either a callable that can be used to load the entrypoint
+      (this is the default behavior), or the outcome of executing the
+      entry point loader.
     """
+
     from datalad import cfg
-    load_extensions = cfg.get('datalad.extensions.load', get_all=True)
-    if load_extensions == '':
+    load_extensions_cfg = cfg.get('datalad.extensions.load', get_all=True)
+    all_extensions = []
+    if load_extensions_cfg == '':
         # empty value is an explicit way to disable loading any extension
-        lgr.debug("Not loading any extensions as requested")
-    else:
-        from datalad.utils import ensure_list
-        exts = {
-            ename: eload
-            for ename, _, eload in iter_entrypoints('datalad.extensions')
-        }
-        if load_extensions is None:
-            # no explicit list of extensions was requested - load all
-            load_extensions = exts
-        for el in ensure_list(load_extensions):
-            if el not in exts:
-                lgr.warning('Requested extension %r is not available', el)
-                continue
+        lgr.debug("Not considering any extensions as requested")
+        return
+    elif load_extensions_cfg is not None:
+        from datalad.utils import ensure_iter
+        load_extensions_cfg = ensure_iter(load_extensions_cfg, set)
+
+    # We will do loading here to mimic prior behavior/logging better
+    for ename, mod, eload in iter_entrypoints('datalad.extensions', load=False):
+        all_extensions.append(ename)
+        if not (load_extensions_cfg is None or ename in load_extensions_cfg):
+            continue
+        if load:
             try:
-                exts[el]()
+                yield ename, mod, eload()
             except Exception as e:
                 ce = CapturedException(e)
                 lgr.warning('Could not load extension %r: %s', el, ce)
+        else:
+            yield ename, mod, eload
+
+    if load_extensions_cfg:
+        for ext in load_extensions_cfg.difference(all_extensions):
+            lgr.warning('Requested extension %r is not available', ext)
+
+
+def load_extensions():
+    """Load DataLad extensions entrypoints.
+
+    A convenience and compatibility helper over
+    :py:func:`datalad.support.entrypoints.iter_extensions`.
+    """
+    for _ in iter_extensions(load=True):
+        pass

--- a/datalad/tests/test_config.py
+++ b/datalad/tests/test_config.py
@@ -176,6 +176,7 @@ def test_something(path=None, new_home=None):
     # empty value is False
     assert_equal(cfg.getbool('something', 'empty'), False)
     assert_equal(cfg.get('something.empty'), '')
+    assert_equal(cfg.get('something.empty', get_all=True), '')
     assert_equal(cfg.getbool('doesnot', 'exist', default=True), True)
     assert_raises(TypeError, cfg.getbool, 'something', 'user')
 


### PR DESCRIPTION
It should 
- make it easier for naive users to use DataLad -- typically they just install an extension and get extension functionality immediately exposed, e.g. like was reported in 
   -  https://github.com/datalad/datalad-dataverse/issues/302
   - [ ] TODO: check that actually this PR makes it not needed...  
- retain capability to whitelist a list of extensions to consider via `datalad.extensions.load` configuration variable
  - [ ] an option is to deprecate it in favor of `datalad.extensions.enable` which would be more descriptive
- make it uniform across all points which consider extensions, not only for loading
  - or are there specific use-cases where you want to have extension functionality available but not "loaded"? 
