### PR TITLE
BF: update patoolib imports for 2.0 API change and coverage-bin/datalad to arbitrary path to execute from

### DIFF
--- a/changelog.d/pr-7832.md
+++ b/changelog.d/pr-7832.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: update patoolib imports for 2.0 API change and coverage-bin/datalad to arbitrary path to execute from.  [PR #7832](https://github.com/datalad/datalad/pull/7832) (by [@jkonieczny2](https://github.com/jkonieczny2))

--- a/datalad/support/archive_utils_patool.py
+++ b/datalad/support/archive_utils_patool.py
@@ -18,7 +18,7 @@ assert(external_versions["patoolib"] >= "1.7")
 # check_new_filename moved from patoolib.util -> patoolib.fileutil in 2.0.0
 # still exists in patoolib.util as of 1.7; given the above assert we only
 # need to consider those two locations
-if int(patoolib.__version__.split(".")[0]) >= 2:
+if external_versions["patoolib"] >= "2.0":
     from patoolib.fileutil import check_new_filename
 else:  # pragma: no cover -- patoolib 1.x; CI uses 2.x
     from patoolib.util import check_new_filename  # pragma: no cover

--- a/datalad/support/archive_utils_patool.py
+++ b/datalad/support/archive_utils_patool.py
@@ -15,6 +15,15 @@ from .external_versions import external_versions
 # There were issues, so let's stay consistently with recent version
 assert(external_versions["patoolib"] >= "1.7")
 
+# check_new_filename moved from patoolib.util -> patoolib.fileutil in 2.0.0
+# still exists in patoolib.util as of 1.7; given the above assert we only
+# need to consider those two locations
+if int(patoolib.__version__.split(".")[0]) >= 2:
+    from patoolib.fileutil import check_new_filename
+else:
+    from patoolib.util import check_new_filename
+
+
 import logging
 import os
 

--- a/datalad/support/archive_utils_patool.py
+++ b/datalad/support/archive_utils_patool.py
@@ -20,8 +20,8 @@ assert(external_versions["patoolib"] >= "1.7")
 # need to consider those two locations
 if int(patoolib.__version__.split(".")[0]) >= 2:
     from patoolib.fileutil import check_new_filename
-else:
-    from patoolib.util import check_new_filename
+else:  # pragma: no cover -- patoolib 1.x; CI uses 2.x
+    from patoolib.util import check_new_filename  # pragma: no cover
 
 
 import logging

--- a/tools/coverage-bin/datalad
+++ b/tools/coverage-bin/datalad
@@ -5,14 +5,19 @@
 
 set -eu
 
+# Paths must not use $PWD: tests invoke datalad with cwd under temp dirs, so
+# $PWD/../.coveragerc would not point at the repository root (see AppVeyor/CI).
+_script_dir=$(cd "$(dirname "$0")" && pwd)
+_repo_root=$(cd "$_script_dir/../.." && pwd)
+
 bin=$(basename $0)
 curbin=$(which "$bin")
 curdatalad=$(which datalad)
 curdir=$(dirname $curdatalad)
 
 COVERAGE_RUN="-m coverage run"
-export COVERAGE_PROCESS_START=$PWD/../.coveragerc
-export PYTHONPATH="$PWD/../tools/coverage-bin/"
+export COVERAGE_PROCESS_START=$_repo_root/.coveragerc
+export PYTHONPATH="$_script_dir/"
 export PATH=${PATH//$curdir:/}
 newdatalad=$(which datalad)
 newbin=$(which $bin)


### PR DESCRIPTION
* import check_new_filename from patoolib.fileutil after 2.0.0, or patoolib.util prior to that
* fixes code that calls archive_utils_patool; prior to this, check_new_filename could not be found

I noticed this issue when running tests after initial setup.  Pip retrieved the latest version of patool (4.0.4), which led to the import error.  You can reproduce with the following script:

```python
#!/usr/bin/env python
from datalad.support.archive_utils_patool import compress_files

if __name__ == "__main__":
    files = ["test.foo"]
    archive = "test.foo.gz"
    overwrite = False

    print("compressing files")

    compress_files(
        files,
        archive,
        overwrite=False,
    )
```

And confirm that it throws with patoolib >= 2.0 and without this change:

```
((venv) ) joshua@joshua-XPS-13-7390:~/projects/datalad$ ./test.py                                                
compressing files                                                                                                
Traceback (most recent call last):                      
  File "/home/joshua/projects/datalad/./test.py", line 11, in <module>                                           
    compress_files(                                     
  File "/home/joshua/projects/datalad/datalad/support/archive_utils_patool.py", line 220, in compress_files      
    check_new_filename(archive)                                                                                  
    ^^^^^^^^^^^^^^^^^^                                                                                           
NameError: name 'check_new_filename' is not defined
```
