### PR TITLE
fix: submodule property `datalad-url` used wrong submodule name

### DIFF
--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -378,7 +378,10 @@ class Clone(Interface):
                 # Note, that we didn't allow deviating from git's default
                 # behavior WRT a submodule's name vs its path when we made this
                 # a new subdataset.
-                subds_name = path.relative_to(ds.pathobj)
+                # all pathobjs involved are platform paths, but the
+                # default submodule name equals the relative path
+                # in posix conventions, hence .as_posix()
+                subds_name = path.relative_to(ds.pathobj).as_posix()
                 ds.repo.call_git(
                     ['config',
                      '--file',


### PR DESCRIPTION
Instead of the relative path in POSIX conventions, it used the relative path in platform conventions. On windows this led to a dangling submodule property, detached from the actual submodule record, whenever a submodule was added in a 2nd-level subdirectory. This led to warnings from routines that parsed the submodule.

This change force-converts the name/path to POSIX conventions.