### PR TITLE
BF: Suppress RequestsDependencyWarning from requests (Closes #7825)

### DIFF
--- a/changelog.d/20260314_094253_yaroslav_halchenko_suppress_requests_warning.md
+++ b/changelog.d/20260314_094253_yaroslav_halchenko_suppress_requests_warning.md
@@ -1,0 +1,8 @@
+### 🐛 Bug Fixes
+
+- Suppress `RequestsDependencyWarning` emitted by `requests` 2.32.x
+  when `chardet>=6` is installed.  The warning was purely cosmetic
+  (HTTP functionality is unaffected) but appeared on stderr for every
+  datalad command.
+  Fixes [#7825](https://github.com/datalad/datalad/issues/7825)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/__init__.py
+++ b/datalad/__init__.py
@@ -21,6 +21,18 @@ if not __debug__:
 
 import atexit
 import os
+import warnings
+
+# Suppress RequestsDependencyWarning from requests.
+# requests 2.32.x checks chardet<6 but datalad (and the ecosystem) uses
+# chardet>=6.  The requests main branch already accepts chardet<8 but no
+# release has been cut yet.
+# TODO: remove once a requests release supports chardet>=6
+warnings.filterwarnings(
+    "ignore",
+    message=r"urllib3.*or chardet.*doesn't match a supported version",
+    category=Warning,
+)
 
 # this is not to be modified. for querying use get_apimode()
 __api = 'python'

--- a/datalad/distributed/ora_remote.py
+++ b/datalad/distributed/ora_remote.py
@@ -761,22 +761,7 @@ class HTTPRemoteIO(object):
     def exists(self, path):
         # use same signature as in SSH and Local IO, although validity is
         # limited in case of HTTP.
-        # Lazy import: requests is only needed for HTTP-based RIA access.
-        # A top-level import would cause requests to emit a
-        # RequestsDependencyWarning to stderr at startup when chardet>=6
-        # is installed (requests 2.32 only declares support for chardet<6).
-        # Since datalad requires chardet (no upper bound) while requests
-        # depends on charset-normalizer, both get installed, and requests
-        # checks chardet first, failing its version assertion.
-        # Suppress the warning to keep stderr clean — git-annex-remote-ora
-        # runs as a git-annex external special remote subprocess where
-        # unexpected stderr output may interfere with operation.
-        import warnings
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message="urllib3.*chardet", category=Warning
-            )
-            import requests
+        import requests
 
         url = self.store_url + path.as_posix()
         try:

--- a/datalad/tests/test_installed.py
+++ b/datalad/tests/test_installed.py
@@ -43,11 +43,7 @@ def test_run_datalad_help():
     out, err = check_run_and_get_output("datalad --help")
     ok_startswith(out, "Usage: ")
     # There could be a warning from coverage that no data was collected, should be benign.
-    # RequestsDependencyWarning can appear when requests doesn't recognize
-    # the installed chardet version (e.g. chardet 6.x with older requests).
     lines = [l for l in err.split(os.linesep)
              if ('no-data-collected' not in l)
-             and ('RequestsDependencyWarning' not in l)
-             and ('warnings.warn(' not in l)
              and l]
     eq_(lines, [])


### PR DESCRIPTION
requests 2.32.x ships a check_compatibility() that asserts chardet < 6, but datalad declares chardet>=3.0.4 with no upper bound.  Modern resolvers (pip, uv) install chardet 7.x, which trips the assertion and emits a RequestsDependencyWarning to stderr on every `import requests`.

The requests main branch already accepts chardet < 8 (PR #7220 and follow-ups), but no release has been cut since Aug 2025, so the warning is purely cosmetic — HTTP functionality works fine.

Add a global warnings.filterwarnings() in datalad/__init__.py to suppress the warning before any transitive `import requests` can fire. This replaces two ad-hoc workarounds:

- datalad/distributed/ora_remote.py: warnings.catch_warnings() block around `import requests` in HTTPRemoteIO.exists()
- datalad/tests/test_installed.py: stderr filtering for RequestsDependencyWarning in test_run_datalad_help

### PR checklist

- [x] Provide an overview of the changes you're making and explain why you're proposing them.
- [x] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title;
  or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).
- [x] Include `Fixes #NNN` somewhere in the description and `scriv` changelog entry if this PR addresses an existing issue.
