### PR TITLE
Only run scheduled tests on GitHub for datalad/datalad

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ env:
 
 jobs:
   filter:
+    if: ${{ github.repository == 'datalad/datalad' || github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     outputs:
       jobs: ${{ steps.jobs.outputs.matrix }}
@@ -49,6 +50,7 @@ jobs:
           echo 'EOT' >> "$GITHUB_OUTPUT"
 
   test:
+    if: ${{ github.repository == 'datalad/datalad' || github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     needs: filter
     strategy:


### PR DESCRIPTION
This adds a repository conditional to the jobs in the "Test" GitHub workflow, which is triggered on schedule. As such, it should be disabled by default in forks, but e.g. manually pushing the main branch to a fork created before the action was added will cause it to become enabled.

Based on:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository

See also:
https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow

Closes #7672 