### PR TITLE
BF: Reload config after enableremote in create-sibling-ria

### DIFF
--- a/changelog.d/pr-7828.md
+++ b/changelog.d/pr-7828.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: Reload config after enableremote in create-sibling-ria.  Fixes [#7827](https://github.com/datalad/datalad/issues/7827) via [PR #7828](https://github.com/datalad/datalad/pull/7828) (by [@just-meng](https://github.com/just-meng))

--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -648,6 +648,8 @@ def _create_sibling_ria(
                 # using `git annex trust` requires --force.
                 trust_cmd.append('--force')
             ds.repo.call_annex(trust_cmd + [srname])
+        # reload config to pick up annex-uuid set by init_remote/enableremote
+        ds.config.reload()
         # get uuid for use in bare repo's config
         uuid = ds.config.get("remote.{}.annex-uuid".format(srname))
 

--- a/datalad/distributed/tests/test_create_sibling_ria.py
+++ b/datalad/distributed/tests/test_create_sibling_ria.py
@@ -169,6 +169,14 @@ def _test_create_store(host, base_path=None, ds_path=None, clone_path=None):
     assert_result_count(res, 1, path=str(subds.pathobj), status='ok', action="create-sibling-ria")
     assert_result_count(res, 1, path=str(subds2.pathobj), status='ok', action="create-sibling-ria")
 
+    # verify that ORA remote UUID in bare repo config is preserved
+    # after reconfigure
+    content = git_config.read_text()
+    recfg_uuid = ds.config.get(
+        "remote.{}.annex-uuid".format('datastore-storage'))
+    eq_(recfg_uuid, super_uuid)
+    assert_in("uuid = {}".format(recfg_uuid), content)
+
     # remotes now exist in super and sub
     siblings = ds.siblings(result_renderer='disabled')
     eq_({'datastore', 'datastore-storage', 'here'},
@@ -192,6 +200,26 @@ def _test_create_store(host, base_path=None, ds_path=None, clone_path=None):
         assert_in('[datastore-storage]',
                   [r['description']
                    for r in res['{}ed repositories'.format(trust)]])
+
+    # Verify reconfigure after removing siblings writes correct UUID
+    # to the RIA bare repo config (gh-7827).  When the git remote is
+    # removed, the annex-uuid is gone from the in-memory config; the
+    # subsequent enableremote writes it back to disk but without a
+    # config.reload() the stale in-memory value (None) was written
+    # into the bare repo config instead.
+    ds.siblings('remove', name='datastore', result_renderer='disabled')
+    ds.siblings('remove', name='datastore-storage', result_renderer='disabled')
+    res = ds.create_sibling_ria("ria+ssh://test-store:", "datastore",
+                                existing='reconfigure',
+                                new_store_ok=True)
+    assert_result_count(res, 1, status='ok', action='create-sibling-ria')
+    content = git_config.read_text()
+    recfg_uuid = ds.config.get(
+        "remote.{}.annex-uuid".format('datastore-storage'))
+    assert recfg_uuid is not None, \
+        "annex-uuid must not be None after reconfigure (gh-7827)"
+    eq_(recfg_uuid, super_uuid)
+    assert_in("uuid = {}".format(recfg_uuid), content)
 
 
 @slow  # 11 + 42 sec on travis


### PR DESCRIPTION
## Summary

- Fixes #7827

- `create-sibling-ria --existing reconfigure` fails with `[ERROR] expected str, bytes or os.PathLike object, not NoneType` on first run, succeeds on second run
- **Root cause**: When `--existing reconfigure` is used and the special remote already exists, `init_remote()` fails and the code falls back to raw `call_annex(['enableremote', ...])`, which (unlike `init_remote()` and `enable_remote()`) does not call `config.reload()`. The subsequent `ds.config.get("remote.{}.annex-uuid")` returns `None`, causing the TypeError when passed to `gr.config.add()`
- **Fix**: Add `ds.config.reload()` before reading the UUID to ensure the config reflects the on-disk state regardless of which code path was taken

## Test plan

- [x] Red/green verified: pytest datalad/distributed/tests/test_create_sibling_ria.py::test_create_simple fails without the fix, passes with it
- [x] Manual test see #7827 

🤖 Generated with [Claude Code](https://claude.com/claude-code)