### PR TITLE
Provide detail on why CHECKURL failed for datalad and archive special remotes (would require new AnnexRemote release (above 1.6.5) to take advantage of this PR)

### DIFF
--- a/changelog.d/pr-7648.md
+++ b/changelog.d/pr-7648.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Provide detail on why CHECKURL failed for datalad and archive special remotes (would require new AnnexRemote release (above 1.6.5) to take advantage of this PR).  [PR #7648](https://github.com/datalad/datalad/pull/7648) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/customremotes/archives.py
+++ b/datalad/customremotes/archives.py
@@ -312,7 +312,7 @@ class ArchiveAnnexCustomRemote(AnnexCustomRemote):
         else:
             # TODO: theoretically we should first check if key is available
             # from any remote to know if file is available
-            return False
+            raise RemoteError(f"archive key {akey} is not available locally.")
 
     def checkpresent(self, key):
         # TODO: so we need to maintain mapping from urls to keys.  Then

--- a/datalad/customremotes/datalad.py
+++ b/datalad/customremotes/datalad.py
@@ -13,16 +13,15 @@ __docformat__ = 'restructuredtext'
 import logging
 from urllib.parse import urlparse
 
+from datalad.customremotes import RemoteError
+from datalad.customremotes.base import AnnexCustomRemote
+from datalad.customremotes.main import main as super_main
 from datalad.downloaders.providers import Providers
 from datalad.support.exceptions import (
     CapturedException,
     TargetFileAbsent,
 )
 from datalad.utils import unique
-
-from datalad.customremotes import RemoteError
-from datalad.customremotes.base import AnnexCustomRemote
-from datalad.customremotes.main import main as super_main
 
 lgr = logging.getLogger('datalad.customremotes.datalad')
 
@@ -72,7 +71,7 @@ class DataladAnnexCustomRemote(AnnexCustomRemote):
         except Exception as exc:
             ce = CapturedException(exc)
             self.message("Failed to check url %s: %s" % (url, ce))
-            return False
+            raise RemoteError(str(ce))
 
     def checkpresent(self, key):
         resp = None


### PR DESCRIPTION
Inspired by

- https://github.com/datalad/datalad-container/issues/267

but to be of benefit, requires review/merge/release of

- https://github.com/Lykos153/AnnexRemote/pull/106

But should be safe otherwise since ATM (without the above PR) AnnexRemote simply ignores the message
