### PR TITLE
Mark test_create_sibling_ghlike::test_invalid_call and test_get_flexible_source_candidates_for_submodule as slow

### DIFF
--- a/datalad/distributed/tests/test_create_sibling_ghlike.py
+++ b/datalad/distributed/tests/test_create_sibling_ghlike.py
@@ -26,10 +26,12 @@ from datalad.tests.utils_pytest import (
     assert_result_count,
     assert_status,
     eq_,
+    slow,
     with_tempfile,
 )
 
 
+@slow  # could take 60-120 seconds, we should not time out
 @with_tempfile
 def test_invalid_call(path=None):
     # no dataset

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -70,6 +70,7 @@ from datalad.utils import (
 from ..dataset import Dataset
 
 
+@slow   # occasionally takes up to 120sec
 @with_tempfile
 @with_tempfile
 @with_tempfile


### PR DESCRIPTION
Our cron etc was failing once in a while, primarily under `sudo -E due` to this test timing out

    datalad@smaug:/mnt/datasets/datalad/ci/logs/2025/09$ git grep -l 'FAILED.*test_create_sibling_ghlike.py::test_invalid_call'  | nl
         1	19/cron/20250919T062703/aea09a7/github-Test-766-failed/5_test (3.9).txt
         2	19/cron/20250919T062703/aea09a7/github-Test-766-failed/7_test (3.9, true, sudo -E, 0).txt
         3	19/cron/20250919T062703/aea09a7/github-Test-766-failed/test (3.9)/18_Run tests.txt
         4	19/cron/20250919T062703/aea09a7/github-Test-766-failed/test (3.9, true, sudo -E, 0)/18_Run tests.txt
         5	25/cron/20250925T062740/aea09a7/github-Test-772-failed/6_test (3.9, true, sudo -E, 0).txt
         6	25/cron/20250925T062740/aea09a7/github-Test-772-failed/test (3.9, true, sudo -E, 0)/18_Run tests.txt

    datalad@smaug:/mnt/datasets/datalad/ci/logs/2025/09$ git grep -l 'FAILED.*test_create_sibling_ghlike.py::test_invalid_call'  | while read f; do grep "Test passed but took too long to run:" "$f"; done | nl
         1	2025-09-19T07:13:42.3185839Z Test passed but took too long to run: Duration 120.87311853600022s > 60.0s
         2	2025-09-19T07:13:42.3190033Z Test passed but took too long to run: Duration 118.11191542999995s > 60.0s
         3	2025-09-19T07:13:52.6569040Z Test passed but took too long to run: Duration 106.58325559200011s > 60.0s
         4	2025-09-19T07:13:42.3185521Z Test passed but took too long to run: Duration 120.87311853600022s > 60.0s
         5	2025-09-19T07:13:42.3190029Z Test passed but took too long to run: Duration 118.11191542999995s > 60.0s
         6	2025-09-19T07:13:52.6569034Z Test passed but took too long to run: Duration 106.58325559200011s > 60.0s
         7	2025-09-25T07:25:33.3068590Z Test passed but took too long to run: Duration 69.50624759399989s > 60.0s
         8	2025-09-25T07:25:33.3068571Z Test passed but took too long to run: Duration 69.50624759399989s > 60.0s

(so some above might be some other/extra timeouts...)

    datalad@smaug:/mnt/datasets/datalad/ci/logs/2025/09$ git grep -l 'FAILED.*test_create_sibling_ghlike.py::test_invalid_call'  | while read f; do grep "Z FAILED" "$f"; done | grep -v test_invalid_call
    2025-09-19T07:13:42.5776002Z FAILED ../datalad/distribution/tests/test_get.py::test_get_flexible_source_candidates_for_submodule
    2025-09-19T07:13:42.5776000Z FAILED ../datalad/distribution/tests/test_get.py::test_get_flexible_source_candidates_for_submodule

so marked that one too -- seems to be taking also in the 120 sec ballpark

    2025-09-19T07:13:42.3188729Z ______________ test_get_flexible_source_candidates_for_submodule _______________
    2025-09-19T07:13:42.3189388Z [gw0] linux -- Python 3.9.0 /tmp/dl-miniconda-4re4frhm/bin/python
    2025-09-19T07:13:42.3190033Z Test passed but took too long to run: Duration 118.11191542999995s > 60.0s

PS it is for 4 years, since 7a9bf1688c68e3e8afccef5709edcbbc2ab518e8 we had a limit on tests, which was originally 30 sec, and then raised to 60 sec in 2023 ee619ecece40d021e9000db9043dfdcb3e7fc06f .

Thanks for contributing!
