### PR TITLE
Replace 3.7 with 3.8 in ASV, contributing docs, and matrix for GitHub CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ particular subsystems in DataLad to inform standard development practice.
 
 ## Development environment
 
-We support Python 3 only (>= 3.7).
+We support Python 3 only (>= 3.8).
 
 See [README.md:Dependencies](README.md#Dependencies) for basic information
 about installation of datalad itself.

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -40,8 +40,8 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    // We are looking into the future now, so benchmarking 3.7
-    "pythons": ["3.7"],
+    // We are looking into the future now, so benchmarking 3.8
+    "pythons": ["3.8"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ datalad_setup(
     install_requires=
         requires['core'] + requires['downloaders'] +
         requires['publish'],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     project_urls={'Homepage': 'https://www.datalad.org',
                   'Developer docs': 'https://docs.datalad.org/en/stable',
                   'User handbook': 'https://handbook.datalad.org',

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -4,7 +4,7 @@
 # conditionally filter out jobs that should only be run on cron; cf.
 # <https://stackoverflow.com/q/65384420/744178>.
 
-- python-version: '3.7'
+- python-version: '3.8'
   extra-envs: {}
 
 - python-version: '3.8'
@@ -43,20 +43,20 @@
     DATALAD_TESTS_GITCONFIG: "\n[annex]\n stalldetection = 1KB/120s\n"
     _DL_ANNEX_INSTALL_SCENARIO: "miniconda --channel conda-forge --python-match minor --batch git-annex -m conda"
 
-- python-version: '3.7'
+- python-version: '3.8'
   cron-only: true
   extra-envs:
     PYTEST_SELECTION: ""
     PYTEST_SELECTION_OP: "not"
 
 # Split runs for v6 since a single one is too long now
-- python-version: '3.7'
+- python-version: '3.8'
   extra-envs:
     DATALAD_SSH_MULTIPLEX__CONNECTIONS: "0"
     DATALAD_RUNTIME_PATHSPEC__FROM__FILE: always
     _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=10.20220525 -m conda"
 
-- python-version: '3.7'
+- python-version: '3.8'
   extra-envs:
     PYTEST_SELECTION_OP: ""
     DATALAD_SSH_MULTIPLEX__CONNECTIONS: "0"
@@ -68,7 +68,7 @@
     LANG: bg_BG.UTF-8
 
 # Run slow etc tests under a single tricky scenario
-- python-version: '3.7'
+- python-version: '3.8'
   extra-envs:
     PYTEST_SELECTION_OP: ""
     _DL_TMPDIR: "/var/tmp/sym link"
@@ -79,7 +79,7 @@
 # A run loaded with various customizations to smoke test those functionalities
 # Apparently moving symlink outside has different effects on abspath
 # See https://github.com/datalad/datalad/issues/878
-- python-version: '3.7'
+- python-version: '3.8'
   extra-envs:
     # eventually: _DL_TMPDIR: "/var/tmp/sym ссылка"
     _DL_TMPDIR: "/var/tmp/sym link"
@@ -93,7 +93,7 @@
     DATALAD_RUNTIME_MAX__BATCHED: "2"
     DATALAD_RUNTIME_MAX__INACTIVE__AGE: "10"
 
-- python-version: '3.7'
+- python-version: '3.8'
   extra-envs:
     # By default no logs will be output. This one is to test with low level but
     # dumped to /dev/null
@@ -116,7 +116,7 @@
     GIT_COMMITTER_EMAIL: committer@example.com
 
 # Test some under NFS mount  (only selected sub-set)
-- python-version: '3.7'
+- python-version: '3.8'
   extra-envs:
     # do not run SSH-based tests due to stall(s)
     # https://github.com/datalad/datalad/pull/4172
@@ -132,26 +132,26 @@
 # TODO: ATM we do not have that minimal version as a Debian package in
 # snapshots!
 
-- python-version: '3.7'
+- python-version: '3.8'
   cron-only: true
   extra-envs:
     _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20200309 -m conda"
 
 # Run with git's master branch rather the default one on the system.
-- python-version: '3.7'
+- python-version: '3.8'
   cron-only: true
   upstream-git: true
   extra-envs:
     DATALAD_USE_DEFAULT_GIT: "1"
 
 # Run with our reported minimum Git version.
-- python-version: '3.7'
+- python-version: '3.8'
   cron-only: true
   minimum-git: true
   extra-envs:
     DATALAD_USE_DEFAULT_GIT: "1"
 
-- python-version: '3.7'
+- python-version: '3.8'
   cron-only: true
   extra-envs:
     # to test operation under root since also would consider FS "crippled" due
@@ -160,7 +160,7 @@
     # no key authentication for root:
     DATALAD_TESTS_SSH: "0"
 
-- python-version: '3.7'
+- python-version: '3.8'
   cron-only: true
   extra-envs:
     DATALAD_TESTS_NONETWORK: "1"
@@ -169,7 +169,7 @@
     https_proxy: ""
 
 # Test under NFS mount  (full, only in master)
-- python-version: '3.7'
+- python-version: '3.8'
   cron-only: true
   allow-failure: true
   extra-envs:
@@ -178,7 +178,7 @@
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)
 # We would need to migrate to boto3 to test it fully, but SSH should work
-#- python-version: '3.7'
+#- python-version: '3.8'
 #  extra-envs:
 #    DATALAD_TESTS_SSH: "1"
 #    UNSET_S3_SECRETS: "1"


### PR DESCRIPTION
Closes #7449 

which was already partially done in other PRs (for appveyor). This one should drop from other CIs and docs.

