### PR TITLE
Update affiliation of Matthias Riße in .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -128,7 +128,7 @@
             "orcid": "0000-0002-4028-2087"
         },
         {
-            "affiliation": "Institute of Energy and Climate Research - Stratosphere (IEK-7), Research Centre Jülich, Jülich, Germany",
+            "affiliation": "Institute of Climate and Energy Systems - Stratosphere (ICE-4), Research Centre Jülich, Jülich, Germany",
             "name": "Riße, Matthias",
             "orcid": "0009-0006-6081-9327"
         },


### PR DESCRIPTION
While adding myself to the .zenodo.json file of the handbook in https://github.com/datalad-handbook/book/pull/1229 I noticed that my recorded affiliation here is outdated, since our institute was renamed starting yesterday. This is just a quick fix of that.

Hopefully the new name will stick for a while...

@adswa could you take a look here as well?