### PR TITLE
DOC: clarify in config documentation that we log to stderr not stdout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -514,7 +514,7 @@ Refer datalad/config.py for information on how to add these environment variable
   Used to point to an alternative location for `///` dataset. If running
   tests preferred to be set to https://datasets-tests.datalad.org
 - *DATALAD_LOG_LEVEL*:
-  Used for control the verbosity of logs printed to stdout while running datalad commands/debugging
+  Used for control the verbosity of logs printed to stderr while running datalad commands/debugging
 - *DATALAD_LOG_NAME*:
   Whether to include logger name (e.g. `datalad.support.sshconnector`) in the log
 - *DATALAD_LOG_OUTPUTS*:

--- a/changelog.d/pr-7734.md
+++ b/changelog.d/pr-7734.md
@@ -1,0 +1,3 @@
+### 📝 Documentation
+
+- DOC: clarify in config documentation that we log to stderr not stdout.  [PR #7734](https://github.com/datalad/datalad/pull/7734) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -433,7 +433,7 @@ _definitions = {
     'datalad.log.level': {
         'ui': ('question', {
             'title': 'Used for control the verbosity of logs printed to '
-                     'stdout while running datalad commands/debugging'}),
+                     'stderr while running datalad commands/debugging'}),
     },
     'datalad.log.result-level': {
         'ui': ('question', {


### PR DESCRIPTION
We also have handling of DATALAD_LOG_OUTPUT but it is not interfaced in common_cfg.py thus I do not mention

*Proof*:
```shell
❯ DATALAD_LOG_LEVEL=debug datalad wtf 2>&1 | head -n 2
[DEBUG] Not retro-fitting GitRepo with deprecated symbols, datalad-deprecated package not found 
[DEBUG] Command line args 1st pass for DataLad 1.1.5. Parsed: Namespace(cfg_overrides=None, change_path=None, _=False, log_level='warning', common_on_failure=None, common_report_status=None, common_report_type=None, common_result_renderer='tailored', common_debug=False, common_idebug=False, version=None) Unparsed: ['wtf'] 
❯ DATALAD_LOG_LEVEL=debug datalad wtf 2>/dev/null | head -n 2
# WTF
## configuration <SENSITIVE, report disabled by configuration>
```

and code is here https://github.com/datalad/datalad/blob/HEAD/datalad/log.py#L614