### PR TITLE
Exit with the original non-0 exit code if underlying functionality, in particular "datalad run", returned incomplete result record with a non-0 exit code

### DIFF
--- a/changelog.d/pr-7641.md
+++ b/changelog.d/pr-7641.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Exit with the original non-0 exit code if underlying functionality, in particular "datalad run", returned incomplete result record with a non-0 exit code.  Fixes [#7504](https://github.com/datalad/datalad/issues/7504) via [PR #7641](https://github.com/datalad/datalad/pull/7641) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -214,8 +214,15 @@ def _run_with_exception_handler(cmdlineargs):
             exit_codes = [
                 r['exit_code'] for r in exc.failed if 'exit_code' in r]
             if exit_codes:
-                # we have exit code(s), take the last one
-                exit_code = exit_codes[-1]
+                # we have exit code(s), take the first non-0 one
+                non0_codes = [e for e in exit_codes if e]
+                if len(non0_codes) != len(exit_codes):
+                    lgr.debug(
+                        "Among %d incomplete results with exit codes %d had exit code 0",
+                        len(exit_codes),
+                        len(exit_codes) - len(non0_codes))
+                if non0_codes:
+                    exit_code = non0_codes[0]
         elif isinstance(exc, CommandError):
             exit_code = _communicate_commanderror(exc) or exit_code
         elif isinstance(exc, KeyboardInterrupt):

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -208,6 +208,14 @@ def _run_with_exception_handler(cmdlineargs):
             # in general we do not want to see the error again, but
             # present in debug output
             lgr.debug('could not perform all requested actions: %s', ce)
+            # fish for an exit code. If any of the "failed" results
+            # is caused by a command error, it will come with an `exit_code`
+            # property.
+            exit_codes = [
+                r['exit_code'] for r in exc.failed if 'exit_code' in r]
+            if exit_codes:
+                # we have exit code(s), take the last one
+                exit_code = exit_codes[-1]
         elif isinstance(exc, CommandError):
             exit_code = _communicate_commanderror(exc) or exit_code
         elif isinstance(exc, KeyboardInterrupt):

--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -211,6 +211,18 @@ def test_combined_short_option():
     assert_in("too few arguments", stderr)
 
 
+# https://github.com/datalad/datalad/issues/7504
+@with_tempfile(mkdir=True)
+def test_run_exit_code(tempdir=None):
+    # datalad run is just an internal command which can readily be used to trigger
+    # desired situation
+    create(dataset=tempdir, annex=False)
+    with chpwd(tempdir):  # can't just use -C tempdir since we do "in process" run_main
+        stdout, stderr = run_main(['run', '--explicit', 'exit 3'], exit_code=3) #, expect_stderr=True)
+    print(stdout)
+    print(stderr)
+
+
 # https://github.com/datalad/datalad/issues/6814
 @with_tempfile(mkdir=True)
 def test_conflicting_short_option(tempdir=None):


### PR DESCRIPTION
Closes #7504 

- pretty much @mih code from comment within that issue
- I just modified it to return first (not last) and non-0 code, not just last one and happen somehow that there are 0 exit codes - debug log about them.
- added a test