### PR TITLE
Docs: Fix glossary entry reference to the handbook on extensions

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -52,9 +52,8 @@ them to the corresponding Git_/git-annex_ concepts.
     A Python package, developed outside of the core DataLad codebase, which
     (when installed) typically either provides additional top level `datalad`
     commands and/or additional metadata extractors.  Visit
-    `Handbook, Ch.2. DataLad’s extensions <http://handbook.datalad.org/en/latest/basics/101-144-intro_extensions.html>`_
-    for a representative list of extensions and instructions on how to install
-    them.
+    `Handbook, Ch.2. DataLad’s extensions <https://handbook.datalad.org/en/latest/beyond_basics/basics-extensions.html>`_
+    for general information about extensions, a non-exhaustive list of extensions and instructions on how to install them, and walk-throughs of selected extensions.
 
 .. _Git: https://git-scm.com
 .. _Git-annex: http://git-annex.branchable.com


### PR DESCRIPTION
This fixes a link, and a description what to find there. No changelog needed IMO