### PR TITLE
Also apt install build-dependencies for "upstream-git" run (cron only)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Install custom Git from upstream
         if: matrix.upstream-git
         run: |
+          sudo apt-get install -y gettext libcurl4-gnutls-dev
           source tools/ci/install-upstream-git.sh
           echo "$target_dir/bin-wrappers" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
should fix one of the failing cron tests. The one left would be NFS fails (#7624) .

edit: I do not think it is worth a changelog since tiny fix for CI testing only