### PR TITLE
Move codespell config from .codespellrc to pyproject.toml

### DIFF
--- a/.codespell-ignorelines
+++ b/.codespell-ignorelines
@@ -1,2 +1,0 @@
-                %%NAME\tthe name of the dataset, where slashes are replaced by
-               inputs=["fo*"], outputs=["b*r"])

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,9 +1,0 @@
-[codespell]
-skip = .venv,venvs,.git,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem,trash,dist
-check-hidden = True
-# commitish - vote if we want to fix (should be committish) -- used in GitRepo API
-# froms - plural "from" introduced by export_archive_ora
-# ned - Ned is a name
-# includeds - func arg name
-ignore-words-list = afile,ba,commitish,froms,ro,ned,includeds
-exclude-file = .codespell-ignorelines

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,10 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
     rev: v2.4.1
     hooks:
     -   id: codespell
         exclude: datalad/tests/ca/certificate-key.pem
+        additional_dependencies:
+        -   tomli; python_version<'3.11'

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -705,7 +705,7 @@ def test_dry_run(path=None):
 
     with swallow_outputs() as cmo:
         ds.run("blah {inputs} {outputs}", dry_run="basic",
-               inputs=["fo*"], outputs=["b*r"])
+               inputs=["fo*"], outputs=["b*r"])  # codespell:ignore fo
         assert_in(
             'blah "foo" "bar"' if on_windows else "blah foo bar",
             cmo.out)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,15 @@ include = ["datalad*"]
 [tool.setuptools.dynamic]
 version = { attr = "datalad.__version__" }
 
+[tool.codespell]
+skip = '.venv,venvs,.git,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem,trash,dist,.cache,.npm'
+check-hidden = true
+# commitish - vote if we want to fix (should be committish) -- used in GitRepo API
+# froms - plural "from" introduced by export_archive_ora
+# ned - Ned is a name
+# includeds - func arg name
+ignore-words-list = 'afile,ba,commitish,froms,ro,ned,includeds'
+
 [tool.isort]
 force_grid_wrap = 2
 include_trailing_comma = true


### PR DESCRIPTION
- Migrate all settings (skip, check-hidden, ignore-words-list) and comments to [tool.codespell] in pyproject.toml
- Replace .codespell-ignorelines exclude-file with inline `# codespell:ignore` pragma in test_run.py
- Add tomli dependency to pre-commit hook for Python <3.11
- Delete .codespellrc and .codespell-ignorelines