### PR TITLE
fix: do load extension interfaces if early parsing errors out

### DIFF
--- a/changelog.d/pr-7679.md
+++ b/changelog.d/pr-7679.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- fix: do load extension interfaces if early parsing errors out.  Fixes [#7678](https://github.com/datalad/datalad/issues/7678) via [PR #7679](https://github.com/datalad/datalad/pull/7679) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -124,9 +124,10 @@ def setup_parser(
 
     # when completing and we have no incomplete option or parameter
     # we still need to offer all commands for completion
-    if (completing and status == 'allknown') or (
+    if ((completing and status == 'allknown') or (
             status == 'subcommand' and parseinfo not in
-            get_commands_from_groups(interface_groups)):
+            get_commands_from_groups(interface_groups))
+            or status == 'error'):
         # we know the command is not in the core package
         # still a chance it could be in an extension
         command_provider = 'extension'


### PR DESCRIPTION
Apparently we have not been loading them upon error in early parsing. Debian has python 3.12 patched with some patches from what came after 3.14 (!) and that broke that interface.  We silently just did not even try to get those parsers in place.  With this change we would

TODOs
- ~~add a fix to actually use that new `intermixed` flag~~ -- we seems just need to drop 3.8 and stop using the protected method there -- will do separate PR!  That would also unblock testing datalad-neuroimaging which dropped 3.8 already

- In effect fixes #7678