### PR TITLE
BF(CI): Fix extension tests for metalad and next

### DIFF
--- a/.github/workflows/test_extensions.yml
+++ b/.github/workflows/test_extensions.yml
@@ -118,7 +118,7 @@ jobs:
         # configuration.  So far attempts to "fix" by somehow providing full path did not work.
         # That is why just symlink it here.  If no tox.ini -- create an empty one
         [ -e ../__extension__/tox.ini ] && ln -s ../__extension__/tox.ini . || touch tox.ini
-        python -m pytest -c ./tox.ini -s -v --cov=datalad $DL_PYTEST_OPTS --pyargs ${DL_PACKAGE}
+        eval python -m pytest -c ./tox.ini -s -v --cov=datalad $DL_PYTEST_OPTS --pyargs ${DL_PACKAGE}
       if: env.DL_TESTER == 'pytest'
 
     - name: Prepare coverage


### PR DESCRIPTION
- Install libexempi-dev for datalad-metalad to fix test_xmp failures
- Skip test_existing_switch for datalad-next (see datalad/datalad-next#791)
- Add DL_PYTEST_OPTS variable to support extension-specific pytest options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The ultimate goal is to make CI fully green for a good baseline for testing anything new.