### PR TITLE
[DATALAD RUNCMD] Use ubuntu-22.04 until we fixup NeuroDebian APT for recent debian/ubuntu

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   vs-master:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Set up system

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       jobs: ${{ steps.jobs.outputs.matrix }}
     steps:
@@ -49,7 +49,7 @@ jobs:
           echo 'EOT' >> "$GITHUB_OUTPUT"
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: filter
     strategy:
       fail-fast: false

--- a/.github/workflows/test_crippled.yml
+++ b/.github/workflows/test_crippled.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Set up system
       shell: bash

--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
otherwise -- our CI is very red now