### PR TITLE
Ensure early patch-loading when running datalad-next extension tests

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -65,6 +65,10 @@ jobs:
           datalad-container)
             DL_NEED_SINGULARITY=1;;
         esac
+        case ${{ matrix.extension }} in
+          datalad-next)
+            DATALAD_EXTENSIONS_LOAD=next;;
+        esac
         {
         echo "DL_PIP_INSTALLS=$DL_PIP_INSTALLS"
         echo "DL_APT_INSTALLS=$DL_APT_INSTALLS"
@@ -73,7 +77,7 @@ jobs:
         echo "DL_NEED_SINGULARITY=$DL_NEED_SINGULARITY"
         echo "DL_PACKAGE=$(echo ${{ matrix.extension }} | tr '-' '_')"
         } >> "$GITHUB_ENV"
-        
+
     - name: Clone and install ${{ matrix.extension }} extension
       run: |
         git clone https://github.com/$DL_REPO __extension__

--- a/changelog.d/pr-7605.md
+++ b/changelog.d/pr-7605.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Ensure early patch-loading when running datalad-next extension tests.  [PR #7605](https://github.com/datalad/datalad/pull/7605) (by [@christian-monch](https://github.com/christian-monch))


### PR DESCRIPTION
Fixes issue [datalad-next #705](https://github.com/datalad/datalad-next/issues/705)

The code in this PR sets `DATALAD_EXTENSIONS_LOAD=next` when testing the datalad-next extension. This is necessary to ensure patches are loaded before the objects they patch are used. 

"Delayed" loading of patches might also be the cause of the errors that were fixed by PR [datalad-next #696](https://github.com/datalad/datalad-next/pull/696). 

I am proposing this patch because it lets datalad-extension tests pass in datalad-next version 1.4.0, and I believe that the previous fix, i.e. [datalad-next #696](https://github.com/datalad/datalad-next/pull/696), should be reverted in the future, if the associated debian-test failures are resolved. 

In the datalad-next extension tests [datalad-next #696](https://github.com/datalad/datalad-next/pull/696) masked a genuine error, i.e. calling new ria-code function from old ria-code functions that used faulty arguments.


ping @mih 
