### PR TITLE
BF(TST): move and reuse @skip_if_no_psutil for more tests in save

### DIFF
--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -46,6 +46,7 @@ from datalad.tests.utils_pytest import (
     ok_,
     patch,
     skip_if_adjusted_branch,
+    skip_if_no_psutil,
     skip_wo_symlink_capability,
     swallow_logs,
     swallow_outputs,
@@ -1142,6 +1143,7 @@ def _mock_open_for_writing(open_file_abspath):
     return _fake
 
 
+@skip_if_no_psutil
 @pytest.mark.ai_generated
 @with_tempfile
 def test_save_skip_openfiles(path=None):
@@ -1197,6 +1199,7 @@ def test_save_skip_openfiles(path=None):
     assert_in_results(res, path=str(f_open), status='ok', action='add')
 
 
+@skip_if_no_psutil
 @pytest.mark.ai_generated
 def test_check_for_openfiles_invalid_config(tmp_path):
     """_check_for_openfiles raises ValueError on invalid config."""

--- a/datalad/pytest_plugin.py
+++ b/datalad/pytest_plugin.py
@@ -49,6 +49,7 @@ def pytest_configure(config):
         "serve_path_via_http: marks tests that serve paths via HTTP",
         "skip_if_adjusted_branch: skip test on adjusted branches",
         "skip_if_no_network: skip test when network is unavailable",
+        "skip_if_no_psutil: skip test when psutil is not installed",
         "skip_if_on_windows: skip test on Windows",
         "skip_if_root: skip test when running as root",
         "skip_known_failure: skip tests with known failures",

--- a/datalad/support/tests/test_openfiles.py
+++ b/datalad/support/tests/test_openfiles.py
@@ -20,22 +20,15 @@ from unittest.mock import (
 
 import pytest
 
-from datalad.tests.utils_pytest import with_tree
+from datalad.tests.utils_pytest import (
+    skip_if_no_psutil,
+    with_tree,
+)
 
 from ..openfiles import (
     _is_write_mode,
     _lsof_get_write_files,
     get_files_open_for_writing,
-)
-
-try:
-    import psutil
-except ImportError:
-    psutil = None
-
-skip_if_no_psutil = pytest.mark.skipif(
-    psutil is None,
-    reason="psutil is not installed",
 )
 
 

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -183,6 +183,17 @@ def skip_if_no_module(module):
         pytest.skip("Module %s fails to load" % module, allow_module_level=True)
 
 
+try:
+    import psutil as _psutil
+except ImportError:
+    _psutil = None
+
+skip_if_no_psutil = pytest.mark.skipif(
+    _psutil is None,
+    reason="psutil is not installed",
+)
+
+
 def skip_if_scrapy_without_selector():
     """A little helper to skip some tests which require recent scrapy"""
     try:


### PR DESCRIPTION
psutil is an optional dependency (in the [misc] extra), but tests for the openfiles feature unconditionally call get_files_open_for_writing() which raises ImportError without it.

- Move skip_if_no_psutil marker to be defined in datalad/tests/utils_pytest.py
- Register the marker in datalad/pytest_plugin.py
- Apply to tests in test_save.py that need psutil

no changelog  entry needed as we got one already