### PR TITLE
rf(`CommandError`): now based on datasalad's `CommandError`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ from _datalad_build_support.setup import (
 
 requires = {
     'core': [
+        'datasalad>=0.1.0',
         'platformdirs',
         'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',


### PR DESCRIPTION
This change bases the essential `CommandError` class on the analog class in the new `datasalad` library. This primarily improves the user-facing messaging, and debugging. For example, a `CommandError.__repr__()` no longer returns an empty string, which has hindered investigations in the past.

However, most reporting improvements (e.g., alignment with Python's `subprocess` behavior) have been overwritten again, to maintain the original behavior.

The primary motivation for this change is that in countless places type comparisions with `CommandError` are made, and until all used `CommandError` implementations are using a common basis migration of other code is blocked.

Refs: https://github.com/datalad/datasalad/pull/17, https://github.com/datalad/datalad-next/pull/728