### PR TITLE
Remove import of GIT_SSH_COMMAND within .consts (import directly from datalad.runner.gitrunner)

### DIFF
--- a/changelog.d/pr-7656.md
+++ b/changelog.d/pr-7656.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- Remove import of GIT_SSH_COMMAND within .consts (import directly from datalad.runner.gitrunner).  [PR #7656](https://github.com/datalad/datalad/pull/7656) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/consts.py
+++ b/datalad/consts.py
@@ -10,8 +10,8 @@
 """
 
 import os
-from os.path import join
 import re
+from os.path import join
 
 # directory containing prepared metadata of a dataset repository:
 DATALAD_DOTDIR = ".datalad"
@@ -47,9 +47,6 @@ WEB_META_LOG = join(DATALAD_GIT_DIR, 'logs')
 
 # Format to use for time stamps
 TIMESTAMP_FMT = "%Y-%m-%dT%H:%M:%S%z"
-
-# in order to avoid breakage, import runner-related const
-from datalad.runner.gitrunner import GIT_SSH_COMMAND
 
 # magic sha is from `git hash-object -t tree /dev/null`, i.e. from nothing
 PRE_INIT_COMMIT_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'


### PR DESCRIPTION
It was added there for compatibility in 24d463109ececaa2e9633daa7445516330f01f73 when moved deeper in hierarchy.

I think it would be best for us to avoid deeper imports in this file and thus to avoid possible circular imports observed in the past. Ref: https://github.com/datalad/datalad/issues/7393

Even though it would "break" external API, I think it is unlikely someone relies on this in extensions (I could be proven wrong), and thus I think it should be ok to release in minor release.