### PR TITLE
Try to address git-annex/cabal installation: Use "sonoma" (2023) instead of "monterey" (2021) on Appveyor for OSX

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,7 +95,7 @@ environment:
     - ID: MacP38core
       # ~40min
       DTS: datalad.core datalad.dataset datalad.runner datalad.support
-      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-sonoma
       PY: 3.8
       # does not give a functional installation
       # INSTALL_GITANNEX: git-annex -m snapshot
@@ -151,7 +151,7 @@ environment:
           datalad.interface
           datalad.tests
           datalad.ui
-      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-sonoma
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
@@ -161,7 +161,7 @@ environment:
       DTS: >
           datalad.local
           datalad.distributed
-      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-sonoma
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets


### PR DESCRIPTION
ATM our appveyor on OSX times out while running tests. Actually for running tests it has barely 5 minutes left since otherwise it (brew?) seems to be taking care about installing git-annex judging from timings like

    [00:02:54] ==> Installing git-annex
    [00:03:02] ==> cabal v2-update^M
    [00:03:36] ==> cabal v2-install --flags=+S3^M
    [00:55:45] ==> Caveats
    [00:55:45] To start git-annex now and restart at login:
    [00:55:45]   brew services start git-annex
    [00:55:45] Or, if you don't want/need a background service you can just run:
    [00:55:45]   /usr/local/opt/git-annex/bin/git-annex assistant --autostart

I see that in datasalad @mih is using sonoma so decided to check if it would be the same.

FWIW it is also something "new" since it used to be quick as e.g. last month:

	datalad@smaug:/mnt/datasets/datalad/ci/logs/2024/09$ git grep '\] To start git-annex now and restart at login' | tail
	10/push/maint/f71ff4f/appveyor-9849-success/u6sj7gppun9h9jnw.txt:[00:00:45] To start git-annex now and restart at login:
	10/push/maint/f71ff4f/appveyor-9849-success/u6sj7gppun9h9jnw.txt:[00:00:49] To start git-annex now and restart at login:
	10/push/maint/f71ff4f/appveyor-9849-success/yvlyi46pkcy7ew9u.txt:[00:00:50] To start git-annex now and restart at login:
	10/push/maint/f71ff4f/appveyor-9849-success/yvlyi46pkcy7ew9u.txt:[00:00:53] To start git-annex now and restart at login:
	24/pr/7643/7e7ad48/appveyor-9851-success/4snf59wyahu701g1.txt:[00:00:53] To start git-annex now and restart at login:
	24/pr/7643/7e7ad48/appveyor-9851-success/4snf59wyahu701g1.txt:[00:00:57] To start git-annex now and restart at login:
	24/pr/7643/7e7ad48/appveyor-9851-success/idu7mku8x7s01ts3.txt:[00:00:54] To start git-annex now and restart at login:
	24/pr/7643/7e7ad48/appveyor-9851-success/idu7mku8x7s01ts3.txt:[00:00:59] To start git-annex now and restart at login:
	24/pr/7643/7e7ad48/appveyor-9851-success/ypkmo7119s6y1p61.txt:[00:00:57] To start git-annex now and restart at login:
	24/pr/7643/7e7ad48/appveyor-9851-success/ypkmo7119s6y1p61.txt:[00:01:02] To start git-annex now and restart at login:

and all available for this month already slow:

	datalad@smaug:/mnt/datasets/datalad/ci/logs/2024/10$ git grep '\] To start git-annex now and restart at login'
	10/pr/7247/f0fe28a/appveyor-9852-failed/nmaoji34v63d0xt9.txt:[00:52:33] To start git-annex now and restart at login:
	10/pr/7247/f0fe28a/appveyor-9852-failed/nmaoji34v63d0xt9.txt:[00:52:39] To start git-annex now and restart at login:
	10/pr/7247/f0fe28a/appveyor-9852-failed/v88a5mn3gt59r96p.txt:[00:51:29] To start git-annex now and restart at login:
	10/pr/7247/f0fe28a/appveyor-9852-failed/v88a5mn3gt59r96p.txt:[00:51:35] To start git-annex now and restart at login:
	14/pr/7667/a96ee8b/appveyor-9853-failed/rfp9yk7mwff55b2j.txt:[00:55:45] To start git-annex now and restart at login:
	14/pr/7667/a96ee8b/appveyor-9853-failed/rfp9yk7mwff55b2j.txt:[00:55:52] To start git-annex now and restart at login:
	14/pr/7667/a96ee8b/appveyor-9853-failed/vxa92xnqruk93iox.txt:[00:52:48] To start git-annex now and restart at login:
	14/pr/7667/a96ee8b/appveyor-9853-failed/vxa92xnqruk93iox.txt:[00:52:56] To start git-annex now and restart at login:

Complement to
- #7667 
