### PR TITLE
BF(xfail): Mark test_ria_postclone_noannex for git-annex >= 10.20260213

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -81,6 +81,7 @@ from datalad.tests.utils_pytest import (
     with_sameas_remote,
     with_tempfile,
     with_tree,
+    xfail_annex_ignore_not_respected_for_local,
     xfail_buggy_annex_info,
 )
 from datalad.utils import (
@@ -1251,6 +1252,7 @@ def test_no_ria_postclonecfg(dspath=None, storepath=None, clonepath=None):
 
 # fatal: Could not read from remote repository.
 @known_failure_githubci_win  # in datalad/git-annex as e.g. of 20201218
+@xfail_annex_ignore_not_respected_for_local
 @with_tempfile(mkdir=True)
 @with_tempfile
 @with_tempfile

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1082,6 +1082,19 @@ xfail_buggy_annex_info = pytest.mark.xfail(
     reason="Regression in git-annex info. https://github.com/datalad/datalad/issues/7286"
 )
 
+xfail_annex_ignore_not_respected_for_local = pytest.mark.xfail(
+    # In 10.20260213, configRead in Remote/Git.hs was reordered for "Push to
+    # Create" support: (True, _, _) (repoCheap/local) is now matched before
+    # (_, True, _) (annex-ignore), so annex-ignore is not respected for local
+    # remotes.  This causes auto-initialization of the annex directory on the
+    # remote bare repo during clone.
+    # In 10.20250630 and earlier, (_, True, _) was matched first, correctly
+    # short-circuiting for annex-ignored remotes.
+    # https://git-annex.branchable.com/bugs/annex-ignore_check_is_skipped_for_local_remotes/
+    external_versions['cmd:annex'] and external_versions['cmd:annex'] >= '10.20260213',
+    reason="git-annex regression: annex-ignore not respected for local remotes"
+)
+
 
 def _get_resolved_flavors(flavors):
     #flavors_ = (['local', 'clone'] + (['local-url'] if not on_windows else [])) \


### PR DESCRIPTION
git-annex 10.20260213 reordered case matching in configRead (Remote/Git.hs) for "Push to Create" support, causing local remotes to bypass the annex-ignore check.  This auto-initializes annex on bare remotes despite annex-ignore=true being set.

https://git-annex.branchable.com/bugs/annex-ignore_check_is_skipped_for_local_remotes/

If not objections I will merge/release in a day to get builds of datalad/git-annex into greener land

attn to all @datalad/german who use RIA on a daily basis