### PR TITLE
BF: import from distutils.errors directly if no longer in setuptools

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip install -r requirements.txt
         pip install ".[devel-docs]"
         sudo apt-get install p7zip

--- a/_datalad_build_support/setup.py
+++ b/_datalad_build_support/setup.py
@@ -24,11 +24,11 @@ from genericpath import exists
 from packaging.version import Version
 from setuptools import (
     Command,
-    DistutilsOptionError,
     find_namespace_packages,
     findall,
     setup,
 )
+from setuptools.errors import OptionError
 
 from . import formatters as fmt
 
@@ -75,11 +75,11 @@ class BuildManPage(Command):
 
     def finalize_options(self):
         if self.manpath is None:
-            raise DistutilsOptionError('\'manpath\' option is required')
+            raise OptionError('\'manpath\' option is required')
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         if self.parser is None:
-            raise DistutilsOptionError('\'parser\' option is required')
+            raise OptionError('\'parser\' option is required')
         self.manpath = _path_rel2file(self.manpath)
         self.rstpath = _path_rel2file(self.rstpath)
         mod_name, func_name = self.parser.split(':')
@@ -183,9 +183,9 @@ class BuildRSTExamplesFromScripts(Command):
 
     def finalize_options(self):
         if self.expath is None:
-            raise DistutilsOptionError('\'expath\' option is required')
+            raise OptionError('\'expath\' option is required')
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         self.expath = _path_rel2file(self.expath)
         self.rstpath = _path_rel2file(self.rstpath)
         self.announce('Converting example scripts')
@@ -217,7 +217,7 @@ class BuildConfigInfo(Command):
 
     def finalize_options(self):
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         self.rstpath = _path_rel2file(self.rstpath)
         self.announce('Generating configuration documentation')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # wheel to get more lightweight (not EASY-INSTALL) entry-points
-requires = ["packaging", "setuptools>=40.8.0", "wheel"]
+requires = ["packaging", "setuptools>=59.0.0", "wheel"]
 
 [tool.isort]
 force_grid_wrap = 2


### PR DESCRIPTION
May be in the future we should just switch to a more generic exception type there if that code is still relevant at all

Closes #7722 

edit 1: oh no!  Since we never swallowed the pill to distill a single of those https://github.com/datalad/datalad-buildsupport deprecating never used https://github.com/datalad/datalad_build_support, and duplicated the code everywhere, we have the same issue in extensions! heh  ... separate issue/PRs to push

edit 2.1: oh -- it was actually here (and those few other extensions and our extensions templa) where in our attempt to "get rid of distutils" we moved from that import to be done from `distutils.errors` in 40ce29923ec1d22174b0624bd1166cd670b61a0e. 

final edit: **the verdict is to import and use `OptionError` (not `DistutilsOptionError`) from `setuptools.errors` which came to existence in setuptools 59.0.0. GitHub python envs could have outdated setuptools 58.1.0 thus requiring explicit upgrade (uff)**.  I will introduce similar fixes elsewhere where needed.  

Related PRs
- https://github.com/datalad/datalad-extension-template/pull/98
- https://github.com/datalad/datalad-container/pull/273
- https://github.com/datalad/datalad-neuroimaging/pull/136