### PR TITLE
Cancel lengthy running workflows if a new commit is pushed

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,10 @@ name: Benchmarks
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   vs-master:
 

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -2,6 +2,10 @@ name: CrippledFS
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   test:
 

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -2,6 +2,10 @@ name: Extensions
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   test:
 

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -4,6 +4,10 @@ on:
     - pull_request
     - push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: macos-latest

--- a/changelog.d/pr-7601.md
+++ b/changelog.d/pr-7601.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Cancel lengthy running workflows if a new commit is pushed.  [PR #7601](https://github.com/datalad/datalad/pull/7601) (by [@jwodder](https://github.com/jwodder))


### PR DESCRIPTION
With this change, if a branch is updated while any of the affected workflows are still running on the branch's previous `HEAD`, the outstanding runs are cancelled.  As a result, the runs for the updated `HEAD` will not have to wait as long for runners to become available, and resources will not be wasted on outdated code.