### PR TITLE
BF: Harden test_gitea against transient demo.gitea.com failures

### DIFF
--- a/changelog.d/pr-7812.md
+++ b/changelog.d/pr-7812.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- BF: Harden test_gitea against transient demo.gitea.com failures.  [PR #7812](https://github.com/datalad/datalad/pull/7812) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/distributed/tests/test_create_sibling_ghlike.py
+++ b/datalad/distributed/tests/test_create_sibling_ghlike.py
@@ -7,6 +7,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test create publication target on GIN"""
 
+import logging
 import os
 from os.path import basename
 from unittest.mock import patch
@@ -182,11 +183,19 @@ def check4real(testcmd, testdir, credential, api, delete_endpoint,
             moretests(ds)
     finally:
         token = os.environ[token_var]
-        requests.delete(
+        resp = requests.delete(
             '{}/{}'.format(api, delete_endpoint.format(reponame=reponame)),
             headers={
                 'user-agent': DEFAULT_USER_AGENT,
                 'authorization':
                     f'token {token}',
             },
-        ).raise_for_status()
+        )
+        # A 404 here means the repo was never created (e.g. creation
+        # failed with 401/500) -- just warn so we don't mask the real error.
+        if resp.status_code == 404:
+            logging.getLogger(__name__).warning(
+                "Cleanup DELETE returned 404 for %s (repo likely never created)",
+                reponame)
+        else:
+            resp.raise_for_status()

--- a/datalad/distributed/tests/test_create_sibling_gitea.py
+++ b/datalad/distributed/tests/test_create_sibling_gitea.py
@@ -7,6 +7,8 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test create publication target on Gitea"""
 
+import pytest
+import requests
 
 from datalad.api import create_sibling_gitea
 from datalad.tests.utils_pytest import (
@@ -18,6 +20,7 @@ from .test_create_sibling_ghlike import check4real
 
 
 @skip_if_no_network
+@pytest.mark.flaky(retries=3, only_on=[requests.exceptions.HTTPError])
 @with_tempfile
 def test_gitea(path=None):
     check4real(


### PR DESCRIPTION
demo.gitea.com is unreliable -- analysis of 139 AppVeyor runs in Feb 2026 shows 8 failures (5.8%): 401 Unauthorized (4), 500 Internal Server Error (2), 404 Not Found (2).

The 404 errors are secondary: when repo creation fails (401/500), the cleanup finally block's raise_for_status() on the DELETE call raises a 404 (repo was never created), masking the original error.

Two fixes:

- check4real() finally block: only suppress 404 from the cleanup DELETE (with a warning log) since it means the repo was never created; keep raise_for_status() for any other unexpected status code

- test_gitea: add @pytest.mark.flaky(retries=3, only_on=[HTTPError]) to automatically retry on transient API errors from demo.gitea.com

### PR checklist

- [x] Provide an overview of the changes you're making and explain why you're proposing them.
- [x] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title;
  or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).