### PR TITLE
Add `data all` option to `push` to copy all annex'ed files

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -24,6 +24,7 @@ from datalad.distribution.dataset import (
     require_dataset,
     resolve_path,
 )
+from datalad.dochelpers import single_or_plural
 from datalad.interface.base import (
     Interface,
     build_doc,
@@ -251,12 +252,15 @@ class Push(Interface):
                 dss = []
             dss.append(ds.path)
 
-            non_ds_paths = sorted(set(paths) - set(map(Path, dss)))
+            non_ds_paths = sorted(map(str, set(paths) - set(map(Path, dss))))
             if non_ds_paths:
-                b = "\n".join(map(str, non_ds_paths))
                 raise ValueError(
-                    "The following paths are not (sub)datasets or the"
-                    f" recursion limit is insufficient:\n{b}"
+                    single_or_plural(
+                        f"path `{non_ds_paths[0]}` is not a (sub)dataset",
+                        f"{len(non_ds_paths)} paths ({non_ds_paths[0]}, ...) are not (sub)datasets",
+                        len(non_ds_paths),
+                    )
+                    + " or the recursion limit is insufficient"
                 )
 
             # list subdatasets, but no need to list files as `git annex copy --all`

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -239,7 +239,7 @@ class Push(Interface):
 
         if data == "all":
             if recursive:
-                subds = ds.subdatasets(
+                dss = ds.subdatasets(
                     path,
                     recursive=recursive,
                     recursion_limit=recursion_limit,
@@ -248,10 +248,10 @@ class Push(Interface):
                     bottomup=True,
                 )
             else:
-                subds = []
-            subds.append(ds.path)
+                dss = []
+            dss.append(ds.path)
 
-            non_ds_paths = sorted(set(paths) - set(map(Path, subds)))
+            non_ds_paths = sorted(set(paths) - set(map(Path, dss)))
             if non_ds_paths:
                 b = "\n".join(map(str, non_ds_paths))
                 raise ValueError(
@@ -261,7 +261,7 @@ class Push(Interface):
 
             # list subdatasets, but no need to list files as `git annex copy --all`
             # will transfer all of them
-            ds_spec = [(d, []) for d in subds]
+            ds_spec = [(d, []) for d in dss]
         else:
             # obtain a generator for information on the datasets to process
             # idea is to turn the `paths` argument into per-dataset

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -113,16 +113,17 @@ class Push(Interface):
             constraints=EnsureStr() | EnsureNone()),
         data=Parameter(
             args=("--data",),
-            doc="""what to do with (annex'ed) data. 'anything' would cause
-            transfer of all annexed content, 'nothing' would avoid call to
-            `git annex copy` altogether. 'auto' would use 'git annex copy' with
-            '--auto' thus transferring only data which would satisfy "wanted"
+            doc="""what to do with (annex'ed) data. 'all' would cause
+            transfer of all annexed content, including unused files. 'anything' would
+            push all files from the current commit (git HEAD). 'nothing' would avoid
+            call to `git annex copy` altogether. 'auto' would use 'git annex copy'
+            with '--auto' thus transferring only data which would satisfy "wanted"
             or "numcopies" settings for the remote (thus "nothing" otherwise).
             'auto-if-wanted' would enable '--auto' mode only if there is a
             "wanted" setting for the remote, and transfer 'anything' otherwise.
-            """,
+            Note that 'all' cannot be used in conjunction with `since`.""",
             constraints=EnsureChoice(
-                'anything', 'nothing', 'auto', 'auto-if-wanted')),
+                'all', 'anything', 'nothing', 'auto', 'auto-if-wanted')),
         force=Parameter(
             # multi-mode option https://github.com/datalad/datalad/issues/3414
             args=("-f", "--force",),
@@ -190,6 +191,8 @@ class Push(Interface):
         # behavior. '' was/is (to be deprecated) used in `publish`. Alert user about the mistake
         if since == '':
             raise ValueError("'since' should point to commitish or use '^'.")
+        if data == 'all' and since:
+            raise ValueError("`data='all'` cannot be used with `since`")
         # we resolve here, because we need to perform inspection on what was given
         # as an input argument further down
         paths = [resolve_path(p, dataset) for p in ensure_list(path)]
@@ -234,17 +237,43 @@ class Push(Interface):
             # will blow with ValueError if unusable
             ds_repo.get_hexsha(since)
 
+        if data == "all":
+            if recursive:
+                subds = ds.subdatasets(
+                    path,
+                    recursive=recursive,
+                    recursion_limit=recursion_limit,
+                    result_xfm="paths",
+                    result_renderer="disabled",
+                    bottomup=True,
+                )
+            else:
+                subds = []
+            subds.append(ds.path)
 
-        # obtain a generator for information on the datasets to process
-        # idea is to turn the `paths` argument into per-dataset
-        # content listings that can be acted upon
-        ds_spec = _datasets_since_(
-            # important to pass unchanged dataset arg
-            dataset,
-            since,
-            paths,
-            recursive,
-            recursion_limit)
+            non_ds_paths = sorted(set(paths) - set(map(Path, subds)))
+            if non_ds_paths:
+                b = "\n".join(map(str, non_ds_paths))
+                raise ValueError(
+                    "The following paths are not (sub)datasets or the"
+                    f" recursion limit is insufficient:\n{b}"
+                )
+
+            # list subdatasets, but no need to list files as `git annex copy --all`
+            # will transfer all of them
+            ds_spec = [(d, []) for d in subds]
+        else:
+            # obtain a generator for information on the datasets to process
+            # idea is to turn the `paths` argument into per-dataset
+            # content listings that can be acted upon
+            ds_spec = _datasets_since_(
+                # important to pass unchanged dataset arg
+                dataset,
+                since,
+                paths,
+                recursive,
+                recursion_limit,
+            )
 
         # instead of a loop, this could all be done in parallel
         matched_anything = False
@@ -799,50 +828,89 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
             )
             return
 
-    # it really looks like we will transfer files, get info on what annex
-    # has in store
-    # paths must be recoded to a dataset REPO root (in case of a symlinked
-    # location
-    annex_info_init = \
-        {ds_repo.pathobj / Path(c['path']).relative_to(ds.pathobj): c
-         for c in content} if ds.pathobj != ds_repo.pathobj else \
-        {Path(c['path']): c for c in content}
-    content = ds.repo.get_content_annexinfo(
-        # paths are taken from `annex_info_init`
-        paths=None,
-        init=annex_info_init,
-        ref='HEAD',
-        # this is an expensive operation that is only needed
-        # to perform a warning below, and for more accurate
-        # progress reporting (exclude unavailable content).
-        # limit to cases with explicit paths provided
-        eval_availability=True if got_path_arg else False,
-    )
-    # figure out which of the reported content (after evaluating
-    # `since` and `path` arguments needs transport
-    to_transfer = [
-        c
-        for c in content.values()
-        # by force
-        if ((force in ('all', 'checkdatapresent') or
-             # or by modification report
-             c.get('state', None) not in ('clean', 'deleted'))
-            # only consider annex'ed files
-            and 'key' in c
+    if data == "all":
+        cmd = ["copy", "--all", "--to", target]
+        file_list = None
+        repkey_paths = {}
+        nbytes = None
+    else:
+        # it really looks like we will transfer files, get info on what annex
+        # has in store
+        # paths must be recoded to a dataset REPO root (in case of a symlinked
+        # location
+        annex_info_init = (
+            {
+                ds_repo.pathobj / Path(c["path"]).relative_to(ds.pathobj): c
+                for c in content
+            }
+            if ds.pathobj != ds_repo.pathobj
+            else {Path(c["path"]): c for c in content}
         )
-    ]
-    if got_path_arg:
-        for c in [c for c in to_transfer if not c.get('has_content', False)]:
-            yield dict(
-                res_kwargs,
-                type=c['type'],
-                path=c['path'],
-                action='copy',
-                status='impossible',
-                message='Slated for transport, but no content present',
+        content = ds.repo.get_content_annexinfo(
+            # paths are taken from `annex_info_init`
+            paths=None,
+            init=annex_info_init,
+            ref="HEAD",
+            # this is an expensive operation that is only needed
+            # to perform a warning below, and for more accurate
+            # progress reporting (exclude unavailable content).
+            # limit to cases with explicit paths provided
+            eval_availability=True if got_path_arg else False,
+        )
+        # figure out which of the reported content (after evaluating
+        # `since` and `path` arguments needs transport
+        to_transfer = [
+            c
+            for c in content.values()
+            # by force
+            if (
+                (
+                    force in ("all", "checkdatapresent")
+                    or
+                    # or by modification report
+                    c.get("state", None) not in ("clean", "deleted")
+                )
+                # only consider annex'ed files
+                and "key" in c
             )
+        ]
+        if got_path_arg:
+            for c in [c for c in to_transfer if not c.get("has_content", False)]:
+                yield dict(
+                    res_kwargs,
+                    type=c["type"],
+                    path=c["path"],
+                    action="copy",
+                    status="impossible",
+                    message="Slated for transport, but no content present",
+                )
 
-    cmd = ['copy', '--batch', '-z', '--to', target]
+        cmd = ["copy", "--batch", "-z", "--to", target]
+
+        # A set and a dict is used to track files pointing to the
+        # same key.  The set could be dropped, using a single dictionary
+        # that has an entry for every seen key and a (likely empty) list
+        # of redundant files, but that would mean looping over potentially
+        # many keys to yield likely few if any notneeded results.
+        seen_keys = set()
+        repkey_paths = dict()
+
+        # produce final path list. use knowledge that annex command will
+        # run in the root of the dataset and compact paths to be relative
+        # to this location
+        file_list = b""
+        nbytes = 0
+        for c in to_transfer:
+            key = c["key"]
+            if key in seen_keys:
+                repkey_paths.setdefault(key, []).append(c["path"])
+            else:
+                file_list += bytes(Path(c["path"]).relative_to(ds.pathobj))
+                file_list += b"\0"
+                nbytes += c.get("bytesize", 0)
+                seen_keys.add(key)
+        lgr.debug("Counted %d bytes of annex data to transfer", nbytes)
+
 
     if jobs:
         cmd.extend(['--jobs', str(jobs)])
@@ -865,31 +933,6 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
     # input has type=dataset, but now it is about files
     res_kwargs.pop('type', None)
 
-    # A set and a dict is used to track files pointing to the
-    # same key.  The set could be dropped, using a single dictionary
-    # that has an entry for every seen key and a (likely empty) list
-    # of redundant files, but that would mean looping over potentially
-    # many keys to yield likely few if any notneeded results.
-    seen_keys = set()
-    repkey_paths = dict()
-
-    # produce final path list. use knowledge that annex command will
-    # run in the root of the dataset and compact paths to be relative
-    # to this location
-    file_list = b''
-    nbytes = 0
-    for c in to_transfer:
-        key = c['key']
-        if key in seen_keys:
-            repkey_paths.setdefault(key, []).append(c['path'])
-        else:
-            file_list += bytes(Path(c['path']).relative_to(ds.pathobj))
-            file_list += b'\0'
-            nbytes += c.get('bytesize', 0)
-            seen_keys.add(key)
-    lgr.debug('Counted %d bytes of annex data to transfer',
-              nbytes)
-
     # and go
     res = ds_repo._call_annex_records(
         cmd,
@@ -906,13 +949,18 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
     for j in res:
         yield annexjson2result(j, ds, type='file', **res_kwargs)
 
-    for annex_key, paths in repkey_paths.items():
-        for path in paths:
-            yield dict(
-                res_kwargs, action='copy', type='file', status='notneeded',
-                path=path, annexkey=annex_key,
-                message='Another file points to the same key')
-    return
+    if data != "all":
+        for annex_key, paths in repkey_paths.items():
+            for path in paths:
+                yield dict(
+                    res_kwargs,
+                    action="copy",
+                    type="file",
+                    status="notneeded",
+                    path=path,
+                    annexkey=annex_key,
+                    message="Another file points to the same key",
+                )
 
 
 def _get_corresponding_remote_state(repo, to):

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -422,6 +422,13 @@ def test_push_all(src_path=None, dst_path=None, dst_path_all=None):
 @with_tempfile(mkdir=True)
 def test_push_all_recursive(src_path=None, dst_path=None):
     """Check recursive push with `data="all"`"""
+    # Create three subdatasets with one subsubdataset each. Tests performed:
+    # 1. Push subdataset 1 with recursion limit 1, which should push root and
+    #   subdataset 1, but not subsubdataset 1.
+    # 2. Push subdataset 2 without recursion limit. This should push subdataset 2 and
+    #   subsubdataset 2, but not root as it has already been pushed before.
+    # 3. Push the root dataset. This should push all remeaining stuff, i.e, subsubdataset1,
+    #   subdataset 3, subsubdataset 3, but nothing that has already been pushed.
     src = {"": Dataset(src_path).create(force=True)}
     for i in range(1, 4):
         src[f"sub{i}"] = src[""].create(f"sub{i}", force=True)
@@ -448,6 +455,8 @@ def test_push_all_recursive(src_path=None, dst_path=None):
         "sub1", to="target", data="all", recursive=True, recursion_limit=1
     )
     res1_copy = [r for r in res1 if r["action"] == "copy"]
+    # due to recursion limit, only files of root dataset and sub1, but not sub11
+    # should have been pushed
     assert len(res1_copy) == 4
     for d in "", "sub1":
         ds = src[d]

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -394,24 +394,21 @@ def test_push_all(src_path=None, dst_path=None, dst_path_all=None):
         )
 
 
-@slow  # 70 seconds on laptop
+@slow  # 40 seconds on laptop
 @with_tree(
     tree={
         "sub1": {
             "sub11": {"file": "Stuff.", "file_del": "Stuff to be deleted."},
-            "sub12": {"file": "Stuff.", "file_del": "Stuff to be deleted."},
             "file": "Stuff.",
             "file_del": "Stuff to be deleted.",
         },
         "sub2": {
             "sub21": {"file": "Stuff.", "file_del": "Stuff to be deleted."},
-            "sub22": {"file": "Stuff.", "file_del": "Stuff to be deleted."},
             "file": "Stuff.",
             "file_del": "Stuff to be deleted.",
         },
         "sub3": {
             "sub31": {"file": "Stuff.", "file_del": "Stuff to be deleted."},
-            "sub32": {"file": "Stuff.", "file_del": "Stuff to be deleted."},
             "file": "Stuff.",
             "file_del": "Stuff to be deleted.",
         },
@@ -432,8 +429,7 @@ def test_push_all_recursive(src_path=None, dst_path=None):
     src = {"": Dataset(src_path).create(force=True)}
     for i in range(1, 4):
         src[f"sub{i}"] = src[""].create(f"sub{i}", force=True)
-        for j in range(1, 3):
-            src[f"sub{i}/sub{i}{j}"] = src[f"sub{i}"].create(f"sub{i}{j}", force=True)
+        src[f"sub{i}/sub{i}1"] = src[f"sub{i}"].create(f"sub{i}1", force=True)
 
     src[""].save(to_git=False, message="Create files", recursive=True)
     file_keys = {k: ds.repo.get_file_annexinfo("file")["key"] for k, ds in src.items()}
@@ -471,9 +467,9 @@ def test_push_all_recursive(src_path=None, dst_path=None):
             )
     res2 = src[""].push("sub2", to="target", data="all", recursive=True)
     res2_copy = [r for r in res2 if r["action"] == "copy"]
-    # root dataset has already been pushed, leaving sub2, sub21, sub22
-    assert len(res2_copy) == 6
-    for d in "sub2", "sub2/sub21", "sub2/sub22":
+    # root dataset has already been pushed, leaving sub2, sub21
+    assert len(res2_copy) == 4
+    for d in "sub2", "sub2/sub21":
         ds = src[d]
         for k in file_keys[d], file_del_keys[d]:
             assert_in_results(
@@ -487,8 +483,8 @@ def test_push_all_recursive(src_path=None, dst_path=None):
     # This should push the rest (i.e., subsets of sub1 and all of sub3)
     res3 = src[""].push(to="target", data="all", recursive=True)
     res3_copy = [r for r in res3 if r["action"] == "copy"]
-    assert len(res3_copy) == 10
-    for d in "sub1/sub11", "sub1/sub12", "sub3", "sub3/sub31", "sub3/sub32":
+    assert len(res3_copy) == 6
+    for d in "sub1/sub11", "sub3", "sub3/sub31":
         ds = src[d]
         for k in file_keys[d], file_del_keys[d]:
             assert_in_results(


### PR DESCRIPTION
This uses `git annex copy --all` to transfer all annexed data, not only files from current HEAD.

Useful for full data backup. 

- Fixes #7738.
