### PR TITLE
Remove absolute path specification from `/bin/ls` invocation while interrogating remote path

### DIFF
--- a/changelog.d/pr-7730.md
+++ b/changelog.d/pr-7730.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Remove absolute path specification from `/bin/ls` invocation while interrogating remote path.  [PR #7730](https://github.com/datalad/datalad/pull/7730) (by [@malikwirin](https://github.com/malikwirin))

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -396,7 +396,7 @@ def _ls_remote_path(ssh, path):
         # sh_quote could decide to quote Windows-style
         # C.UTF-8 locale as opposed to C locale handles special characters (umlauts etc.)
         # ls falls back to C locale if LC_ALL is set to unknown locale, so this should be safe.
-        ls_cmd = "LC_ALL=C.UTF-8; export LC_ALL; /bin/ls -A1 {}".format(shlex.quote(path))
+        ls_cmd = "LC_ALL=C.UTF-8; export LC_ALL; ls -A1 {}".format(shlex.quote(path))
         # TODO: Using sh_quote here is also flawed as it checks whether the
         # *local* machine is Windows. Doesn't help if the remote we're ssh'ing in is Windows.
         ssh_cmd = "sh -c {}".format(sh_quote(ls_cmd))


### PR DESCRIPTION
`/bin/ls` is not available on every unix system like on mine (NixOS).
This should fix the compatibility issue


