### PR TITLE
Address github cronjob CI runs issues: inability to build/install old git (wrong version/tag, absent build-depends)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Install minimum Git
         if: matrix.minimum-git
         run: |
+          sudo apt-get install -y gettext libcurl4-gnutls-dev
           tools/ci/install-minimum-git.sh
           echo "$PWD/git-src/bin-wrappers" >> "$GITHUB_PATH"
 

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -817,7 +817,7 @@ class GitRepo(CoreGitRepo):
     # should do it once
     _config_checked = False
 
-    GIT_MIN_VERSION = "2.25"
+    GIT_MIN_VERSION = "2.25.0"
     git_version = None
 
     @classmethod


### PR DESCRIPTION
### PR checklist

- [x] Provide an overview of the changes you're making and explain why you're proposing them.
- [x] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title;
  or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).
- [ ] Remove TEMP commit (lightens up CI and forces to run cron jobs too)