### PR TITLE
BF: replace url for codecov uploader for macos to versioned one with two archs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -102,7 +102,7 @@ environment:
       #INSTALL_GITANNEX: git-annex=8.20201129
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
-      CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
+      CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
 
     # Additional test runs
     - ID: Ubu20a1
@@ -155,7 +155,7 @@ environment:
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
-      CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
+      CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
     - ID: MacP38a2
       # ~40min
       DTS: >
@@ -165,7 +165,7 @@ environment:
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
-      CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
+      CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
 
     # Test alternative Python versions
     - ID: Ubu20P311a

--- a/changelog.d/pr-7649.md
+++ b/changelog.d/pr-7649.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- BF: replace url for codecov uploader for macos to versioned one with two archs.  Fixes [#7642](https://github.com/datalad/datalad/issues/7642) via [PR #7649](https://github.com/datalad/datalad/pull/7649) (by [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
Otherwise we have been failing to upload codecov reports on appveyor for awhile.

The https://cli.codecov.io/macos/latest "folder" cannot be used directly -- url there is leading to versioned codecov release so I am using that one. Pros: no surprises.

Solution found at
https://github.com/codecov/feedback/issues/141#issuecomment-1932418305

Here is how two differ:

	❯ wget https://cli.codecov.io/v0.7.4/macos/codecov
    ...
	Length: 22362720 (21M) [application/octet-stream]
	Saving to: ‘codecov’

	codecov                100%[=========================>]  21.33M  81.5MB/s    in 0.3s

	2024-08-30 08:22:04 (81.5 MB/s) - ‘codecov’ saved [22362720/22362720]

	❯ wget https://uploader.codecov.io/latest/macos/codecov
    ...
	Length: 52719456 (50M) [application/octet-stream]
	Saving to: ‘codecov.1’

	codecov.1              100%[=========================>]  50.28M  88.9MB/s    in 0.6s

	2024-08-30 08:22:12 (88.9 MB/s) - ‘codecov.1’ saved [52719456/52719456]

	❯ file codecov*
	codecov:   Mach-O universal binary with 2 architectures: [x86_64:\012- Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>] [\012- arm64:\012- Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>]
	codecov.1: Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|WEAK_DEFINES|BINDS_TO_WEAK|PIE|HAS_TLV_DESCRIPTORS>

Fixes #7642 