### PR TITLE
Add --message option to clone, create, and update

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -146,6 +146,11 @@
             "affiliation": "Institute of Biophysics, University of Natural Resources and Life Sciences, Vienna, Austria",
             "name": "Lukas Schrangl",
             "orcid": "0000-0002-0420-7872"
+        },
+        {
+            "affiliation": "Dartmouth College, Hanover, NH, United States",
+            "name": "Macdonald, Austin",
+            "orcid": "0000-0002-8124-807X"
         }
     ],
     "grants": [

--- a/changelog.d/pr-7785.md
+++ b/changelog.d/pr-7785.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- Add `--message` option to `clone`, `create`, and `update` for custom commit messages when registering subdatasets. Related to [#3316](https://github.com/datalad/datalad/issues/3316) via [PR #7785](https://github.com/datalad/datalad/pull/7785) (by [@asmacdo](https://github.com/asmacdo))

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -30,6 +30,7 @@ from datalad.interface.base import (
 from datalad.interface.common_opts import (
     location_description,
     reckless_opt,
+    save_message_opt,
 )
 from datalad.interface.results import get_status_dict
 from datalad.support.annexrepo import AnnexRepo
@@ -218,6 +219,7 @@ class Clone(Interface):
             '--branch'."""),
         description=location_description,
         reckless=reckless_opt,
+        message=save_message_opt,
     )
 
     @staticmethod
@@ -231,6 +233,7 @@ class Clone(Interface):
             dataset=None,
             description=None,
             reckless=None,
+            message=None,
         ):
         # did we explicitly get a dataset to install into?
         # if we got a dataset, path will be resolved against it.
@@ -342,10 +345,9 @@ class Clone(Interface):
             actually_saved_subds = False
             for r in ds.save(
                     path,
-                    # Note, that here we know we don't save anything but a new
-                    # subdataset. Hence, don't go with default commit message,
-                    # but be more specific.
-                    message="[DATALAD] Added subdataset",
+                    # This save only commits the new subdataset, nothing else.
+                    # Use caller's message if provided, otherwise a specific default.
+                    message=message or "[DATALAD] Added subdataset",
                     return_type='generator',
                     result_filter=None,
                     result_xfm=None,

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -379,15 +379,16 @@ def test_clone_custom_message(source_path=None, top_path=None):
     # Single line message
     custom_msg = "Add source dataset for testing"
     ds.clone(source, "sub", message=custom_msg)
-    # Parent has custom message
-    eq_(ds.repo.format_commit("%B").strip(), custom_msg)
+    # Parent has custom message. Use DEFAULT_BRANCH to handle adjusted branches
+    # where git-annex adds an extra commit on top.
+    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
     # Child is unaffected (has its own commit history from source)
     subds = Dataset(ds.pathobj / "sub")
-    neq_(subds.repo.format_commit("%B").strip(), custom_msg)
+    neq_(subds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
     # Multi-line message
     multi_line_msg = "Add second dataset\n\nThis is the body."
     ds.clone(source, "sub2", message=multi_line_msg)
-    eq_(ds.repo.format_commit("%B").strip(), multi_line_msg)
+    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), multi_line_msg)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -321,7 +321,7 @@ def test_clone_into_dataset(source_path=None, top_path=None):
     # Note, we test against the produced history in DEFAULT_BRANCH, not what it
     # turns into in an adjusted branch!
     hexsha_before = ds.repo.get_hexsha(DEFAULT_BRANCH)
-    subds = ds.clone(source, "sub",
+    subds = ds.clone(source, "sub", message="custom clone message",
                      result_xfm='datasets', return_type='item-or-list')
     ok_((subds.pathobj / '.git').is_dir())
     ok_(subds.is_installed())
@@ -341,6 +341,9 @@ def test_clone_into_dataset(source_path=None, top_path=None):
     ))
     assert_not_in(hexsha_before, commits)
     eq_(len(commits), 1)
+    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), "custom clone message")
+    # child is unaffected
+    neq_(subds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), "custom clone message")
 
     # but we could also save while installing and there should be no side-effect
     # of saving any other changes if we state to not auto-save changes
@@ -369,26 +372,6 @@ def test_clone_into_dataset(source_path=None, top_path=None):
                                   'dummy.txt'])
     # nothing was committed
     eq_(hexsha_before, ds.repo.get_hexsha(DEFAULT_BRANCH))
-
-
-@with_tempfile(mkdir=True)
-@with_tempfile(mkdir=True)
-def test_clone_custom_message(source_path=None, top_path=None):
-    source = Dataset(source_path).create()
-    ds = create(top_path)
-    # Single line message
-    custom_msg = "Add source dataset for testing"
-    ds.clone(source, "sub", message=custom_msg)
-    # Parent has custom message. Use DEFAULT_BRANCH to handle adjusted branches
-    # where git-annex adds an extra commit on top.
-    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
-    # Child is unaffected (has its own commit history from source)
-    subds = Dataset(ds.pathobj / "sub")
-    neq_(subds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
-    # Multi-line message
-    multi_line_msg = "Add second dataset\n\nThis is the body."
-    ds.clone(source, "sub2", message=multi_line_msg)
-    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), multi_line_msg)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -373,6 +373,25 @@ def test_clone_into_dataset(source_path=None, top_path=None):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
+def test_clone_custom_message(source_path=None, top_path=None):
+    source = Dataset(source_path).create()
+    ds = create(top_path)
+    # Single line message
+    custom_msg = "Add source dataset for testing"
+    ds.clone(source, "sub", message=custom_msg)
+    # Parent has custom message
+    eq_(ds.repo.format_commit("%B").strip(), custom_msg)
+    # Child is unaffected (has its own commit history from source)
+    subds = Dataset(ds.pathobj / "sub")
+    neq_(subds.repo.format_commit("%B").strip(), custom_msg)
+    # Multi-line message
+    multi_line_msg = "Add second dataset\n\nThis is the body."
+    ds.clone(source, "sub2", message=multi_line_msg)
+    eq_(ds.repo.format_commit("%B").strip(), multi_line_msg)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
 def test_notclone_known_subdataset(src_path=None, path=None):
     src = Dataset(src_path).create()
     sub = src.create('subm 1')

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -36,7 +36,10 @@ from datalad.interface.base import (
     build_doc,
     eval_results,
 )
-from datalad.interface.common_opts import location_description
+from datalad.interface.common_opts import (
+    location_description,
+    save_message_opt,
+)
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureKeyChoice,
@@ -180,7 +183,8 @@ class Create(Interface):
             [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
             to get a list of available procedures, such as cfg_text2git.
             """
-        )
+        ),
+        message=save_message_opt,
     )
 
     @staticmethod
@@ -195,7 +199,8 @@ class Create(Interface):
             dataset=None,
             annex=True,
             fake_dates=False,
-            cfg_proc=None
+            cfg_proc=None,
+            message=None,
     ):
         # we only perform negative tests below
         no_annex = not annex
@@ -443,6 +448,9 @@ class Create(Interface):
             # -> make submodule
             yield from refds.save(
                 path=tbds.path,
+                # This save only commits the new subdataset, nothing else.
+                # Use caller's message if provided, otherwise a specific default.
+                message=message or "[DATALAD] Created subdataset",
                 return_type='generator',
                 result_renderer='disabled',
             )

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -196,7 +196,7 @@ def test_create_sub(path=None):
     ds.create()
 
     # 1. create sub and add to super:
-    subds = ds.create(op.join("some", "what", "deeper"))
+    subds = ds.create(op.join("some", "what", "deeper"), message="custom create message")
     ok_(isinstance(subds, Dataset))
     ok_(subds.is_installed())
     assert_repo_status(subds.path, annex=True)
@@ -213,6 +213,9 @@ def test_create_sub(path=None):
               ds.subdatasets(result_xfm='relpaths'))
     # and was committed:
     assert_repo_status(ds.path)
+    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), "custom create message")
+    # child is unaffected
+    neq_(subds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), "custom create message")
 
     # subds finds superdataset
     ok_(subds.get_superdataset() == ds)
@@ -232,24 +235,6 @@ def test_create_sub(path=None):
     ok_(subds3.is_installed())
     assert_repo_status(subds3.path, annex=False)
     assert_in("third", ds.subdatasets(result_xfm='relpaths'))
-
-
-@with_tempfile
-def test_create_custom_message(path=None):
-    ds = Dataset(path).create()
-    # Single line message
-    custom_msg = "Create raw data subdataset"
-    ds.create("sub", message=custom_msg)
-    # Parent has custom message. Use DEFAULT_BRANCH to handle adjusted branches
-    # where git-annex adds an extra commit on top.
-    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
-    # Child is unaffected (still has default "new dataset" message)
-    subds = Dataset(ds.pathobj / "sub")
-    neq_(subds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
-    # Multi-line message
-    multi_line_msg = "Create processed data\n\nThis is the body."
-    ds.create("sub2", message=multi_line_msg)
-    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), multi_line_msg)
 
 
 @with_tempfile

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -30,6 +30,7 @@ from datalad.tests.utils_pytest import (
     assert_status,
     eq_,
     has_symlink_capability,
+    neq_,
     ok_,
     ok_exists,
     swallow_outputs,
@@ -230,6 +231,23 @@ def test_create_sub(path=None):
     ok_(subds3.is_installed())
     assert_repo_status(subds3.path, annex=False)
     assert_in("third", ds.subdatasets(result_xfm='relpaths'))
+
+
+@with_tempfile
+def test_create_custom_message(path=None):
+    ds = Dataset(path).create()
+    # Single line message
+    custom_msg = "Create raw data subdataset"
+    ds.create("sub", message=custom_msg)
+    # Parent has custom message
+    eq_(ds.repo.format_commit("%B").strip(), custom_msg)
+    # Child is unaffected (still has default "new dataset" message)
+    subds = Dataset(ds.pathobj / "sub")
+    neq_(subds.repo.format_commit("%B").strip(), custom_msg)
+    # Multi-line message
+    multi_line_msg = "Create processed data\n\nThis is the body."
+    ds.create("sub2", message=multi_line_msg)
+    eq_(ds.repo.format_commit("%B").strip(), multi_line_msg)
 
 
 @with_tempfile

--- a/datalad/core/local/tests/test_create.py
+++ b/datalad/core/local/tests/test_create.py
@@ -21,6 +21,7 @@ from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import CommandError
 from datalad.tests.utils_pytest import (
+    DEFAULT_BRANCH,
     OBSCURE_FILENAME,
     assert_in,
     assert_in_results,
@@ -239,15 +240,16 @@ def test_create_custom_message(path=None):
     # Single line message
     custom_msg = "Create raw data subdataset"
     ds.create("sub", message=custom_msg)
-    # Parent has custom message
-    eq_(ds.repo.format_commit("%B").strip(), custom_msg)
+    # Parent has custom message. Use DEFAULT_BRANCH to handle adjusted branches
+    # where git-annex adds an extra commit on top.
+    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
     # Child is unaffected (still has default "new dataset" message)
     subds = Dataset(ds.pathobj / "sub")
-    neq_(subds.repo.format_commit("%B").strip(), custom_msg)
+    neq_(subds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
     # Multi-line message
     multi_line_msg = "Create processed data\n\nThis is the body."
     ds.create("sub2", message=multi_line_msg)
-    eq_(ds.repo.format_commit("%B").strip(), multi_line_msg)
+    eq_(ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), multi_line_msg)
 
 
 @with_tempfile

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -1109,3 +1109,21 @@ def test_update_fetch_failure(path=None):
         status="ok",
         path=ds_b.path,
         action="update")
+
+
+@with_tempfile(mkdir=True)
+def test_update_custom_message(path=None):
+    path = Path(path)
+    origin = Dataset(path / "origin").create()
+    origin.create("sub")
+    clone_ds = install(source=origin.path, path=str(path / "clone"), recursive=True)
+    # Change subdataset without saving in parent - forces save after update
+    (origin.pathobj / "sub" / "newfile.txt").write_text("content")
+    Dataset(origin.pathobj / "sub").save("newfile.txt")
+    custom_msg = "Update subdataset to latest version"
+    clone_ds.update(recursive=True, how="merge", message=custom_msg)
+    # Parent has custom message
+    eq_(clone_ds.repo.format_commit("%B").strip(), custom_msg)
+    # Child is unaffected
+    subds = Dataset(clone_ds.pathobj / "sub")
+    neq_(subds.repo.format_commit("%B").strip(), custom_msg)

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -1122,8 +1122,9 @@ def test_update_custom_message(path=None):
     Dataset(origin.pathobj / "sub").save("newfile.txt")
     custom_msg = "Update subdataset to latest version"
     clone_ds.update(recursive=True, how="merge", message=custom_msg)
-    # Parent has custom message
-    eq_(clone_ds.repo.format_commit("%B").strip(), custom_msg)
+    # Parent has custom message. Use DEFAULT_BRANCH to handle adjusted branches
+    # where git-annex adds an extra commit on top.
+    eq_(clone_ds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)
     # Child is unaffected
     subds = Dataset(clone_ds.pathobj / "sub")
-    neq_(subds.repo.format_commit("%B").strip(), custom_msg)
+    neq_(subds.repo.format_commit("%B", DEFAULT_BRANCH).strip(), custom_msg)

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -26,6 +26,7 @@ from datalad.interface.base import (
 from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
+    save_message_opt,
 )
 from datalad.interface.results import (
     YieldDatasets,
@@ -209,7 +210,9 @@ class Update(Interface):
             args=("--reobtain-data",),
             action="store_true",
             doc="""if enabled, file content that was present before an update
-            will be re-obtained in case a file was changed by the update."""), )
+            will be re-obtained in case a file was changed by the update."""),
+        message=save_message_opt,
+    )
 
     @staticmethod
     @datasetmethod(name='update')
@@ -226,7 +229,9 @@ class Update(Interface):
             recursive=False,
             recursion_limit=None,
             fetch_all=None,
-            reobtain_data=False):
+            reobtain_data=False,
+            message=None,
+    ):
         if fetch_all is not None:
             lgr.warning('update(fetch_all=...) called. Option has no effect, and will be removed')
         if path and not recursive:
@@ -422,10 +427,10 @@ class Update(Interface):
         # it was a pure fetch
         if how_curr and recursive:
             yield from _save_after_update(
-                refds, save_paths, update_failures, path, saw_subds)
+                refds, save_paths, update_failures, path, saw_subds, message)
 
 
-def _save_after_update(refds, tosave, update_failures, path_arg, saw_subds):
+def _save_after_update(refds, tosave, update_failures, path_arg, saw_subds, message=None):
     if path_arg and not saw_subds:
         lgr.warning(
             'path constraints did not match an installed subdataset: %s',
@@ -444,7 +449,7 @@ def _save_after_update(refds, tosave, update_failures, path_arg, saw_subds):
         for r in refds.save(
                 path=save_paths,
                 recursive=False,
-                message='[DATALAD] Save updated subdatasets',
+                message=message or '[DATALAD] Save updated subdatasets',
                 return_type='generator',
                 result_renderer='disabled'):
             yield r


### PR DESCRIPTION
## Summary

Add `--message/-m` option to `clone`, `create`, and `update` commands, allowing users to specify custom commit messages when registering subdatasets in parent datasets.

- `clone -d . -m "message"  <source>` - customizes the "[DATALAD] Added subdataset" commit
- `create -d .  -m "message" <path>` - customizes the "[DATALAD] Created subdataset" commit
- `update -r --how=merge -m "message"` - customizes the "[DATALAD] Save updated subdatasets" commit

The message only affects the parent dataset's commit, not any commits within the subdataset itself.

## Related

This partially addresses #3316. That issue requests `--message` for all committing commands. This PR covers the three main subdataset registration cases (`clone`, `create`, `update`), but does not address other commands like `addurls`, `add_readme`, `no_annex`, or `subdatasets` which also have hardcoded commit messages.

It might also address #3896, though I'm not sure that there was consensus on that.

## TODO

- [x] Add `CHANGELOG-missing` label
- [x] Add semver label