### PR TITLE
Make test for presence of max_path in partitions not run for current psutil 6.0.0

### DIFF
--- a/changelog.d/pr-7622.md
+++ b/changelog.d/pr-7622.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Make test for presence of max_path in partitions not run for current psutil 6.0.0.  [PR #7622](https://github.com/datalad/datalad/pull/7622) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/local/tests/test_wtf.py
+++ b/datalad/local/tests/test_wtf.py
@@ -80,8 +80,10 @@ def test_wtf(topdir=None):
         assert_not_in(_HIDDEN, cmo.out)  # all is shown
         assert_in('user.name: ', cmo.out)
         if external_versions['psutil']:
-            # filesystems detail should be reported
-            assert_in('max_pathlength:', cmo.out)
+            if external_versions['psutil'] < '6.0.0':
+                # filesystems detail should be reported, unless 6.0.0 where
+                # it was removed. See https://github.com/giampaolo/psutil/issues/2109
+                assert_in('max_pathlength:', cmo.out)
         else:
             assert_in("Hint: install psutil", cmo.out)
 


### PR DESCRIPTION
See https://github.com/giampaolo/psutil/issues/2109 - reporting of max_path was removed

Should fix our CI which just turned red 