### PR TITLE
BF: Prevent infinite recursion in clone when a remote points to itself

### DIFF
--- a/changelog.d/pr-7731.md
+++ b/changelog.d/pr-7731.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: Prevent infinite recursion in clone when a remote points to itself.  Fixes [#7721](https://github.com/datalad/datalad/issues/7721) via [PR #7731](https://github.com/datalad/datalad/pull/7731) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -910,8 +910,12 @@ def configure_origins(cfgds, probeds, label=None, remote="origin"):
     # given the clone source is a local dataset, we can have a
     # cheap look at it, and configure its own `remote` as a remote
     # (if there is any), and benefit from additional annex availability
-    yield from configure_origins(
-        cfgds,
-        Dataset(probeds.pathobj / origin_url),
-        label=label + 1,
-        remote=remote)
+    # But first check if we would recurse into the same dataset
+    # to prevent infinite recursion (see gh-7721)
+    next_dataset_path = probeds.pathobj / origin_url
+    if next_dataset_path.resolve() != probeds.pathobj.resolve():
+        yield from configure_origins(
+            cfgds,
+            Dataset(next_dataset_path),
+            label=label + 1,
+            remote=remote)


### PR DESCRIPTION
When cloning a repository that has its origin remote set to point to itself, DataLad would enter an infinite recursion loop in configure_origins().

This fix adds a check to prevent recursing into the same dataset path, avoiding the infinite loop reported in issue #7721.

Fixes #7721

🤖 Generated with [Claude Code](https://claude.ai/code)

Potentially there is other, trickier scenarios (chain of symlinks etc) but at least this would address an obvious issue.