### PR TITLE
Add 3.13 testing/support

### DIFF
--- a/datalad/support/exceptions.py
+++ b/datalad/support/exceptions.py
@@ -11,6 +11,7 @@
 
 import logging
 import re
+import sys
 import traceback
 from os import linesep
 from pathlib import Path
@@ -112,15 +113,26 @@ class CapturedException(object):
         """
         return str(self.tb)
 
-    @property
-    def name(self):
-        """Returns the class name of the original exception
+    if sys.version_info < (3, 13):
+        @property
+        def name(self):
+            """Returns the class name of the original exception
 
-        Returns
-        -------
-        str
-        """
-        return self.tb.exc_type.__qualname__
+            Returns
+            -------
+            str
+            """
+            return self.tb.exc_type.__qualname__
+    else:
+        @property
+        def name(self):
+            """Returns the class name of the original exception
+
+            Returns
+            -------
+            str
+            """
+            return self.tb.exc_type_str
 
     def __str__(self):
         return self.format_short()
@@ -210,7 +222,8 @@ def format_exception_with_cause(e):
     messages.
     """
     s = str(e) or \
-        (e.exc_type.__name__ if isinstance(e, traceback.TracebackException)
+        ((e.exc_type.__name__ if sys.version_info < (3, 13) else e.exc_type_str)
+         if isinstance(e, traceback.TracebackException)
          else e.__class__.__name__)
     exc_cause = getattr(e, '__cause__', None)
     if exc_cause:

--- a/datalad/support/parallel.py
+++ b/datalad/support/parallel.py
@@ -100,17 +100,16 @@ class ProducerConsumer:
 
     Examples
     --------
-    A simple and somewhat boring example could be to count lines in '*.py'
-    files in parallel
+    A simple and somewhat boring example to count lines in '*.py'
 
-        from glob import glob
-        from pprint import pprint
-        from datalad.support.parallel import ProducerConsumer
-
-        def count_lines(fname):
-            with open(fname) as f:
-                return fname, len(f.readlines())
-        pprint(dict(ProducerConsumer(glob("*.py"), count_lines)))
+    >>> from glob import glob
+    >>> from pprint import pprint
+    >>> from datalad.support.parallel import ProducerConsumer
+    >>> def count_lines(fname):
+    ...     with open(fname) as f:
+    ...         return fname, len(f.readlines())
+    >>> pprint(dict(ProducerConsumer(glob("*.py"), count_lines)))  # doctest: +SKIP
+    {'setup.py': 182, 'versioneer.py': 2136}
 
     More usage examples could be found in `test_parallel.py` and around the
     codebase `addurls.py`, `get.py`, `save.py`, etc.

--- a/datalad/support/tests/test_captured_exception.py
+++ b/datalad/support/tests/test_captured_exception.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import patch
 
 from datalad import cfg
@@ -72,15 +73,16 @@ def test_CapturedException():
     assert_equal(full_display[0], "Traceback (most recent call last):")
     # points in f and f2 for first exception with two lines each
     # (where is the line and what reads the line):
-    assert_true(full_display[1].lstrip().startswith("File"))
-    assert_equal(full_display[2].strip(), "f2()")
-    assert_true(full_display[3].lstrip().startswith("File"))
-    assert_equal(full_display[4].strip(), "raise Exception(\"my bad again\")")
-    assert_equal(full_display[5].strip(), "Exception: my bad again")
-    assert_equal(full_display[7].strip(), "The above exception was the direct cause of the following exception:")
-    assert_equal(full_display[9], "Traceback (most recent call last):")
+    assert full_display[1].lstrip().startswith("File")
+    assert full_display[2].strip() == "f2()"
+    inc = int(sys.version_info >= (3, 13))
+    assert full_display[3 + inc].lstrip().startswith("File")
+    assert full_display[4 + inc].strip() == "raise Exception(\"my bad again\")"
+    assert full_display[5 + inc].strip() == "Exception: my bad again"
+    assert full_display[7 + inc].strip() == "The above exception was the direct cause of the following exception:"
+    assert full_display[9 + inc] == "Traceback (most recent call last):"
     # ...
-    assert_equal(full_display[-1].strip(), "RuntimeError: new message")
+    assert full_display[-1].strip() == "RuntimeError: new message"
 
     # CapturedException.__repr__:
     assert_re_in(r".*test_captured_exception.py:f2:[0-9]+\]$",

--- a/datalad/support/tests/test_parallel.py
+++ b/datalad/support/tests/test_parallel.py
@@ -88,7 +88,7 @@ def test_producing_consumer(jobs):
 
     # we auto-detect generator function producer
     pc = ProducerConsumer(producer, consumer, jobs=jobs)
-    assert_equal(list(pc), [0, 1, 2, "0", "1", "4"])
+    assert_equal(set(pc), {0, 1, 2, "0", "1", "4"})
 
 
 def test_producer_future_key(jobs):

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -38,6 +38,16 @@
     DATALAD_TESTS_GITCONFIG: "\n[annex]\n stalldetection = 1KB/120s\n"
     _DL_ANNEX_INSTALL_SCENARIO: "miniconda --channel conda-forge --python-match minor --batch git-annex -m conda"
 
+- python-version: '3.13'
+  extra-envs:
+    PYTEST_SELECTION: ""
+    PYTEST_SELECTION_OP: "not"
+
+- python-version: '3.13'
+  extra-envs:
+    PYTEST_SELECTION: ""
+    PYTEST_SELECTION_OP: ""
+
 - python-version: '3.9'
   cron-only: true
   extra-envs:


### PR DESCRIPTION
Debian has 3.13 already and my attempt to build 1.1.4 for Debian has failed. Hence had to look.

Changes of `CapturedException` as minimal and likely do not capture prior difference in use of `.__str__` vs `.__qualname__`. But I do not think there is anything we could do about that now that there is no `exc_type` stored. May be @bpoldrack would find a moment to have a look. 

Meanwhile I will run this version of the patch into debian package.

TODO
- [x] test_ProducerConsumer (interestingly -- always fails but differently and never seems to succeed "by chance")