### PR TITLE
For appveyor ssh setup, setup MaxSessions 100 to avoid 'channel 22: open failed: connect failed: open failed'

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -250,6 +250,8 @@ init:
   # enable external SSH access to CI worker on all other systems
   # needs APPVEYOR_SSH_KEY defined in project settings (or environment)
   - sh: curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
+  # Ref: https://github.com/datalad/datalad/issues/5250
+  - sh: sudo sh -c 'echo "MaxSessions 100" >> /etc/ssh/sshd_config' && sudo service sshd restart
   # Identity setup
   - git config --global user.email "test@appveyor.land"
   - git config --global user.name "Appveyor Almighty"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -251,7 +251,7 @@ init:
   # needs APPVEYOR_SSH_KEY defined in project settings (or environment)
   - sh: curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
   # Ref: https://github.com/datalad/datalad/issues/5250
-  - sh: sudo sh -c 'echo "MaxSessions 100" >> /etc/ssh/sshd_config' && sudo service sshd restart
+  - sh: sudo sh -c 'echo "MaxSessions 100" >> /etc/ssh/sshd_config' && if [[ "$(uname)" == "Darwin" ]]; then sudo launchctl kickstart -k system/com.openssh.sshd; else sudo service sshd restart; fi
   # Identity setup
   - git config --global user.email "test@appveyor.land"
   - git config --global user.name "Appveyor Almighty"

--- a/changelog.d/pr-7617.md
+++ b/changelog.d/pr-7617.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- For appveyor ssh setup, setup MaxSessions 100 to avoid 'channel 22: open failed: connect failed: open failed'.  [PR #7617](https://github.com/datalad/datalad/pull/7617) (by [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
ATM our logs are filled up (for appveyor only) with that message:

	datalad@smaug:/mnt/datasets/datalad/ci/logs/2024/06$ git grep -c 'channel 22: open failed: connect failed: open failed'
	03/pr/7575/78ce071/appveyor-9739-success/3vrfsttokn3sww1p.txt:495
	03/pr/7575/78ce071/appveyor-9739-success/v2jqxgatl4ktvapj.txt:495
	...
	06/push/master/4c7e73d/appveyor-9752-success/my9t8hofyi3wqtog.txt:495
	06/push/master/4c7e73d/appveyor-9752-success/wiurn8jerqjjj8eb.txt:495
	06/push/master/60b3a58/appveyor-9755-success/g6w8q0pa1cphp4yl.txt:495
	06/push/master/60b3a58/appveyor-9755-success/onnalbjghayrae2h.txt:495
	11/pr/7592/2783f73/appveyor-9757-failed/uxyukgl6ur9e3okn.txt:176
	11/pr/7592/2783f73/appveyor-9757-success/5ehg7v66rwydo09w.txt:495
	15/pr/7592/a221897/appveyor-9758-failed/ya8xa1wce2412jgw.txt:411
	15/pr/7592/a221897/appveyor-9758-success/46tfk9y4pjgu371t.txt:495

and the issue was old known

- https://github.com/datalad/datalad/issues/5250

and addressed for the docker based setups which use http://github.com/datalad-tester/docker-ssh-target e.g. via the tools/ci/prep-travis-forssh.sh .

Attention to the issue was brought while reviewing stalls in
- https://github.com/datalad/datalad/pull/7592 where such messages were the last things seen.
