### PR TITLE
Ignore deprecation warning from httpretty

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,8 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
     # workaround for https://github.com/datalad/datalad/issues/6307
     ignore:The distutils package is deprecated
+    # sent fix upstream: https://github.com/HTTPretty/HTTPretty/pull/9
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:httpretty
 markers =
     fail_slow
     githubci_osx


### PR DESCRIPTION
Although we might just want to get rid of that dependency -- not developed much any longer
