### PR TITLE
[DATALAD RUNCMD] Switch to a more recent py39 based miniconda installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ env:
    DATALAD_LOG_ENV: GIT_SSH_COMMAND
    # How/which git-annex we install.  conda's build would be the fastest,
    # but it must not get ahead in PATH to not shadow travis' python
-   _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20201007 -m conda"
+   _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py39_25.1.1-2 --python-match minor --batch git-annex=8.20201007 -m conda"
    BOTO_CONFIG: /tmp/nowhere
    DATALAD_DATASETS_TOPURL: https://datasets-tests.datalad.org
 

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -59,14 +59,14 @@
   extra-envs:
     DATALAD_SSH_MULTIPLEX__CONNECTIONS: "0"
     DATALAD_RUNTIME_PATHSPEC__FROM__FILE: always
-    _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=10.20220525 -m conda"
+    _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py39_25.1.1-2 --python-match minor --batch git-annex=10.20220525 -m conda"
 
 - python-version: '3.9'
   extra-envs:
     PYTEST_SELECTION_OP: ""
     DATALAD_SSH_MULTIPLEX__CONNECTIONS: "0"
     DATALAD_RUNTIME_PATHSPEC__FROM__FILE: always
-    _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20210310 -m conda"
+    _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py39_25.1.1-2 --python-match minor --batch git-annex=8.20210310 -m conda"
     # To test https://github.com/datalad/datalad/pull/4342 fix in case of no
     # "not" for pytest.  From our testing in that PR seems to have no effect,
     # but kept around since should not hurt.
@@ -140,7 +140,7 @@
 - python-version: '3.9'
   cron-only: true
   extra-envs:
-    _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py37_23.1.0-1 --python-match minor --batch git-annex=8.20200309 -m conda"
+    _DL_ANNEX_INSTALL_SCENARIO: "miniconda=py39_25.1.1-2 --python-match minor --batch git-annex=8.20200309 -m conda"
 
 # Run with git's master branch rather the default one on the system.
 - python-version: '3.9'


### PR DESCRIPTION
Done with the hope to overcome issues with installation of py 3.13 which we seems to experience ATM
