### PR TITLE
fix: remove unnecessary and confusing .path from error message

### DIFF
--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2393,7 +2393,7 @@ class GitRepo(CoreGitRepo):
         # bring into traditional shape
         for name, props in mods.items():
             if 'path' not in props:
-                lgr.warning("Failed to get '%s.path', skipping this submodule", name)
+                lgr.warning("Failed to get '%s', skipping this submodule", name)
                 continue
             modprops = {'gitmodule_{}'.format(k): v
                         for k, v in props.items()


### PR DESCRIPTION
Leads to such messages as

    ❯ datalad get . -r
     [WARNING] Failed to get 'tests/data-for-tests.path', skipping this submodule

which are misleading
