### PR TITLE
BF: commit file deletions in `run --explicit --output` (Closes #7822)

### DIFF
--- a/changelog.d/20260312_142832_yaroslav_halchenko_explicit_output_deleted.md
+++ b/changelog.d/20260312_142832_yaroslav_halchenko_explicit_output_deleted.md
@@ -1,0 +1,9 @@
+### 🐛 Bug Fixes
+
+- Fix `run --explicit --output` failing to commit file deletions.
+  When a command deleted files specified in `--output`, the deletions
+  were left unstaged because post-command globbing only matched
+  files still present on disk.
+  Fixes [#7822](https://github.com/datalad/datalad/issues/7822) via
+  [PR #7823](https://github.com/datalad/datalad/pull/7823)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -1025,6 +1025,12 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     # TODO: If a warning or error is desired when an --output pattern doesn't
     # have a match, this would be the spot to do it.
     if explicit or expand in ["outputs", "both"]:
+        # Before refreshing, capture the pre-command output expansion so we
+        # can detect files that were deleted by the command (gh-7822).
+        # expand_strict() only returns files that exist on disk, so without
+        # this, deleted outputs would be silently excluded from the commit.
+        if explicit:
+            pre_command_outputs = set(globbed['outputs'].expand_strict())
         # also for explicit mode we have to re-glob to be able to save all
         # matching outputs
         globbed['outputs'].expand(refresh=True)
@@ -1051,6 +1057,14 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         '"{}"'.format(record) if record_path else record)
 
     outputs_to_save = globbed['outputs'].expand_strict() if explicit else None
+    if explicit and pre_command_outputs:
+        # Include outputs that existed before the command but were deleted
+        # by it. expand_strict() only returns files present on disk, so
+        # deleted outputs need to be added back explicitly (gh-7822).
+        post_outputs = set(outputs_to_save)
+        for p in sorted(pre_command_outputs - post_outputs):
+            if not op.lexists(op.join(pwd, p)):
+                outputs_to_save.append(p)
     if outputs_to_save is not None and record_path:
         outputs_to_save.append(record_path)
     do_save = outputs_to_save is None or outputs_to_save

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -645,6 +645,38 @@ with open(name + ".txt", "w") as fh:
     ok_exists(str(ds.pathobj / "bar.txt"))
     assert_repo_status(ds.path)
 
+    # Deleting a declared output with a literal path should be committed
+    # (gh-7822).
+    hexsha_pre = repo.get_hexsha()
+    ds.run("rm foo.txt", outputs=["foo.txt"], explicit=True,
+           result_renderer='disabled')
+    assert_false((ds.pathobj / "foo.txt").exists())
+    neq_(hexsha_pre, repo.get_hexsha())
+    assert_repo_status(ds.path)
+
+    # Glob pattern where only some matches are deleted (gh-7822).
+    hexsha_pre = repo.get_hexsha()
+    ds.run("rm bar.txt", outputs=["*.txt"], explicit=True,
+           result_renderer='disabled')
+    assert_false((ds.pathobj / "bar.txt").exists())
+    neq_(hexsha_pre, repo.get_hexsha())
+    assert_repo_status(ds.path)
+
+    # Delete old outputs and create new ones in one command (the motivating
+    # use-case from gh-7822: zip files then delete originals).
+    (ds.pathobj / "a.dat").write_text("a")
+    (ds.pathobj / "b.dat").write_text("b")
+    ds.save(to_git=True)
+    hexsha_pre = repo.get_hexsha()
+    ds.run("{} write_text.py c && rm a.dat b.dat".format(sys.executable),
+           outputs=["*.dat", "*.txt"], explicit=True,
+           result_renderer='disabled')
+    assert_false((ds.pathobj / "a.dat").exists())
+    assert_false((ds.pathobj / "b.dat").exists())
+    ok_exists(str(ds.pathobj / "c.txt"))
+    neq_(hexsha_pre, repo.get_hexsha())
+    assert_repo_status(ds.path)
+
 
 @with_tempfile(mkdir=True)
 def test_run_unexpanded_placeholders(path=None):


### PR DESCRIPTION
When using `datalad run --explicit` with `--output`, files deleted by the command were not being committed. This happened because the post-command re-glob only returns files that exist on disk, so deleted outputs were silently excluded from the save operation.

Fix by capturing the pre-command output expansion before the re-glob refresh, then adding back any previously-matched files that no longer exist on disk.

- Closes #7822 

### PR checklist

- [x] Provide an overview of the changes you're making and explain why you're proposing them.
- [x] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title;
  or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).
- [x] Include `Fixes #NNN` somewhere in the description and `scriv` changelog entry if this PR addresses an existing issue.


@asmacdo -- might like to try it out if works for your case