### PR TITLE
BF: allow for empty output directory to be specified to run

### DIFF
--- a/changelog.d/pr-7654.md
+++ b/changelog.d/pr-7654.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: allow for empty output directory to be specified to run.  Fixes [#7653](https://github.com/datalad/datalad/issues/7653) via [PR #7654](https://github.com/datalad/datalad/pull/7654) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -562,6 +562,12 @@ def _unlock_or_remove(dset_path, paths, remove=False):
                and "cannot unlock" in res["message"]:
                 to_remove.append(res)
                 continue
+            elif (
+                res["status"] == "error" and res["error_message"] == "File unknown to git"
+                and op.isdir(res["path"]) and not os.listdir(res["path"])
+            ):
+                lgr.debug("Empty directory %(path)s is not known to git, skipping unlock", res)
+                continue
             yield res
     # Avoid `datalad remove` because it calls git-rm underneath, which will
     # remove leading directories if no other files remain. See gh-5486.

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -308,9 +308,11 @@ def test_run_from_subds_gh3551(path=None):
 def test_run_empty_output(path=None):
     ds = Dataset(path).create(force=True)
     ds.save()
+    # TODO: replace "echo ..." with "cd ." after git-annex fixed to handle empty files
+    # https://git-annex.branchable.com/bugs/git_diff_in_adj_unlock_reports_diff_for_empty_file/
     with chpwd(ds.path):
         assert_in_results(
-            run("cd .> output_empty/f",
+            run("echo content> output_empty/f",
                 outputs=["output_file", "output_empty", "output_withfile"],
                 return_type="list", result_filter=None, result_xfm=None),
             action="save",

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -298,6 +298,25 @@ def test_run_from_subds_gh3551(path=None):
         # https://github.com/datalad/datalad/pull/3747/checks?check_run_id=248506560#step:8:254
         ok_(subds.repo.file_has_content("f"))
 
+# https://github.com/datalad/datalad/issues/7653
+@with_tree(tree={
+    "output_file": "",
+    "output_empty": {},
+    # to ensure that we do unlock etc the other outputs
+    "output_withfile": {"f": "content"},
+})
+def test_run_empty_output(path=None):
+    ds = Dataset(path).create(force=True)
+    ds.save()
+    with chpwd(ds.path):
+        assert_in_results(
+            run("cd .> output_empty/f",
+                outputs=["output_file", "output_empty", "output_withfile"],
+                return_type="list", result_filter=None, result_xfm=None),
+            action="save",
+            status="ok")
+    ok_(ds.repo.file_has_content("output_empty/f"))
+
 
 @with_tempfile(mkdir=True)
 def test_run_assume_ready(path=None):


### PR DESCRIPTION
ATM git annex find call would leak error message from git that the path (directory) is not known to it, since git does not track directories. We obviously treat it as error and yield an "error" record. We seems took good care about handling all the other results from annex even though overall command errored out -- so it seems to be safe to just ignore such specific error message and proceed -- apparently there is no subsequent hiccups.

- Fixes #7653
