### PR TITLE
Declare minimal compat version of pytest to be 7.0

### DIFF
--- a/changelog.d/pr-7645.md
+++ b/changelog.d/pr-7645.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Declare minimal compat version of pytest to be 7.0.  Fixes [#7555](https://github.com/datalad/datalad/issues/7555) via [PR #7645](https://github.com/datalad/datalad/pull/7645) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ requires = {
         'BeautifulSoup4',  # VERY weak requirement, still used in one of the tests
         'httpretty>=0.9.4',  # Introduced py 3.6 support
         'mypy',
-        'pytest',
+        'pytest>=7.0',  # https://github.com/datalad/datalad/issues/7555
         'pytest-cov',
         'pytest-fail-slow~=0.2',
         'types-python-dateutil',


### PR DESCRIPTION
Closes: https://github.com/datalad/datalad/issues/7555
