### PR TITLE
Drop Python 3.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -335,6 +335,7 @@ before_test:
   - ssh -v localhost exit
   - ssh datalad-test exit
   - ssh datalad-test2 exit
+  - python -m pip freeze
   - datalad wtf
 
 
@@ -350,6 +351,7 @@ test_script:
 
 after_test:
   - sh: python -m coverage combine -a /tmp/.coverage-entrypoints-*;
+  - python -m coverage debug sys
   - python -m coverage xml
   - cmd: curl -fsSL -o codecov.exe "https://uploader.codecov.io/latest/windows/codecov.exe"
   - cmd: .\codecov.exe -f "coverage.xml"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ environment:
     # is a need for debugging
 
     # Ubuntu core tests
-    - ID: Ubu20core
+    - ID: Ubu22core
       # ~30min
       DTS: >
           datalad.cli
@@ -75,7 +75,8 @@ environment:
           datalad.dataset
           datalad.distributed
           datalad.distribution
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
+      PY: 3.9
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
@@ -105,7 +106,7 @@ environment:
       CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
 
     # Additional test runs
-    - ID: Ubu20a1
+    - ID: Ubu22a1
       # ~30min
       DTS: >
           datalad.downloaders
@@ -115,7 +116,8 @@ environment:
           datalad.support
           datalad.tests
           datalad.ui
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
+      PY: 3.9
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
@@ -168,7 +170,7 @@ environment:
       CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
 
     # Test alternative Python versions
-    - ID: Ubu20P311a
+    - ID: Ubu22P311a
       # ~35min
       PY: 3.11
       DTS: >
@@ -178,12 +180,12 @@ environment:
           datalad.dataset
           datalad.distributed
           datalad.distribution
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
       INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
-    - ID: Ubu20P311b
+    - ID: Ubu22P311b
       # ~25min
       PY: 3.11
       DTS: >
@@ -194,7 +196,7 @@ environment:
           datalad.support
           datalad.tests
           datalad.ui
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -80,7 +80,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m snapshot
     # Windows core tests
     - ID: WinP39core
       # ~35 min
@@ -121,7 +121,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m snapshot
     - ID: WinP39a1
       # ~40min
       DTS: >
@@ -184,7 +184,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m snapshot
     - ID: Ubu22P311b
       # ~25min
       PY: 3.11
@@ -200,7 +200,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex_8.20210903-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m snapshot
 
 matrix:
   allow_failures:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -101,7 +101,7 @@ environment:
       # does not give a functional installation
       # INSTALL_GITANNEX: git-annex -m snapshot
       #INSTALL_GITANNEX: git-annex=8.20201129
-      INSTALL_GITANNEX: git-annex
+      INSTALL_GITANNEX: git-annex -m datalad/packages
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
 
@@ -155,7 +155,7 @@ environment:
           datalad.ui
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.9
-      INSTALL_GITANNEX: git-annex
+      INSTALL_GITANNEX: git-annex -m datalad/packages
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
     - ID: MacP39a2
@@ -165,7 +165,7 @@ environment:
           datalad.distributed
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.9
-      INSTALL_GITANNEX: git-annex
+      INSTALL_GITANNEX: git-annex -m datalad/packages
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
 
@@ -229,7 +229,7 @@ cache:
   - /home/appveyor/.cache/pip -> .appveyor.yml
   # TODO: where is the cache on macOS?
   #- /Users/appveyor/.cache/pip -> .appveyor.yml
-  # TODO: Can we cache `brew`?
+  # TODO: Can we cache `rew`?
   #- /usr/local/Cellar
   #- /usr/local/bin
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -92,11 +92,11 @@ environment:
       # This one is set in master but kept without change in maint for now
       # INSTALL_GITANNEX: git-annex -m datalad/packages
     # MacOS core tests
-    - ID: MacP38core
+    - ID: MacP39core
       # ~40min
       DTS: datalad.core datalad.dataset datalad.runner datalad.support
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
-      PY: 3.8
+      PY: 3.9
       # does not give a functional installation
       # INSTALL_GITANNEX: git-annex -m snapshot
       #INSTALL_GITANNEX: git-annex=8.20201129
@@ -141,7 +141,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       PY: 39-x64
 
-    - ID: MacP38a1
+    - ID: MacP39a1
       # ~40min
       DTS: >
           datalad.cli
@@ -152,17 +152,17 @@ environment:
           datalad.tests
           datalad.ui
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
-      PY: 3.8
+      PY: 3.9
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
-    - ID: MacP38a2
+    - ID: MacP39a2
       # ~40min
       DTS: >
           datalad.local
           datalad.distributed
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
-      PY: 3.8
+      PY: 3.9
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,10 +30,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -13,10 +13,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,9 @@ jobs:
         run: sudo pip install --user .
 
       - name: Report WTF information using system-wide installed version
-        run: datalad wtf
+        run: |
+          datalad wtf
+          python -m pip freeze
 
       - name: Run tests
         run: |
@@ -229,7 +231,9 @@ jobs:
       # non-cron jobs, but report for all
 
       - name: Report coverage
-        run: python -m coverage report
+        run: |
+          python -m coverage debug sys
+          python -m coverage report
         working-directory: __testhome__
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -34,10 +34,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -43,10 +43,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install DataLad and dependencies
       run: |

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -92,6 +92,7 @@ jobs:
     - name: WTF!?
       run: |
         datalad wtf
+        python -m pip freeze
 
     - name: ${{ matrix.extension }} tests using pytest
       run: |
@@ -106,6 +107,7 @@ jobs:
     - name: Prepare coverage
       run: |
         cd __testhome__
+        python -m coverage debug sys
         python -m coverage xml
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ particular subsystems in DataLad to inform standard development practice.
 
 ## Development environment
 
-We support Python 3 only (>= 3.8).
+We support Python 3 only (>= 3.9).
 
 See [README.md:Dependencies](README.md#Dependencies) for basic information
 about installation of datalad itself.

--- a/_datalad_build_support/setup.py
+++ b/_datalad_build_support/setup.py
@@ -49,11 +49,7 @@ def get_version(name):
       Name of the folder (package) where from to read version.py
     """
     # delay import so we do not require it for a simple setup stage
-    try:
-        from importlib.metadata import version as importlib_version
-    except ImportError:
-        # TODO - remove whenever python >= 3.8
-        from importlib_metadata import version as importlib_version
+    from importlib.metadata import version as importlib_version
     return importlib_version(name)
 
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -40,8 +40,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    // We are looking into the future now, so benchmarking 3.8
-    "pythons": ["3.8"],
+    "pythons": ["3.12"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/changelog.d/pr-7682.md
+++ b/changelog.d/pr-7682.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Drop Python 3.8.  Fixes [#7678](https://github.com/datalad/datalad/issues/7678) via [PR #7682](https://github.com/datalad/datalad/pull/7682) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/cli/parser.py
+++ b/datalad/cli/parser.py
@@ -98,11 +98,7 @@ def setup_parser(
         description=help_gist,
         formatter_class=formatter_class,
         add_help=False,
-        # TODO: when dropping support for Python 3.8: uncomment below
-        # and use parse_known_args instead of _parse_known_args:
-        # # set to False so parse_known_args does not add its error handling
-        # # Added while RFing from using _parse_known_args to parse_known_args.
-        # exit_on_error=False,
+        exit_on_error=False,
     )
 
     # common options
@@ -353,7 +349,7 @@ def single_subparser_possible(cmdlineargs, parser, completing):
     # Before doing anything additional and possibly expensive see may be that
     # we have got the command already
     try:
-        parsed_args, unparsed_args = parser._parse_known_args(
+        parsed_args, unparsed_args = parser.parse_known_args(
             cmdlineargs[1:], argparse.Namespace())
         # before anything handle possible datalad --version
         if not unparsed_args and getattr(parsed_args, 'version', None):

--- a/datalad/support/parallel.py
+++ b/datalad/support/parallel.py
@@ -89,8 +89,6 @@ class ProducerConsumer:
     -----
     - with jobs > 1, results are yielded as soon as available, so order
       might not match the one provided by "producer".
-    - jobs > 1, is "effective" only for Python >= 3.8.  For older versions it
-      would log a warning (upon initial encounter) if jobs > 1 is specified.
     - `producer` must produce unique entries. AssertionError might be raised if
       the same entry is to be consumed.
     - `consumer` can add to the queue of items produced by producer via

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ requires = {
         'platformdirs',
         'chardet>=3.0.4',      # rarely used but small/omnipresent
         'colorama; platform_system=="Windows"',
-        'distro; python_version >= "3.8"',
+        'distro',
         'importlib-metadata >=3.6; python_version < "3.10"',
-        'importlib-resources >= 3.0; python_version < "3.9"',
         'iso8601',
         'humanize',
         'fasteners>=0.14',
@@ -169,7 +168,7 @@ datalad_setup(
     install_requires=
         requires['core'] + requires['downloaders'] +
         requires['publish'],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     project_urls={'Homepage': 'https://www.datalad.org',
                   'Developer docs': 'https://docs.datalad.org/en/stable',
                   'User handbook': 'https://handbook.datalad.org',

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ requires.update({
     ],
     'devel-utils': [
         'asv',        # benchmarks
-        'coverage',
+        # https://github.com/nedbat/coveragepy/issues/1891#issuecomment-2477760029
+        'coverage<=7.6.4',
         'gprof2dot',  # rendering cProfile output as a graph image
         'psutil',
         'pytest-xdist',  # parallelize pytest runs etc

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,7 @@ requires.update({
     ],
     'devel-utils': [
         'asv',        # benchmarks
-        # https://github.com/nedbat/coveragepy/issues/1891#issuecomment-2477760029
-        'coverage<=7.6.4',
+        'coverage!=7.6.5',
         'gprof2dot',  # rendering cProfile output as a graph image
         'psutil',
         'pytest-xdist',  # parallelize pytest runs etc

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -4,10 +4,10 @@
 # conditionally filter out jobs that should only be run on cron; cf.
 # <https://stackoverflow.com/q/65384420/744178>.
 
-- python-version: '3.8'
+- python-version: '3.9'
   extra-envs: {}
 
-- python-version: '3.8'
+- python-version: '3.9'
   # Run all tests in a single whoop here
   # We cannot have empty -A selector, so the one which always will be fulfilled
   extra-envs:
@@ -18,7 +18,7 @@
     # since should not hurt.
     LC_ALL: ru_RU.UTF-8
 
-- python-version: '3.9'
+- python-version: '3.10'
   extra-envs:
     PYTEST_SELECTION: ""
     PYTEST_SELECTION_OP: "not"
@@ -27,7 +27,7 @@
 # git annex new version of repo" and various extra options/features enabled for
 # git-annex
 
-- python-version: '3.11'
+- python-version: '3.12'
   extra-envs:
     PYTEST_SELECTION: ""
     PYTEST_SELECTION_OP: "not"
@@ -35,7 +35,7 @@
     DATALAD_TESTS_GITCONFIG: "\n[annex]\n stalldetection = 1KB/120s\n"
     _DL_ANNEX_INSTALL_SCENARIO: "miniconda --channel conda-forge --python-match minor --batch git-annex -m conda"
 
-- python-version: '3.11'
+- python-version: '3.12'
   extra-envs:
     PYTEST_SELECTION: ""
     PYTEST_SELECTION_OP: ""
@@ -43,20 +43,20 @@
     DATALAD_TESTS_GITCONFIG: "\n[annex]\n stalldetection = 1KB/120s\n"
     _DL_ANNEX_INSTALL_SCENARIO: "miniconda --channel conda-forge --python-match minor --batch git-annex -m conda"
 
-- python-version: '3.8'
+- python-version: '3.9'
   cron-only: true
   extra-envs:
     PYTEST_SELECTION: ""
     PYTEST_SELECTION_OP: "not"
 
 # Split runs for v6 since a single one is too long now
-- python-version: '3.8'
+- python-version: '3.9'
   extra-envs:
     DATALAD_SSH_MULTIPLEX__CONNECTIONS: "0"
     DATALAD_RUNTIME_PATHSPEC__FROM__FILE: always
     _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=10.20220525 -m conda"
 
-- python-version: '3.8'
+- python-version: '3.9'
   extra-envs:
     PYTEST_SELECTION_OP: ""
     DATALAD_SSH_MULTIPLEX__CONNECTIONS: "0"
@@ -68,7 +68,7 @@
     LANG: bg_BG.UTF-8
 
 # Run slow etc tests under a single tricky scenario
-- python-version: '3.8'
+- python-version: '3.9'
   extra-envs:
     PYTEST_SELECTION_OP: ""
     _DL_TMPDIR: "/var/tmp/sym link"
@@ -79,7 +79,7 @@
 # A run loaded with various customizations to smoke test those functionalities
 # Apparently moving symlink outside has different effects on abspath
 # See https://github.com/datalad/datalad/issues/878
-- python-version: '3.8'
+- python-version: '3.9'
   extra-envs:
     # eventually: _DL_TMPDIR: "/var/tmp/sym ссылка"
     _DL_TMPDIR: "/var/tmp/sym link"
@@ -93,7 +93,7 @@
     DATALAD_RUNTIME_MAX__BATCHED: "2"
     DATALAD_RUNTIME_MAX__INACTIVE__AGE: "10"
 
-- python-version: '3.8'
+- python-version: '3.9'
   extra-envs:
     # By default no logs will be output. This one is to test with low level but
     # dumped to /dev/null
@@ -116,7 +116,7 @@
     GIT_COMMITTER_EMAIL: committer@example.com
 
 # Test some under NFS mount  (only selected sub-set)
-- python-version: '3.8'
+- python-version: '3.9'
   extra-envs:
     # do not run SSH-based tests due to stall(s)
     # https://github.com/datalad/datalad/pull/4172
@@ -132,26 +132,26 @@
 # TODO: ATM we do not have that minimal version as a Debian package in
 # snapshots!
 
-- python-version: '3.8'
+- python-version: '3.9'
   cron-only: true
   extra-envs:
     _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20200309 -m conda"
 
 # Run with git's master branch rather the default one on the system.
-- python-version: '3.8'
+- python-version: '3.9'
   cron-only: true
   upstream-git: true
   extra-envs:
     DATALAD_USE_DEFAULT_GIT: "1"
 
 # Run with our reported minimum Git version.
-- python-version: '3.8'
+- python-version: '3.9'
   cron-only: true
   minimum-git: true
   extra-envs:
     DATALAD_USE_DEFAULT_GIT: "1"
 
-- python-version: '3.8'
+- python-version: '3.9'
   cron-only: true
   extra-envs:
     # to test operation under root since also would consider FS "crippled" due
@@ -160,7 +160,7 @@
     # no key authentication for root:
     DATALAD_TESTS_SSH: "0"
 
-- python-version: '3.8'
+- python-version: '3.9'
   cron-only: true
   extra-envs:
     DATALAD_TESTS_NONETWORK: "1"
@@ -169,7 +169,7 @@
     https_proxy: ""
 
 # Test under NFS mount  (full, only in master)
-- python-version: '3.8'
+- python-version: '3.9'
   cron-only: true
   allow-failure: true
   extra-envs:
@@ -178,7 +178,7 @@
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)
 # We would need to migrate to boto3 to test it fully, but SSH should work
-#- python-version: '3.8'
+#- python-version: '3.9'
 #  extra-envs:
 #    DATALAD_TESTS_SSH: "1"
 #    UNSET_S3_SECRETS: "1"

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -18,11 +18,6 @@
     # since should not hurt.
     LC_ALL: ru_RU.UTF-8
 
-- python-version: '3.10'
-  extra-envs:
-    PYTEST_SELECTION: ""
-    PYTEST_SELECTION_OP: "not"
-
 # Two matrix runs for "recent python and git-annex with the recent supported by
 # git annex new version of repo" and various extra options/features enabled for
 # git-annex

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,6 @@ commands = flake8 {posargs}
 [testenv:typing]
 extras = tests
 deps =
-    distro  # Remove when CI no longer uses Python 3.7 for type-checking.
     types-psutil
 commands =
     # TODO: rich "coverage" sufficient to remove --follow-imports skip, and just specify datalad .


### PR DESCRIPTION
Individual commits have a little more to say.

- also addresses #7678 

We should release either with this or #7679 to fix #7678 which renders extensions unusable on debian ATM.

TODOs
- [x] remove/redo?? TEMP commit for coverage somehow