### PR TITLE
Adjust Gitea demo URL to reenable create-sibling-gitea test in datalad-next

### DIFF
--- a/datalad/distributed/tests/test_create_sibling_gitea.py
+++ b/datalad/distributed/tests/test_create_sibling_gitea.py
@@ -24,6 +24,6 @@ def test_gitea(path=None):
         create_sibling_gitea,
         path,
         'gitea',
-        'https://try.gitea.io',
+        'https://demo.gitea.com',
         'api/v1/repos/dataladtester/{reponame}',
     )


### PR DESCRIPTION
I want to reenable the gitea tests in datalad-next (https://github.com/datalad/datalad-next/issues/608). However, the demo Gitea instance moved from try.gitea.io to demo.gitea.com. I've migrated the ``dataladtester`` account, and saved the new token in the Appveyor project settings of datalad-next. Locally, tests pass with this change.
