### PR TITLE
ENH: Add version capture to datalad run (-V/--versions)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,6 +281,10 @@ Additionally, [tools/testing/test_README_in_docker](tools/testing/test_README_in
 be used to establish a clean docker environment (based on any NtesteuroDebian-supported
 release of Debian or Ubuntu) with all dependencies listed in README.md pre-installed.
 
+The [tools/testing/adhoc](tools/testing/adhoc) folder contains ad-hoc testing
+scripts produced to test specific functionality at some point in time. These
+scripts are not actively maintained but may be useful for reference.
+
 ### CI setup
 
 We are using several continuous integration services to run our tests battery for every PR and on the default branch.

--- a/datalad/core/local/run_versions.py
+++ b/datalad/core/local/run_versions.py
@@ -1,0 +1,480 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Version capture for datalad run records"""
+
+__docformat__ = 'restructuredtext'
+
+import json
+import logging
+import os
+import re
+import shlex
+import shutil
+from pathlib import Path
+
+from datalad.config import anything2bool
+from datalad.support.external_versions import external_versions
+
+lgr = logging.getLogger('datalad.core.local.run_versions')
+
+# Injected versions file path (relative to dataset root, inside .git)
+INJECTED_VERSIONS_FILE = '.git/datalad/run_versions.json'
+
+
+def capture_versions(cmd, versions_spec, ds):
+    """Capture versions for a run record.
+
+    Parameters
+    ----------
+    cmd : str
+        The command being run
+    versions_spec : str or None
+        The --versions argument value, or None for default.
+        Use 'auto' to detect, 'none' to disable, or comma-separated
+        specs like 'cmd:python,py:numpy'.
+    ds : Dataset
+        The dataset being operated on
+
+    Returns
+    -------
+    dict
+        Dictionary mapping version names to version strings.
+        Keys use prefixes: 'cmd:' for CLI tools, 'py:' for Python packages.
+    """
+    result = {}
+
+    # Get config values
+    default = ds.config.get('datalad.run.versions.default', default='auto')
+    include = _get_config_list(ds, 'datalad.run.versions.include', default=['py:datalad'])
+    exclude = set(_get_config_list(ds, 'datalad.run.versions.exclude', default=[]))
+    strict = anything2bool(ds.config.get('datalad.run.versions.strict', default=False))
+
+    # Determine effective versions_spec
+    if versions_spec is None:
+        versions_spec = default
+
+    # Handle 'none' - disable version capture
+    if versions_spec == 'none':
+        return result
+
+    # Parse versions_spec into specs and custom commands
+    specs, custom_commands = _parse_versions_spec(versions_spec, ds)
+
+    # Handle 'auto' - detect tools from command
+    if 'auto' in specs:
+        specs.discard('auto')
+        detected = _detect_tools_from_command(cmd)
+        specs.update(detected)
+
+    # Add configured includes
+    specs.update(include)
+
+    # Remove excludes
+    specs -= exclude
+
+    # Capture each version
+    for name in sorted(specs):
+        try:
+            ver = _get_version(name, custom_commands)
+            if ver is not None:
+                result[name] = str(ver)
+            elif strict:
+                raise RuntimeError(f"Failed to capture version for {name}")
+            else:
+                lgr.debug("Could not capture version for %s", name)
+        except Exception as e:
+            if strict:
+                raise RuntimeError(f"Failed to capture version for {name}: {e}") from e
+            lgr.warning("Version capture failed for %s: %s", name, e)
+
+    return result
+
+
+def _get_config_list(ds, key, default=None):
+    """Get a config value that may be a list (multi-value)."""
+    val = ds.config.get(key, default=None)
+    if val is None:
+        return default if default is not None else []
+    # Config returns a single value or tuple for multi-value
+    if isinstance(val, (list, tuple)):
+        return list(val)
+    # Single value - could be comma-separated
+    return [v.strip() for v in val.split(',') if v.strip()]
+
+
+def _parse_versions_spec(versions_spec, ds):
+    """Parse --versions argument.
+
+    Parameters
+    ----------
+    versions_spec : str
+        The versions argument value. Reserved keywords: 'auto', 'none'.
+        All other specs must have prefix: 'cmd:' for CLI tools,
+        'py:' for Python packages. Use '@path' to load from JSON file.
+    ds : Dataset
+        The dataset (for resolving @file paths)
+
+    Returns
+    -------
+    tuple
+        (set of version specs to capture, dict of custom commands)
+    """
+    specs = set()
+    custom_commands = {}
+
+    if not versions_spec:
+        return specs, custom_commands
+
+    # Handle @file syntax
+    if versions_spec.startswith('@'):
+        file_path = versions_spec[1:]
+        if not os.path.isabs(file_path):
+            file_path = os.path.join(ds.path, file_path)
+        try:
+            with open(file_path) as f:
+                file_specs = json.load(f)
+            # File format: {"cmd:tool": "custom command", "py:package": null}
+            for name, cmd in file_specs.items():
+                _validate_version_spec(name)
+                specs.add(name)
+                if cmd:
+                    custom_commands[name] = cmd
+        except Exception as e:
+            lgr.warning("Failed to load version specs from %s: %s", file_path, e)
+        return specs, custom_commands
+
+    # Parse comma-separated list
+    for item in versions_spec.split(','):
+        item = item.strip()
+        if not item:
+            continue
+
+        if item in ('auto', 'none'):
+            # Reserved keywords
+            specs.add(item)
+        elif item.startswith('cmd:') and item.count(':') >= 2:
+            # Custom command: cmd:tool:command
+            parts = item.split(':', 2)
+            name = f"cmd:{parts[1]}"
+            custom_commands[name] = parts[2]
+            specs.add(name)
+        elif item.startswith('cmd:') or item.startswith('py:'):
+            # Standard prefixed spec
+            specs.add(item)
+        else:
+            lgr.warning(
+                "Invalid version spec '%s': must be 'auto', 'none', "
+                "or have prefix 'cmd:' or 'py:'", item
+            )
+
+    return specs, custom_commands
+
+
+def _validate_version_spec(name):
+    """Validate that a version spec has proper prefix."""
+    if name in ('auto', 'none'):
+        return
+    if not (name.startswith('cmd:') or name.startswith('py:')):
+        lgr.warning(
+            "Version spec '%s' should have prefix 'cmd:' or 'py:'", name
+        )
+
+
+def _detect_tools_from_command(cmd):
+    """Auto-detect executable tools from a command string.
+
+    Parameters
+    ----------
+    cmd : str
+        The command string
+
+    Returns
+    -------
+    set
+        Set of cmd:tool specs detected from the command
+    """
+    detected = set()
+
+    # Shell builtins and trivial commands to ignore
+    ignore = {
+        'cd', 'echo', 'printf', 'export', 'set', 'unset', 'source', '.',
+        'true', 'false', 'test', '[', '[[', 'read', 'eval', 'exec',
+        'exit', 'return', 'break', 'continue', 'shift', 'wait',
+        'ls', 'cat', 'head', 'tail', 'wc', 'sort', 'uniq', 'cut',
+        'tr', 'tee', 'touch', 'mkdir', 'rm', 'cp', 'mv', 'ln',
+        'chmod', 'chown', 'pwd', 'basename', 'dirname', 'realpath',
+    }
+
+    # Try to parse the command
+    try:
+        # Split by common shell operators to get pipeline segments
+        # This is a simple heuristic, not a full shell parser
+        segments = re.split(r'[|&;]|\|\||&&', cmd)
+
+        for segment in segments:
+            segment = segment.strip()
+            if not segment:
+                continue
+
+            # Handle subshells and command substitution simply
+            segment = re.sub(r'\$\([^)]*\)', '', segment)
+            segment = re.sub(r'`[^`]*`', '', segment)
+            segment = segment.lstrip('(').rstrip(')')
+
+            # Try to get the first word (the executable)
+            try:
+                tokens = shlex.split(segment)
+            except ValueError:
+                # shlex failed, try simple split
+                tokens = segment.split()
+
+            if not tokens:
+                continue
+
+            # Skip variable assignments at the start
+            while tokens and '=' in tokens[0] and not tokens[0].startswith('='):
+                tokens = tokens[1:]
+
+            if not tokens:
+                continue
+
+            exe = tokens[0]
+
+            # Skip if it's a path to a script we can't identify
+            if exe.startswith('./') or exe.startswith('/'):
+                exe = os.path.basename(exe)
+
+            # Skip shell builtins and trivial commands
+            if exe in ignore:
+                continue
+
+            # Skip if it looks like an option
+            if exe.startswith('-'):
+                continue
+
+            # Add as cmd:tool
+            detected.add(f'cmd:{exe}')
+
+    except Exception as e:
+        lgr.debug("Failed to parse command for tool detection: %s", e)
+
+    return detected
+
+
+def _get_version(name, custom_commands=None):
+    """Get version for a single tool/package.
+
+    Parameters
+    ----------
+    name : str
+        Name with prefix: 'cmd:tool' for CLI tools, 'py:package' for Python.
+    custom_commands : dict, optional
+        Custom version commands keyed by name
+
+    Returns
+    -------
+    str or None
+        Version string, or None if not found
+    """
+    custom_commands = custom_commands or {}
+
+    # Check for custom command
+    if name in custom_commands:
+        return _run_custom_version_command(custom_commands[name])
+
+    # Determine the key for external_versions
+    # external_versions uses: 'cmd:tool' for CLI, unprefixed for Python
+    if name.startswith('py:'):
+        ev_key = name[3:]  # Strip 'py:' prefix for external_versions
+    else:
+        ev_key = name  # 'cmd:*' is used as-is
+
+    # Try external_versions
+    ver = external_versions[ev_key]
+    if ver is not None and str(ver) != 'UNKNOWN':
+        return str(ver)
+
+    # For cmd:* that aren't registered, try probing
+    if name.startswith('cmd:') and ver is None:
+        tool = name[4:]  # Remove 'cmd:' prefix
+        return _probe_unknown_command(tool)
+
+    return None
+
+
+def _run_custom_version_command(cmd):
+    """Run a custom version command and return output.
+
+    Parameters
+    ----------
+    cmd : str
+        Shell command to run
+
+    Returns
+    -------
+    str or None
+        First line of output, or None on failure
+    """
+    from datalad.cmd import (
+        StdOutErrCapture,
+        WitlessRunner,
+    )
+
+    runner = WitlessRunner()
+    try:
+        out = runner.run(['sh', '-c', cmd], protocol=StdOutErrCapture)
+        output = out['stdout'].strip()
+        if output:
+            # Return first non-empty line
+            for line in output.splitlines():
+                line = line.strip()
+                if line:
+                    return line
+    except Exception as e:
+        lgr.debug("Custom version command failed: %s: %s", cmd, e)
+
+    return None
+
+
+def _probe_unknown_command(tool):
+    """Try common version flags for an unknown command-line tool.
+
+    Parameters
+    ----------
+    tool : str
+        Name of the tool (without cmd: prefix)
+
+    Returns
+    -------
+    str or None
+        Version string, or None if probing failed
+    """
+    from datalad.cmd import (
+        StdOutErrCapture,
+        WitlessRunner,
+    )
+
+    # Check if tool exists
+    if not shutil.which(tool):
+        lgr.debug("Tool not found in PATH: %s", tool)
+        return None
+
+    runner = WitlessRunner()
+
+    # Common version flags to try
+    version_flags = ['--version', '-version', '-V', 'version', '-v']
+
+    for flag in version_flags:
+        try:
+            cmd = [tool, flag] if flag != 'version' else [tool, flag]
+            out = runner.run(cmd, protocol=StdOutErrCapture)
+
+            # Check both stdout and stderr (some tools output to stderr)
+            output = out['stdout'] or out['stderr']
+            if output:
+                output = output.strip()
+                # Try to extract version from first line
+                first_line = output.splitlines()[0].strip()
+                if first_line:
+                    # Try to extract version number pattern
+                    version = _extract_version_from_string(first_line)
+                    if version:
+                        return version
+                    # Fall back to full first line if it's reasonable
+                    if len(first_line) < 100:
+                        return first_line
+
+        except Exception as e:
+            lgr.log(5, "Probing %s %s failed: %s", tool, flag, e)
+            continue
+
+    return None
+
+
+def _extract_version_from_string(s):
+    """Try to extract a version number from a string.
+
+    Parameters
+    ----------
+    s : str
+        String that may contain a version number
+
+    Returns
+    -------
+    str or None
+        Extracted version string, or None
+    """
+    # Common patterns:
+    # "tool version 1.2.3"
+    # "tool v1.2.3"
+    # "tool 1.2.3"
+    # "1.2.3"
+    patterns = [
+        r'[vV]?(\d+\.\d+(?:\.\d+)?(?:[-+.]\w+)*)',  # semver-like
+        r'(\d+\.\d+)',  # major.minor
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, s)
+        if match:
+            return match.group(1)
+
+    return None
+
+
+def check_stale_injected_file(ds):
+    """Check for pre-existing injected versions file.
+
+    Parameters
+    ----------
+    ds : Dataset
+        The dataset
+
+    Returns
+    -------
+    bool
+        True if stale file was found (and should be ignored)
+    """
+    path = Path(ds.path) / INJECTED_VERSIONS_FILE
+    if path.exists():
+        lgr.warning(
+            "Stale %s found (exists before run), ignoring. "
+            "Remove manually if not needed.",
+            path
+        )
+        return True
+    return False
+
+
+def read_injected_versions(ds):
+    """Read and remove injected versions file if present.
+
+    Parameters
+    ----------
+    ds : Dataset
+        The dataset
+
+    Returns
+    -------
+    dict or None
+        Versions dict from the file, or None if not present
+    """
+    path = Path(ds.path) / INJECTED_VERSIONS_FILE
+    if not path.exists():
+        return None
+
+    try:
+        with open(path) as f:
+            versions = json.load(f)
+        path.unlink()  # Delete after reading
+        lgr.debug("Read injected versions from %s: %s", path, versions)
+        return versions
+    except Exception as e:
+        lgr.warning("Failed to read injected versions from %s: %s", path, e)
+        return None

--- a/datalad/core/local/tests/test_run_versions.py
+++ b/datalad/core/local/tests/test_run_versions.py
@@ -1,0 +1,308 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Tests for version capture in `datalad run`"""
+
+import json
+import os
+import pytest
+
+from datalad.api import run
+from datalad.core.local.run import run_command
+from datalad.core.local.run_versions import (
+    INJECTED_VERSIONS_FILE,
+    _detect_tools_from_command,
+    _extract_version_from_string,
+    _get_config_list,
+    _get_version,
+    _parse_versions_spec,
+    capture_versions,
+    check_stale_injected_file,
+    read_injected_versions,
+)
+from datalad.distribution.dataset import Dataset
+from datalad.tests.utils_pytest import (
+    assert_in,
+    assert_in_results,
+    assert_not_in,
+    assert_repo_status,
+    eq_,
+    ok_,
+    with_tempfile,
+    with_tree,
+)
+
+
+@pytest.mark.ai_generated
+class TestDetectToolsFromCommand:
+    """Tests for _detect_tools_from_command function"""
+
+    def test_simple_command(self):
+        detected = _detect_tools_from_command("python script.py")
+        assert "cmd:python" in detected
+
+    def test_pipeline(self):
+        detected = _detect_tools_from_command("cat file.txt | grep pattern | sort")
+        # cat, grep, sort are in ignore list, but let's check pipeline parsing
+        # Actually they're in ignore list, so won't be detected
+        assert "cmd:cat" not in detected
+        assert "cmd:grep" not in detected
+
+    def test_complex_command(self):
+        detected = _detect_tools_from_command(
+            "python script.py && git commit -m 'msg'"
+        )
+        assert "cmd:python" in detected
+        assert "cmd:git" in detected
+
+    def test_with_path(self):
+        detected = _detect_tools_from_command("/usr/bin/python script.py")
+        assert "cmd:python" in detected
+
+    def test_relative_path(self):
+        detected = _detect_tools_from_command("./myscript.sh arg1")
+        # Should extract basename
+        assert "cmd:myscript.sh" in detected
+
+    def test_variable_assignment(self):
+        detected = _detect_tools_from_command("VAR=value python script.py")
+        assert "cmd:python" in detected
+        assert "cmd:VAR=value" not in detected
+
+    def test_empty_command(self):
+        detected = _detect_tools_from_command("")
+        eq_(detected, set())
+
+    def test_shell_builtin_ignored(self):
+        detected = _detect_tools_from_command("echo hello")
+        assert "cmd:echo" not in detected
+
+
+@pytest.mark.ai_generated
+class TestExtractVersionFromString:
+    """Tests for _extract_version_from_string function"""
+
+    def test_semver(self):
+        eq_(_extract_version_from_string("Python 3.12.0"), "3.12.0")
+
+    def test_with_v_prefix(self):
+        eq_(_extract_version_from_string("v1.2.3"), "1.2.3")
+
+    def test_with_suffix(self):
+        eq_(_extract_version_from_string("git version 2.43.0-rc1"), "2.43.0-rc1")
+
+    def test_major_minor_only(self):
+        eq_(_extract_version_from_string("tool 1.2"), "1.2")
+
+    def test_no_version(self):
+        eq_(_extract_version_from_string("no version here"), None)
+
+
+@pytest.mark.ai_generated
+class TestParseVersionsSpec:
+    """Tests for _parse_versions_spec function"""
+
+    @with_tempfile(mkdir=True)
+    def test_auto(self, path=None):
+        ds = Dataset(path).create()
+        specs, custom = _parse_versions_spec("auto", ds)
+        assert "auto" in specs
+        eq_(custom, {})
+
+    @with_tempfile(mkdir=True)
+    def test_none_string(self, path=None):
+        ds = Dataset(path).create()
+        # 'none' is a reserved keyword
+        specs, custom = _parse_versions_spec("none", ds)
+        assert "none" in specs
+
+    @with_tempfile(mkdir=True)
+    def test_explicit_list(self, path=None):
+        ds = Dataset(path).create()
+        # Now requires py: prefix for Python packages
+        specs, custom = _parse_versions_spec("cmd:python,py:numpy,py:pandas", ds)
+        assert "cmd:python" in specs
+        assert "py:numpy" in specs
+        assert "py:pandas" in specs
+
+    @with_tempfile(mkdir=True)
+    def test_unprefixed_rejected(self, path=None):
+        ds = Dataset(path).create()
+        # Unprefixed names (not auto/none) should be rejected with warning
+        specs, custom = _parse_versions_spec("numpy", ds)
+        # Should NOT be added since it lacks prefix
+        assert "numpy" not in specs
+
+    @with_tempfile(mkdir=True)
+    def test_custom_command(self, path=None):
+        ds = Dataset(path).create()
+        specs, custom = _parse_versions_spec(
+            "cmd:mytool:mytool --show-version", ds
+        )
+        assert "cmd:mytool" in specs
+        eq_(custom["cmd:mytool"], "mytool --show-version")
+
+    @with_tempfile(mkdir=True)
+    def test_from_file(self, path=None):
+        ds = Dataset(path).create()
+        # Create a versions.json file with proper prefixes
+        versions_file = os.path.join(path, "versions.json")
+        with open(versions_file, "w") as f:
+            json.dump({"cmd:python": None, "py:numpy": None}, f)
+
+        specs, custom = _parse_versions_spec("@versions.json", ds)
+        assert "cmd:python" in specs
+        assert "py:numpy" in specs
+
+
+@pytest.mark.ai_generated
+class TestGetVersion:
+    """Tests for _get_version function"""
+
+    def test_datalad_version(self):
+        ver = _get_version("py:datalad")
+        ok_(ver is not None)
+
+    def test_python_version(self):
+        ver = _get_version("cmd:python")
+        ok_(ver is not None)
+        # Should be a version string like "3.x.y"
+        assert ver.startswith("3.")
+
+    def test_unknown_package(self):
+        ver = _get_version("py:nonexistent_package_xyz")
+        eq_(ver, None)
+
+
+@pytest.mark.ai_generated
+class TestInjectedVersionsFile:
+    """Tests for injected versions file handling"""
+
+    @with_tempfile(mkdir=True)
+    def test_check_stale_no_file(self, path=None):
+        ds = Dataset(path).create()
+        # No stale file
+        ok_(not check_stale_injected_file(ds))
+
+    @with_tempfile(mkdir=True)
+    def test_check_stale_with_file(self, path=None):
+        ds = Dataset(path).create()
+        # Create stale file
+        injected_path = os.path.join(path, INJECTED_VERSIONS_FILE)
+        os.makedirs(os.path.dirname(injected_path), exist_ok=True)
+        with open(injected_path, "w") as f:
+            json.dump({"cmd:test": "1.0"}, f)
+        # Should detect stale file
+        ok_(check_stale_injected_file(ds))
+
+    @with_tempfile(mkdir=True)
+    def test_read_injected_no_file(self, path=None):
+        ds = Dataset(path).create()
+        eq_(read_injected_versions(ds), None)
+
+    @with_tempfile(mkdir=True)
+    def test_read_injected_with_file(self, path=None):
+        ds = Dataset(path).create()
+        # Create injected file
+        injected_path = os.path.join(path, INJECTED_VERSIONS_FILE)
+        os.makedirs(os.path.dirname(injected_path), exist_ok=True)
+        with open(injected_path, "w") as f:
+            json.dump({"cmd:container": "1.0", "container:image": "test"}, f)
+
+        versions = read_injected_versions(ds)
+        eq_(versions["cmd:container"], "1.0")
+        eq_(versions["container:image"], "test")
+        # File should be deleted
+        ok_(not os.path.exists(injected_path))
+
+
+@pytest.mark.ai_generated
+class TestCaptureVersions:
+    """Tests for capture_versions function"""
+
+    @with_tempfile(mkdir=True)
+    def test_capture_auto(self, path=None):
+        ds = Dataset(path).create()
+        versions = capture_versions("python script.py", "auto", ds)
+        # Should include py:datalad (from default include)
+        assert "py:datalad" in versions
+        # May include cmd:python if detected and available
+        # (depends on environment)
+
+    @with_tempfile(mkdir=True)
+    def test_capture_none(self, path=None):
+        ds = Dataset(path).create()
+        versions = capture_versions("python script.py", "none", ds)
+        eq_(versions, {})
+
+    @with_tempfile(mkdir=True)
+    def test_capture_explicit(self, path=None):
+        ds = Dataset(path).create()
+        versions = capture_versions(
+            "python script.py", "py:datalad,cmd:python", ds
+        )
+        assert "py:datalad" in versions
+        # cmd:python should be captured if python is available
+        if "cmd:python" in versions:
+            assert versions["cmd:python"].startswith("3.")
+
+
+@pytest.mark.ai_generated
+class TestRunWithVersions:
+    """Integration tests for run with version capture"""
+
+    @with_tree(tree={"script.py": "print('hello')"})
+    def test_run_captures_versions(self, path=None):
+        ds = Dataset(path).create(force=True)
+        ds.save()
+        # Run with auto version capture
+        results = list(run_command(
+            "echo hello",
+            dataset=ds,
+            versions="auto",
+        ))
+        # Check that versions were captured in run_info
+        run_result = [r for r in results if r.get("action") == "run"][0]
+        run_info = run_result.get("run_info", {})
+        # py:datalad should be in versions (from default include)
+        assert "versions" in run_info
+        assert "py:datalad" in run_info["versions"]
+
+    @with_tree(tree={"script.py": "print('hello')"})
+    def test_run_versions_none(self, path=None):
+        ds = Dataset(path).create(force=True)
+        ds.save()
+        # Run with version capture disabled
+        results = list(run_command(
+            "echo hello",
+            dataset=ds,
+            versions="none",
+        ))
+        run_result = [r for r in results if r.get("action") == "run"][0]
+        run_info = run_result.get("run_info", {})
+        # versions should be empty or not present
+        versions = run_info.get("versions", {})
+        eq_(versions, {})
+
+    @with_tree(tree={"script.py": "print('hello')"})
+    def test_run_with_extra_info_versions(self, path=None):
+        ds = Dataset(path).create(force=True)
+        ds.save()
+        # Run with extra_info containing versions (simulating extension)
+        results = list(run_command(
+            "echo hello",
+            dataset=ds,
+            versions="auto",
+            extra_info={"versions": {"container:image": "test:latest"}},
+        ))
+        run_result = [r for r in results if r.get("action") == "run"][0]
+        run_info = run_result.get("run_info", {})
+        # Should have both captured and extra versions
+        assert "versions" in run_info
+        assert "py:datalad" in run_info["versions"]
+        assert run_info["versions"]["container:image"] == "test:latest"

--- a/datalad/support/external_versions.py
+++ b/datalad/support/external_versions.py
@@ -160,6 +160,15 @@ def _get_system_7z_version():
     lgr.debug("Could not determine version of 7z from stdout. %s", out)
 
 
+def _get_python_version():
+    """Return version of Python interpreter."""
+    out = _runner.run(
+        ['python', '--version'],
+        protocol=StdOutErrCapture)
+    # Output: "Python 3.12.0"
+    return out['stdout'].strip().split()[1]
+
+
 def get_rsync_version():
 
     # This does intentionally not query the version of rsync itself, but
@@ -215,6 +224,7 @@ class ExternalVersions(object):
         'cmd:ssh': _get_ssh_version,
         'cmd:system-ssh': _get_system_ssh_version,
         'cmd:7z': _get_system_7z_version,
+        'cmd:python': _get_python_version,
     }
     # ad-hoc hardcoded map for relevant Python packages which do not provide
     # __version__ and are shipped by a differently named pypi package

--- a/tools/testing/adhoc/README.md
+++ b/tools/testing/adhoc/README.md
@@ -1,0 +1,13 @@
+# Ad-hoc Testing Scripts
+
+This folder contains ad-hoc testing scripts produced to test specific
+functionality at some point in time.
+
+**Note:** These scripts are not actively maintained and may not work with
+current versions of the codebase. They are kept here for reference and
+potential future use.
+
+## Scripts
+
+- `test_backwards_compat_versions.sh` - Tests backwards compatibility of
+  the `versions` field in run records with older datalad versions.

--- a/tools/testing/adhoc/test_backwards_compat_versions.sh
+++ b/tools/testing/adhoc/test_backwards_compat_versions.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Test backwards compatibility: older datalad should be able to rerun
+# commits created by newer datalad with "versions" field in run record.
+#
+# Usage: ./test_backwards_compat_versions.sh [OLD_DATALAD_VERSION]
+# Default OLD_DATALAD_VERSION is 1.0.0
+
+set -eu
+
+OLD_VERSION="${1:-1.0.0}"
+TESTDIR=$(mktemp -d)
+CURRENT_DIR=$(pwd)
+
+cleanup() {
+    echo "Cleaning up $TESTDIR"
+    # Need to make annexed files writable before removal
+    chmod -R +w "$TESTDIR" 2>/dev/null || true
+    rm -rf "$TESTDIR"
+}
+trap cleanup EXIT
+
+echo "=== Backwards Compatibility Test for 'versions' field ==="
+echo "Testing that datalad $OLD_VERSION can rerun commits from current version"
+echo "Test directory: $TESTDIR"
+echo
+
+cd "$TESTDIR"
+
+# Create virtual environments
+echo "--- Creating venvs ---"
+uv venv venv-current
+uv venv venv-old
+
+# Install current datalad (development version)
+echo "--- Installing current datalad from $CURRENT_DIR ---"
+uv pip install -p venv-current/bin/python -e "$CURRENT_DIR"
+
+# Install old datalad
+echo "--- Installing datalad==$OLD_VERSION ---"
+uv pip install -p venv-old/bin/python "datalad==$OLD_VERSION"
+
+# Show versions
+echo "--- Installed versions ---"
+echo "Current:"
+venv-current/bin/python -c "import datalad; print(f'  datalad {datalad.__version__}')"
+echo "Old:"
+venv-old/bin/python -c "import datalad; print(f'  datalad {datalad.__version__}')"
+echo
+
+# Create test dataset with current datalad
+echo "--- Creating test dataset with current datalad ---"
+mkdir testds && cd testds
+../venv-current/bin/datalad create -f .
+echo "initial content" > input.txt
+../venv-current/bin/datalad save -m "Add input file"
+
+# Run a command with version capture enabled (default)
+# Use -i for input and -o for output to properly handle annexed files
+echo "--- Running command with version capture (current datalad) ---"
+../venv-current/bin/datalad run -m "Test command with versions" \
+    -i input.txt -o output.txt \
+    "cat input.txt > output.txt && echo 'processed' >> output.txt"
+
+# Show the run record
+echo "--- Run record in commit message ---"
+git log -1 --format="%B" | head -20
+echo "..."
+echo
+
+# Verify versions field is present
+if git log -1 --format="%B" | grep -q '"versions"'; then
+    echo "✓ 'versions' field is present in run record"
+else
+    echo "✗ 'versions' field NOT found in run record"
+    exit 1
+fi
+echo
+
+# Now test with old datalad
+echo "--- Testing rerun with datalad $OLD_VERSION ---"
+
+# First, check if old datalad can at least parse the commit
+echo "Attempting 'datalad rerun --report' with old version..."
+if ../venv-old/bin/datalad rerun --report HEAD 2>&1; then
+    echo "✓ Old datalad can report on the run commit"
+else
+    echo "⚠ Old datalad failed to report (may be expected)"
+fi
+echo
+
+# Save the run commit hash before reset
+RUN_COMMIT=$(git rev-parse HEAD)
+
+# Reset to before the run and try actual rerun
+echo "Resetting to parent commit and attempting actual rerun..."
+git reset --hard HEAD~1
+
+# Remove output file if it exists
+rm -f output.txt
+
+echo "Attempting to rerun commit $RUN_COMMIT with old datalad..."
+if ../venv-old/bin/datalad rerun "$RUN_COMMIT" 2>&1; then
+    echo "✓ Old datalad successfully reran the command!"
+    echo
+    echo "--- Resulting commit message ---"
+    git log -1 --format="%B" | head -20
+else
+    EXITCODE=$?
+    echo "✗ Old datalad FAILED to rerun (exit code: $EXITCODE)"
+    echo
+    echo "This may indicate a backwards compatibility issue!"
+    exit 1
+fi
+
+echo
+echo "=== SUCCESS: Backwards compatibility test PASSED ==="
+echo "datalad $OLD_VERSION can rerun commits with 'versions' field"


### PR DESCRIPTION
Capture tool and package versions in run records for reproducibility.

New CLI option:
- `-V/--versions SPEC`: Specify versions to capture
  - 'auto' (default): Auto-detect tools from command
  - 'none': Disable version capture
  - 'cmd:tool': CLI tools (e.g., cmd:python, cmd:git)
  - 'py:package': Python packages (e.g., py:numpy)
  - 'cmd:tool:command': Custom version command
  - '@file.json': Load specs from JSON file

Configuration options:
- datalad.run.versions.default: Default behavior (auto/none/list)
- datalad.run.versions.include: Always capture these (default: py:datalad)
- datalad.run.versions.exclude: Never capture these
- datalad.run.versions.strict: Fail on capture errors

Extension support:
- Register parsers via external_versions.add()
- Pass versions via extra_info={'versions': {...}}
- Injected file: .git/datalad/run_versions.json

Record format adds 'versions' field:
{"cmd": "...", "versions": {"py:datalad": "0.19.0", "cmd:python": "3.12.0"}}

🤖 Generated with [Claude Code](https://claude.com/claude-code)

TODOs
- [ ] more of review for added code 
    - [ ] seems we might want to trim "detection" to only lead command(s), or make an option on how
    - [ ] might want to move "version detection" heuristic into `external_version` for `cmd`s in general!
- [ ] potentially make default to no capture and rely on people to configure

But overall l would really like to see smth like that since I was in this situation many many times needing to figure out versions of even datalad and git-annex not to say of underlying commands. 


<details>
<summary>Seems to work on simple cases I tried</summary> 

```shell
❯ datalad run duct ls
[INFO   ] == Command start (output follows) ===== 
2026-01-04T09:39:27-0500 [INFO    ] con-duct: duct 0.17.0 is executing 'ls'...
2026-01-04T09:39:27-0500 [INFO    ] con-duct: Log files will be written to .duct/logs/2026.01.04T09.39.27-843373_
2026-01-04T09:39:27-0500 [INFO    ] con-duct: Summary:
Exit Code: 0
Command: ls
Log files location: .duct/logs/2026.01.04T09.39.27-843373_
Wall Clock Time: 0.002 sec
Memory Peak Usage (RSS): -
Memory Average Usage (RSS): -
Virtual Memory Peak Usage (VSZ): -
Virtual Memory Average Usage (VSZ): -
Memory Peak Percentage: -%
Memory Average Percentage: -%
CPU Peak Usage: -%
Average CPU Usage: -%

[INFO   ] == Command exit (modification check follows) ===== 
run(ok): /tmp/testds (dataset) [duct ls]
add(ok): .duct/logs/2026.01.04T09.39.27-843373_stderr (file)                                                                                                                                                                      
add(ok): .duct/logs/2026.01.04T09.39.27-843373_stdout (file)                                                                                                                                                                      
add(ok): .duct/logs/2026.01.04T09.39.27-843373_usage.json (file)                                                                                                                                                                  
add(ok): .duct/logs/2026.01.04T09.39.27-843373_info.json (file)                                                                                                                                                                   
save(ok): . (dataset)                                                                                                                                                                                                             
❯ git show
commit 2729dd2fb8dd9f5c23f435cc2d3df38a4f8841e6 (HEAD -> master)
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Sun Jan 4 09:39:28 2026 -0500

    [DATALAD RUNCMD] duct ls
    
    === Do not change lines below ===
    {
     "chain": [],
     "cmd": "duct ls",
     "dsid": "5f22ad01-8659-4701-b788-b51fe5a656ed",
     "exit": 0,
     "extra_inputs": [],
     "inputs": [],
     "outputs": [],
     "pwd": ".",
     "versions": {
      "cmd:duct": "0.17.0",
      "py:datalad": "1.2.3+3.g38643aeab"
     }
    }
    ^^^ Do not change lines above ^^^

```

```
❯ datalad run dcm2niix --version
[INFO   ] == Command start (output follows) ===== 
Chris Rorden's dcm2niiX version v1.0.20241025  (JP2:OpenJPEG) GCC14.2.0 x86-64 (64-bit Linux)
v1.0.20241025
[INFO   ] == Command exit (modification check follows) ===== 
[INFO   ] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -d . -r -F .git/COMMIT_EDITMSG' 
run(error): /tmp/testds (dataset) [dcm2niix --version]
❯ cat .git/COMMIT_EDITMSG
[DATALAD RUNCMD] dcm2niix --version

=== Do not change lines below ===
{
 "chain": [],
 "cmd": "dcm2niix --version",
 "dsid": "5f22ad01-8659-4701-b788-b51fe5a656ed",
 "exit": 3,
 "extra_inputs": [],
 "inputs": [],
 "outputs": [],
 "pwd": ".",
 "versions": {
  "cmd:dcm2niix": "1.0.20241025",
  "py:datalad": "1.2.3+3.gb878ad346"
 }
}
^^^ Do not change lines above ^^^
```
</details>