### PR TITLE
OPT: use set O(log(n)) instead of list O(n) for checking if modified in _check_files

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -1997,10 +1997,11 @@ class AnnexRepo(GitRepo, RepoInterface):
         # ATTN: test_AnnexRepo_file_has_content has a failure before Git
         # v2.13 (tested back to v2.9) because this diff call unexpectedly
         # reports a type change as modified.
-        modified = [
+        modified = {
             f for f in self.call_git_items_(
                 ['diff', '--name-only', '-z'], sep='\0')
-            if f] if pointers else []
+            if f
+        } if pointers else set()
         annex_res = fn(files, normalize_paths=False, batch=batch)
         return [bool(annex_res.get(f) and
                      not (pointers and normpath(f) in modified))


### PR DESCRIPTION
Likely impact is minimal since likely is not used for heavy lists of files, but who knows