### PR TITLE
Use case-insensitive matching for Git error "Not a valid object name"

### DIFF
--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -823,7 +823,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             )
         except CommandError as e:
             if (
-                ('Not a valid object name git-annex:remote.log' in e.stderr) or  # e.g. git 2.30.2
+                ('not a valid object name git-annex:remote.log' in e.stderr.lower()) or  # e.g. git 2.30.2
                 ("fatal: path 'remote.log' does not exist in 'git-annex'" in e.stderr) or # e.g. 2.35.1+next.20220211-1
                 ("fatal: invalid object name 'git-annex'" in e.stderr) # e.g., 2.43.0
             ):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1731,7 +1731,7 @@ class GitRepo(CoreGitRepo):
             if exc.code == 1 and not (exc.stdout or exc.stderr):
                 # No merge base was found (unrelated commits).
                 return None
-            if "fatal: Not a valid object name" in exc.stderr:
+            if "not a valid object name" in exc.stderr.lower():
                 return None
             raise
 
@@ -2904,7 +2904,7 @@ class GitRepo(CoreGitRepo):
                 expect_fail=True,
                 read_only=True)
         except CommandError as exc:
-            if "fatal: Not a valid object name" in exc.stderr:
+            if "not a valid object name" in exc.stderr.lower():
                 raise InvalidGitReferenceError(ref)
             raise
         lgr.debug('Done query repo: %s', cmd)


### PR DESCRIPTION
Fixes #7805

Git is lowercasing the `fatal: Not a valid object name` error message
to follow its CodingGuidelines. This change makes the string matching
case-insensitive so it works with both the current and future Git versions.

Changes:
- Use `.lower()` before checking for the error substring

See: https://lore.kernel.org/git/pull.2052.git.1771836302101.gitgitgadget@gmail.com