### PR TITLE
test_gracefull_death: raise test_gracefull_death  threshold to 300 from 100

### DIFF
--- a/changelog.d/pr-7619.md
+++ b/changelog.d/pr-7619.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- test_gracefull_death: raise test_gracefull_death  threshold to 300 from 100.  [PR #7619](https://github.com/datalad/datalad/pull/7619) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/support/tests/test_parallel.py
+++ b/datalad/support/tests/test_parallel.py
@@ -172,9 +172,10 @@ def test_gracefull_death():
     results = assert_provides_and_raises(
         ProducerConsumer(range(1000), faulty_consumer, jobs=5), ValueError)
     # and analysis of futures to raise an exception can take some time etc, so
-    # we could get more, but for sure we should not get all 999 and not even a 100
+    # we could get more, but for sure we should not get all 999 and not even a 100.
+    # But some times we get some excursions above 100, so limiting to 300
     if info_log_level:
-        assert_greater(100, len(results))
+        assert_greater(300, len(results))
     assert_equal(results[:4], [0, 2, 3, 4])
 
     def producer():


### PR DESCRIPTION
On the recent ones we had:

	datalad@smaug:/mnt/datasets/datalad/ci/logs/2024$ datalad foreach-dataset -s --o-s relpath bash -c "git grep FAIL.*test_graceful.*assert\ 100"
	01/25/pr/7551/8df6c0c/github-Test on macOS-4860-failed/0_test (brew).txt:2024-01-25T19:43:26.2831880Z FAILED ../tests/test_parallel.py::test_gracefull_death - assert 100 > 178
	01/25/pr/7551/8df6c0c/github-Test on macOS-4860-failed/test (brew)/8_Run tests.txt:2024-01-25T19:43:26.2831150Z FAILED ../tests/test_parallel.py::test_gracefull_death - assert 100 > 178
	02/13/push/maint/b8535c9/github-Test on macOS-4882-failed/1_test (snapshot).txt:2024-02-13T16:01:49.8189220Z FAILED ../tests/test_parallel.py::test_gracefull_death - assert 100 > 107
	02/13/push/maint/b8535c9/github-Test on macOS-4882-failed/test (snapshot)/8_Run tests.txt:2024-02-13T16:01:49.8189210Z FAILED ../tests/test_parallel.py::test_gracefull_death - assert 100 > 107
	06/03/pr/7575/78ce071/appveyor-9739-failed/vfb0o8gscoye5u02.txt:[00:13:52] FAILED ../datalad/support/tests/test_parallel.py::test_gracefull_death - assert 100 > 229
	06/06/pr/7575/4295dd0/appveyor-9750-failed/mm4b8hdqs9tik33x.txt:[00:14:35] FAILED ../datalad/support/tests/test_parallel.py::test_gracefull_death - assert 100 > 105
	06/16/pr/7616/2aecc96/appveyor-9763-failed/h877t5kly4jfdb7a.txt:[00:13:09] FAILED ../datalad/support/tests/test_parallel.py::test_gracefull_death - assert 100 > 104

