### PR TITLE
foreach-dataset: add common usage options of {ds} and {refds} to datalad help

### DIFF
--- a/datalad/local/foreach_dataset.py
+++ b/datalad/local/foreach_dataset.py
@@ -113,7 +113,9 @@ class ForEachDataset(Interface):
     - "{pwd}" will be replaced with the full path of the current working directory.
     - "{ds}" and "{refds}" will provide instances of the dataset currently
       operated on and the reference "context" dataset which was provided via ``dataset``
-      argument.
+      argument. Therefore, {ds.path} returns the path to the submodule and {ds.id}
+      produces the submodule's datalad ID. The placeholder "refds" is used in the same
+      way. See the API documentation of "Dataset" for more options.
     - "{tmpdir}" will be replaced with the full path of a temporary directory.
     """
     _examples_ = [


### PR DESCRIPTION
The help page of "foreach-dataset" could be more accessible to non-technical people w.r.t. usage of the {ds} and {refds} placeholders. Added two common cases on how to use it and where to find more info


