### PR TITLE
chore: for github tests CI - py 3.13 matrix should also (as for 3.12) use most recent available git-annex

### DIFF
--- a/changelog.d/pr-7710.md
+++ b/changelog.d/pr-7710.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- chore: for github tests CI - py 3.13 matrix should also (as for 3.12) use most recent available git-annex.  [PR #7710](https://github.com/datalad/datalad/pull/7710) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -42,11 +42,13 @@
   extra-envs:
     PYTEST_SELECTION: ""
     PYTEST_SELECTION_OP: "not"
+    _DL_ANNEX_INSTALL_SCENARIO: "miniconda --channel conda-forge --python-match minor --batch git-annex -m conda"
 
 - python-version: '3.13'
   extra-envs:
     PYTEST_SELECTION: ""
     PYTEST_SELECTION_OP: ""
+    _DL_ANNEX_INSTALL_SCENARIO: "miniconda --channel conda-forge --python-match minor --batch git-annex -m conda"
 
 - python-version: '3.9'
   cron-only: true


### PR DESCRIPTION
ATM 3.13 environment cannot install our old minimal git-annex version, try

    rm -rf /tmp/test-env*; src/datalad_installer.py -E /tmp/test-env.sh miniconda --batch --path /tmp/test-env -c conda-forge -e python=3.13 git-annex=8.20201007

and I now spotted that we did custom installation for 3.12 so I guess we are doomed to do that for 3.13 as well.  Verified that

    rm -rf /tmp/test-env*; src/datalad_installer.py -E /tmp/test-env.sh miniconda --batch --path /tmp/test-env -c conda-forge -e python=3.13 git-annex

worked
