### PR TITLE
releasing package datalad version 1.1.5-2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+datalad (1.1.5-2.1) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * Remove recommenadation of python3-lzma, no longer a separate
+    package in Debian, part of Python 3.3 and later. (Closes: #1099382).
+
+ -- Sven Hoexter <hoexter@debian.org>  Sun, 15 Jun 2025 11:01:44 +0200
+
 datalad (1.1.5-2) unstable; urgency=medium
 
   * Skip test_producer_future_key flaky on Debian test

--- a/debian/control
+++ b/debian/control
@@ -89,7 +89,6 @@ Depends: git-annex (>= 8.20200309~) | git-annex-standalone (>= 8.20200309~),
          ${python3:Depends}
 Recommends: python3-html5lib,
             python3-httpretty,
-            python3-lzma,
             python3-pytest (>= 7.0),
             python3-pyperclip,
             python3-vcr,


### PR DESCRIPTION
I'm uploading this NMU to Debian to allow datalad to be released with the upcoming stable release trixie.
This fixes Debian bug https://bugs.debian.org/1099382