### PR TITLE
Fixup minor typos in documentation/comments using fresh codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4846,7 +4846,7 @@ New features and bugfix release
 
 New feature and bugfix release
 
-- greately improved documentation
+- greatly improved documentation
 - publish command API RFing allows for custom options to annex, and uses
   --to REMOTE for consistent with annex invocation
 - variety of fixes and enhancements throughout

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, caste, color, religion, or sexual
 identity and orientation.
 

--- a/changelog.d/pr-7610.md
+++ b/changelog.d/pr-7610.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Fixup minor typos in documentation/comments using fresh codespell.  [PR #7610](https://github.com/datalad/datalad/pull/7610) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -109,7 +109,7 @@ def test_save(path=None):
             f.write(fn)
 
     ds.save([op.join(path, f) for f in files])
-    # superfluous call to save (alll saved it already), should not fail
+    # superfluous call to save (all saved it already), should not fail
     # but report that nothing was saved
     assert_status('notneeded', ds.save(message="set of new files"))
     assert_repo_status(path, annex=isinstance(ds.repo, AnnexRepo))

--- a/datalad/distributed/create_sibling_github.py
+++ b/datalad/distributed/create_sibling_github.py
@@ -153,7 +153,7 @@ class CreateSiblingGithub(Interface):
        The ``github_login||--github-login`` option will be removed in a future
        release, use the ``credential||--credential`` option instead.
        The ``github_organization||--github-organization`` option will be
-       removed in a future release, prefix the reposity name with ``<org>/``
+       removed in a future release, prefix the repository name with ``<org>/``
        instead.
     """
 
@@ -286,7 +286,7 @@ class CreateSiblingGithub(Interface):
             warnings.warn(
                 "datalad-create-sibling-github's `github_organization` "
                 "option is deprecated and will be removed in a future "
-                "release, prefix the reposity name with `<org>/` instead.",
+                "release, prefix the repository name with `<org>/` instead.",
                 DeprecationWarning)
             reponame = f'{github_organization}/{reponame}'
 

--- a/datalad/local/remove.py
+++ b/datalad/local/remove.py
@@ -241,7 +241,7 @@ class Remove(Interface):
                     if delpath.is_dir():
                         lgr.debug('Remove directory: %s', delpath)
                         rmtree(delpath)
-                    # cannot use .exists() must forsee dead symlinks
+                    # cannot use .exists() must foresee dead symlinks
                     else:
                         lgr.debug('Remove file: %s', delpath)
                         delpath.unlink()

--- a/datalad/local/tests/test_gitcredential.py
+++ b/datalad/local/tests/test_gitcredential.py
@@ -182,7 +182,7 @@ def test_credential_cycle(path=None):
 """)
     ds.save(message="Add provider config")
 
-    gitcred = GitCredentialInterface(url="https://some.data.exampe.com",
+    gitcred = GitCredentialInterface(url="https://some.data.example.com",
                                      repo=ds)
 
     # There's nothing set up yet, helper should return empty.

--- a/datalad/local/tests/test_rerun.py
+++ b/datalad/local/tests/test_rerun.py
@@ -125,7 +125,7 @@ def test_rerun(path=None, nodspath=None):
     # Now rerun the buried command.
     ds.rerun(revision=DEFAULT_BRANCH + "~", message="rerun buried")
     eq_('xxx\n', open(probe_path).read())
-    # Also check that the messasge override worked.
+    # Also check that the message override worked.
     eq_(last_commit_msg(ds.repo).splitlines()[0],
         "[DATALAD RUNCMD] rerun buried")
     # Or a range of commits, skipping non-run commits.

--- a/datalad/support/locking.py
+++ b/datalad/support/locking.py
@@ -121,7 +121,7 @@ def try_lock_informatively(lock, purpose=None, timeouts=(5, 60, 240), proceed_un
     """Try to acquire lock (while blocking) multiple times while logging INFO messages on failure
 
     Primary use case is for operations which are user-visible and thus should not lock
-    indefinetely or for long period of times (so user would just Ctrl-C if no update is provided)
+    indefinitely or for long period of times (so user would just Ctrl-C if no update is provided)
     without "feedback".
 
     Parameters

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8144,7 +8144,7 @@ New features and bugfix release
 
 New feature and bugfix release
 
--  greately improved documentation
+-  greatly improved documentation
 -  publish command API RFing allows for custom options to annex, and
    uses –to REMOTE for consistent with annex invocation
 -  variety of fixes and enhancements throughout


### PR DESCRIPTION
Ran into in the course of
- https://github.com/datalad/datalad/pull/7603