### PR TITLE
ENH: run - add "datalad.run.cmdexec" config to wrap commands execution

### DIFF
--- a/datalad/interface/common_cfg.py
+++ b/datalad/interface/common_cfg.py
@@ -702,6 +702,17 @@ _definitions = {
         'default': time.time(),
 
     },
+    'datalad.run.cmdexec': {
+        'ui': ('question', {
+            'title': 'Command execution wrapper',
+            'text': 'Template for wrapping commands before execution. '
+                    'Supports {python} placeholder for Python executable path '
+                    'and {cmd} placeholder for the actual command to execute. '
+                    'This allows running commands using arbitrary wrappers (like '
+                    '`duct` of `con-duct` or even using a container).'}),
+        'destination': 'dataset',
+        'type': EnsureStr(),
+    },
     'datalad.ssh.executable': {
         'ui': ('question', {
             'title': "Name of ssh executable for 'datalad sshrun'",

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ filterwarnings =
     # sent fix upstream: https://github.com/HTTPretty/HTTPretty/pull/9
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:httpretty
 markers =
+    ai_generated
     fail_slow
     githubci_osx
     githubci_win


### PR DESCRIPTION
- Closes https://github.com/datalad/datalad/issues/7756

We also contemplated adding the cmdexec into the RUNCMD record within the
commit, or expand the command before creating the record so we store formatted command?

<details>
<summary>edit 1: FWIW we have those substitutions for which we also do not provide values thus making command not-rerunnable unless they are specified, but I guess it could be taken as a feature (e.g. to specify passwords etc)
</summary> 

```shell
❯ datalad -c datalad.run.substitutions.param=win -c datalad.run.cmdexec="echo {cmd} > out.dat" run --explicit --output out.dat -- 'do not let them {param}'
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) ===== 
run(ok): /home/yoh/proj/datalad/datalad-maint (dataset) [echo 'do not let them win' > out.dat]
add(ok): out.dat (file)                                                                                                                                                                                                        
save(ok): . (dataset)                                                                                                                                                                                                          
❯ git show
commit f1a75e076ac685366c61b1c8891998a792e1c2bc (HEAD -> enh-cmdexec)
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Fri Oct 17 16:36:19 2025 -0400

    [DATALAD RUNCMD] echo 'do not let them win' > out.dat
    
    === Do not change lines below ===
    {
     "chain": [],
     "cmd": "'do not let them {param}'",
     "exit": 0,
     "extra_inputs": [],
     "inputs": [],
     "outputs": [
      "out.dat"
     ],
     "pwd": "."
    }
    ^^^ Do not change lines above ^^^

diff --git a/out.dat b/out.dat
new file mode 100644
index 000000000..e0a8bb92a
--- /dev/null
+++ b/out.dat
@@ -0,0 +1 @@
+do not let them win

❯ datalad rerun
[INFO   ] run commit f1a75e0; (echo 'do not let ...) 
run(impossible): /home/yoh/proj/datalad/datalad-maint (dataset) [command has an unrecognized placeholder: 'param']
action summary:
  run (impossible: 1)
  unlock (notneeded: 1)
```
</details>


TODOs
- [ ] per above -- might like to do so we record full expanded command or gain tw
- [ ] fix test so works on windows

<details>
<summary>redirect is no good</summary> 

```shell
_____________________________ test_cmdexec_config _____________________________
[gw0] win32 -- Python 3.9.13 C:\Python39-x64\python.exe
path = 'C:\\DLTMP\\datalad_temp_xns6h6lc'
    @pytest.mark.ai_generated
    @with_tempfile(mkdir=True)
    def test_cmdexec_config(path=None):
        """Test that datalad.run.cmdexec wraps commands correctly."""
        ds = Dataset(path).create()
    
        # Test basic command wrapping with echo
        ds.config.set("datalad.run.cmdexec", "sh -c '{cmd}'", scope="local")
    
        # Run a command that creates output
        ds.run("echo hello > output.txt", message="test cmdexec")
    
        # Verify the file was created and committed
>       ok_file_has_content(op.join(ds.path, "output.txt"), "hello\n")
..\datalad\core\local\tests\test_run.py:822: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
..\datalad\tests\utils_pytest.py:579: in ok_file_has_content
    ok_exists(path)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
path = WindowsPath('C:/DLTMP/datalad_temp_xns6h6lc/output.txt')
    def ok_exists(path):
>       assert Path(path).exists(), 'path %s does not exist (or dangling symlink)' % path
E       AssertionError: path C:\DLTMP\datalad_temp_xns6h6lc\output.txt does not exist (or dangling symlink)
E       assert False
E        +  where False = exists()
E        +    where exists = WindowsPath('C:/DLTMP/datalad_temp_xns6h6lc/output.txt').exists
E        +      where WindowsPath('C:/DLTMP/datalad_temp_xns6h6lc/output.txt') = Path(WindowsPath('C:/DLTMP/datalad_temp_xns6h6lc/output.txt'))
..\datalad\tests\utils_pytest.py:572: AssertionError
=============================== tests coverage ================================
_______________ coverage: platform win32, python 3.9.13-final-0 _______________

```
</details>