### PR TITLE
INFRA: Add RTD-recommended configuration ahead of deprecations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -263,6 +263,15 @@ html_show_sourcelink = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'dataladdoc'
 
+# see https://about.readthedocs.com/blog/2024/07/addons-by-default/ for the
+# reasoning behind the following:
+html_context = {}
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {


### PR DESCRIPTION
In an email to maintainers of affected projects, readthedocs advised to make configuration changes ahead of the deprecation of injecting Sphinx- related configurations during build time.
For more info, see: https://about.readthedocs.com/blog/2024/07/addons-by-default/

With this deprecation, Read the Docs will stop defining html_baseurl, and it has to be defined on its own to keep the configured canonical custom domain properly configured.

This change adds the recommended configuration change.