### PR TITLE
Resolve datetime library warnings

### DIFF
--- a/_datalad_build_support/formatters.py
+++ b/_datalad_build_support/formatters.py
@@ -36,8 +36,9 @@ class ManPageFormatter(argparse.HelpFormatter):
 
         self._prog = prog
         self._section = 1
-        self._today = datetime.datetime.utcfromtimestamp(
-            cfg.obtain('datalad.source.epoch')
+        self._today = datetime.datetime.fromtimestamp(
+            cfg.obtain('datalad.source.epoch'),
+            datetime.timezone.utc
         ).strftime('%Y\\-%m\\-%d')
         self._ext_sections = ext_sections
         self._version = version

--- a/changelog.d/pr-7714.md
+++ b/changelog.d/pr-7714.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Resolve datetime library warnings.  [PR #7714](https://github.com/datalad/datalad/pull/7714) (by [@emmanuel-ferdman](https://github.com/emmanuel-ferdman))


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` library warnings:
```python
/home/runner/work/datalad/datalad/_datalad_build_support/formatters.py:39: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```