### PR TITLE
NF+BM: extend create_test_dataset spec, add save/run benchmarks on heavy hierarchies

### DIFF
--- a/benchmarks/save_run.py
+++ b/benchmarks/save_run.py
@@ -1,0 +1,196 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Benchmarks for save and run operations on realistic dataset hierarchies.
+
+These benchmarks cover:
+- Standard save on a small dataset -- regression guard
+- Standard save on a heavy hierarchy (10 annex subs × 1000 files)
+- run() on a heavy hierarchy
+
+Tagging convention: benchmark classes set ``tags = ['ai_generated']``
+to mirror ``@pytest.mark.ai_generated`` in the test suite.  ASV has
+no marks system; tags are a project convention for grep/filtering.
+"""
+
+import os
+import os.path as op
+import tarfile
+import tempfile
+
+from datalad.api import (
+    Dataset,
+    create_test_dataset,
+)
+from datalad.utils import (
+    create_tree,
+    get_tempfile_kwargs,
+    rmtree,
+    rotree,
+)
+
+from .common import SuprocBenchmarks
+
+# ---- helpers ---------------------------------------------------------------
+
+# Heavy hierarchy uses a manual helper (not create_test_dataset) because
+# we need predictable subdataset names (sub00..sub09) to modify specific
+# subs in setup().  create_test_dataset randomizes leading dirs.
+
+N_SUBS = 10
+N_FILES_PER_SUB = 1000
+
+
+def _create_heavy_hierarchy(ds_path):
+    """Create a super-dataset with N_SUBS annex subdatasets, each containing
+    N_FILES_PER_SUB tracked files.  Uses default annex repos to benchmark
+    the realistic code path.
+    """
+    ds = Dataset(ds_path).create()
+    for si in range(N_SUBS):
+        sub = ds.create(f"sub{si:02d}")
+        tree = {
+            f"file_{fi:04d}.txt": f"sub{si} file {fi}"
+            for fi in range(N_FILES_PER_SUB)
+        }
+        create_tree(sub.path, tree)
+        sub.save(message=f"sub{si:02d}: {N_FILES_PER_SUB} files")
+    # A few top-level tracked files
+    tree = {f"top_{i:02d}.txt": f"top {i}" for i in range(20)}
+    create_tree(ds.path, tree)
+    ds.save(message="hierarchy with heavy subs")
+    return ds
+
+
+def _extract_tar(tarpath, dsname, counter_cls):
+    """Extract a tarball to a fresh tempdir, return (tempdir, ds_path)."""
+    tempdir = tempfile.mkdtemp(
+        **get_tempfile_kwargs({}, prefix="bm_"))
+    with tarfile.open(tarpath) as tar:
+        tar.extractall(tempdir)
+    epath = op.join(tempdir, dsname)
+    epath_unique = epath + str(counter_cls.ds_count)
+    os.rename(epath, epath_unique)
+    counter_cls.ds_count += 1
+    return tempdir, epath_unique
+
+
+# ---- benchmarks: small / flat ---------------------------------------------
+
+
+class save_clean(SuprocBenchmarks):
+    """Baseline: standard save without fr= (Status-based path).
+
+    Guards against regressions in the save code path.
+    Uses create_test_dataset for a single dataset with 50 files.
+    """
+    tags = ['ai_generated']
+
+    def setup(self):
+        tempdir = tempfile.mkdtemp(
+            **get_tempfile_kwargs({}, prefix="bm_save_clean"))
+        self.remove_paths.append(tempdir)
+        dss = create_test_dataset(
+            op.join(tempdir, "ds"), spec='0', seed=0, nfiles=50)
+        self.ds = Dataset(dss[0])
+        # Dirty 5 files for save to pick up
+        for i in range(5):
+            (self.ds.pathobj / f"file{i}.dat").write_text("modified")
+
+    def time_save(self):
+        self.ds.save(message="benchmark save")
+
+
+class run_simple(SuprocBenchmarks):
+    """End-to-end run() benchmark on a lightweight single dataset."""
+    tags = ['ai_generated']
+
+    def setup(self):
+        tempdir = tempfile.mkdtemp(
+            **get_tempfile_kwargs({}, prefix="bm_run"))
+        self.remove_paths.append(tempdir)
+        dss = create_test_dataset(
+            op.join(tempdir, "ds"), spec='0', seed=0, nfiles=5)
+        self.ds = Dataset(dss[0])
+
+    def time_run(self):
+        self.ds.run('echo plain > plain_file', result_renderer='disabled')
+
+
+# ---- benchmarks: heavy hierarchy ------------------------------------------
+# 10 subdatasets × 1000 tracked files each.
+# Measures the cost of recursive save/run scanning a large tree
+# when only 2 of 10 subdatasets have changes.
+
+
+class save_heavy_hierarchy(SuprocBenchmarks):
+    """save on a heavy hierarchy (10 subs × 1000 files).
+
+    Benchmarks standard recursive save after modifying files in only
+    2 of 10 subdatasets.
+
+    setup_cache creates the hierarchy once (expensive ~30s);
+    setup extracts it and makes minimal changes.
+    """
+    tags = ['ai_generated']
+
+    timeout = 3600
+    dsname = 'bm_heavy'
+    _tarfile = 'bm_heavy.tar'
+    ds_count = 0
+
+    def setup_cache(self):
+        _create_heavy_hierarchy(self.dsname)
+        self._tarfile = op.realpath(self._tarfile)
+        rotree(self.dsname, ro=False, chmod_files=False)
+        with tarfile.open(self._tarfile, "w") as tar:
+            tar.add(self.dsname, recursive=True)
+        rmtree(self.dsname)
+
+    def setup(self):
+        tempdir, ds_path = _extract_tar(
+            self._tarfile, self.dsname, self.__class__)
+        self.remove_paths.append(tempdir)
+        self.ds = Dataset(ds_path)
+        # Add a new file in 2 of 10 subdatasets (the rest stay clean).
+        # We create new files rather than modifying existing ones because
+        # annexed files are read-only symlinks.
+        for si in (0, 5):
+            sub = Dataset(op.join(ds_path, f"sub{si:02d}"))
+            (sub.pathobj / "new_file.txt").write_text("added by setup")
+
+    def time_save(self):
+        """Standard recursive save — the baseline."""
+        self.ds.save(recursive=True, message="bm save")
+
+
+class run_heavy_hierarchy(SuprocBenchmarks):
+    """End-to-end run() on a heavy hierarchy.
+
+    Command touches 2 of 10 subdatasets: creates a file in each.
+    Measures the full run pipeline on a realistic tree.
+    """
+    tags = ['ai_generated']
+
+    timeout = 3600
+    dsname = 'bm_heavy'
+    _tarfile = 'bm_heavy.tar'
+    ds_count = 0
+
+    setup_cache = save_heavy_hierarchy.setup_cache
+
+    def setup(self):
+        tempdir, ds_path = _extract_tar(
+            self._tarfile, self.dsname, self.__class__)
+        self.remove_paths.append(tempdir)
+        self.ds = Dataset(ds_path)
+
+    def time_run(self):
+        """run() that creates files in 2 subs (no inner git commits)."""
+        self.ds.run(
+            'echo new > sub00/new_file.txt && echo new > sub05/new_file.txt',
+            result_renderer='disabled')

--- a/changelog.d/pr-7839.md
+++ b/changelog.d/pr-7839.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- NF+BM: extend create_test_dataset spec, add save/run benchmarks on heavy hierarchies.  [PR #7839](https://github.com/datalad/datalad/pull/7839) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -136,10 +136,14 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2, nfiles=1):
     RepoClass = GitRepo if random.randint(0, 1) else AnnexRepo
     lgr.info("Generating repo of class %s under %s", RepoClass, path)
     repo = RepoClass(path, create=True)
-    # Create tracked files
+    # Create tracked files.  Consume one random.randint for the first
+    # filename to preserve RNG sequence compatibility with the original
+    # code that used random filenames (callers with fixed seeds depend
+    # on the RNG producing the same dataset structure).
     fns = []
+    first_file_id = random.randint(1, 1000)
     for fi in range(nfiles):
-        fn = opj(path, "file%d.dat" % fi)
+        fn = opj(path, "file%d.dat" % (first_file_id if fi == 0 else fi))
         with open(fn, 'w') as f:
             f.write(fn)
         fns.append(fn)

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -137,11 +137,13 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2, nfiles=1):
     lgr.info("Generating repo of class %s under %s", RepoClass, path)
     repo = RepoClass(path, create=True)
     # Create tracked files
+    fns = []
     for fi in range(nfiles):
         fn = opj(path, "file%d.dat" % fi)
         with open(fn, 'w') as f:
             f.write(fn)
-    repo.add('.', git=True)
+        fns.append(fn)
+    repo.add(fns, git=True)
     repo.commit(msg="Added %d file(s)" % nfiles)
 
     yield path

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -43,12 +43,38 @@ lgr = logging.getLogger('datalad.distribution.tests')
 
 
 def _parse_spec(spec):
-    out = []   # will return a list of tuples (min, max) for each layer
+    """Parse a hierarchy spec string into a list of level descriptors.
+
+    Each level is separated by ``/`` and has the form::
+
+        [d]min[-max][+Nf]
+
+    ``d`` prefix makes entries plain directories instead of subdatasets.
+    ``+Nf`` suffix adds N tracked files to each dataset at that level
+    (default: 1 file per dataset, as before).
+
+    Returns a list of dicts with keys: min, max, is_dir, nfiles.
+    """
+    out = []
     if not spec:
         return out
     for ilevel, level in enumerate(spec.split('/')):
         if not level:
             continue
+
+        is_dir = False
+        nfiles = None  # None means "use the nfiles parameter default"
+
+        # Check for +Nf suffix (e.g., "2+100f")
+        if '+' in level and level.endswith('f'):
+            level, nf_str = level.rsplit('+', 1)
+            nfiles = int(nf_str[:-1])  # strip trailing 'f'
+
+        # Check for 'd' prefix (plain directory, not subdataset)
+        if level.startswith('d'):
+            is_dir = True
+            level = level[1:]
+
         minmax = level.split('-')
         if len(minmax) == 1:  # only abs number specified
             minmax = int(minmax[0])
@@ -58,17 +84,20 @@ def _parse_spec(spec):
             if not min_:  # might be omitted entirely
                 min_ = 0
             if not max_:
-                raise ValueError("Specify max number at level %d. Full spec was: %s"
-                                 % (ilevel, spec))
+                raise ValueError(
+                    "Specify max number at level %d. Full spec was: %s"
+                    % (ilevel, spec))
             min_ = int(min_)
             max_ = int(max_)
         else:
-            raise ValueError("Must have only min-max at level %d" % ilevel)
-        out.append((min_, max_))
+            raise ValueError(
+                "Must have only min-max at level %d" % ilevel)
+
+        out.append(dict(min=min_, max=max_, is_dir=is_dir, nfiles=nfiles))
     return out
 
 
-def _makeds(path, levels, ds=None, max_leading_dirs=2):
+def _makeds(path, levels, ds=None, max_leading_dirs=2, nfiles=1):
     """Create a hierarchy of datasets
 
     Used recursively, with current invocation generating datasets for the
@@ -79,14 +108,17 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
     path : str
       Path to the top directory under which dataset will be created.
       If relative -- relative to current directory
-    levels : list of list
-      List of specifications for :func:`random.randint` call per each level.
+    levels : list of dict
+      List of level descriptors from :func:`_parse_spec`.
     ds : Dataset, optional
       Super-dataset which would contain a new dataset (thus its path would be
       a parent of path. Note that ds needs to be installed.
     max_leading_dirs : int, optional
       Up to how many leading directories within a dataset could lead to a
       sub-dataset
+    nfiles : int, optional
+      Number of files to create in each dataset (default 1).  Per-level
+      ``+Nf`` spec overrides this.
 
     Yields
     ------
@@ -104,12 +136,13 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
     RepoClass = GitRepo if random.randint(0, 1) else AnnexRepo
     lgr.info("Generating repo of class %s under %s", RepoClass, path)
     repo = RepoClass(path, create=True)
-    # let's create some dummy file and add it to the beast
-    fn = opj(path, "file%d.dat" % random.randint(1, 1000))
-    with open(fn, 'w') as f:
-        f.write(fn)
-    repo.add(fn, git=True)
-    repo.commit(msg="Added %s" % fn)
+    # Create tracked files
+    for fi in range(nfiles):
+        fn = opj(path, "file%d.dat" % fi)
+        with open(fn, 'w') as f:
+            f.write(fn)
+    repo.add('.', git=True)
+    repo.commit(msg="Added %d file(s)" % nfiles)
 
     yield path
 
@@ -118,16 +151,37 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
         ds_ = Dataset(path)
         # Process the levels
         level, levels_ = levels[0], levels[1:]
-        nrepos = random.randint(*level)  # how many subds to generate
-        for irepo in range(nrepos):
-            # we would like to have up to 2 leading dirs
-            subds_path = opj(*(['d%i' % i
-                                for i in range(random.randint(0, max_leading_dirs+1))]
-                               + ['r%i' % irepo]))
-            subds_fpath = opj(path, subds_path)
-            # yield all under
-            for d in _makeds(subds_fpath, levels_, ds=ds_):
-                yield d
+        nchildren = random.randint(level['min'], level['max'])
+        child_nfiles = level.get('nfiles') or nfiles
+
+        for ichild in range(nchildren):
+            if level['is_dir']:
+                # Plain directory with files, not a subdataset
+                dirname = "dir%d" % ichild
+                dirpath = opj(path, dirname)
+                os.makedirs(dirpath, exist_ok=True)
+                for fi in range(child_nfiles):
+                    fn = opj(dirpath, "file%d.dat" % fi)
+                    with open(fn, 'w') as f:
+                        f.write(fn)
+                repo.add(dirname, git=True)
+            else:
+                # Subdataset
+                # we would like to have up to 2 leading dirs
+                subds_path = opj(
+                    *(['d%i' % i
+                       for i in range(
+                           random.randint(0, max_leading_dirs + 1))]
+                      + ['r%i' % ichild]))
+                subds_fpath = opj(path, subds_path)
+                # yield all under
+                for d in _makeds(subds_fpath, levels_, ds=ds_,
+                                 nfiles=child_nfiles):
+                    yield d
+
+        if level['is_dir']:
+            # Commit the directories we just created
+            repo.commit(msg="Added %d directories" % nchildren)
 
     if ds:
         assert ds.is_installed()
@@ -150,27 +204,46 @@ class CreateTestDataset(Interface):
         spec=Parameter(
             args=("--spec",),
             doc="""\
-            spec for hierarchy, defined as a min-max (min could be omitted to assume 0)
-            defining how many (random number from min to max) of sub-datasets to generate
-            at any given level of the hierarchy.  Each level separated from each other with /.
-            Example:  1-3/-2  would generate from 1 to 3 subdatasets at the top level, and
-            up to two within those at the 2nd level
+            spec for hierarchy.  Each level is separated by ``/`` and has
+            the form ``[d]min[-max][+Nf]``.
+
+            ``min-max`` defines how many (random from min to max)
+            sub-datasets to generate at that level (min can be omitted
+            to assume 0).
+
+            Prefix ``d`` makes entries plain directories instead of
+            subdatasets (e.g. ``d3`` creates 3 dirs with files).
+
+            Suffix ``+Nf`` creates N tracked files per entry at that
+            level (overrides --nfiles for that level).
+
+            Examples::
+
+                1-3/-2        1–3 subdatasets at L1, up to 2 at L2
+                2+100f/-2     2 subs at L1 each with 100 files, up to 2 at L2
+                10/d5+50f     10 subs, each containing 5 plain dirs with 50 files
             """,
             constraints=EnsureStr() | EnsureNone()),
         seed=Parameter(
             args=("--seed",),
             doc="""seed for rng""",
             constraints=EnsureInt() | EnsureNone()),
-
+        nfiles=Parameter(
+            args=("--nfiles",),
+            doc="""number of files to create in each dataset (default 1).
+            Per-level +Nf suffix in spec overrides this.""",
+            constraints=EnsureInt() | EnsureNone()),
     )
 
     @staticmethod
-    def __call__(path=None, *, spec=None, seed=None):
+    def __call__(path=None, *, spec=None, seed=None, nfiles=None):
         levels = _parse_spec(spec)
 
         if seed is not None:
             # TODO: if to be used within a bigger project we shouldn't seed main RNG
             random.seed(seed)
+        if nfiles is None:
+            nfiles = 1
         if path is None:
             kw = get_tempfile_kwargs({}, prefix="ds")
             path = tempfile.mkdtemp(**kw)
@@ -180,7 +253,7 @@ class CreateTestDataset(Interface):
             os.makedirs(path)
 
         # now we should just make it happen and return list of all the datasets
-        return list(_makeds(path, levels))
+        return list(_makeds(path, levels, nfiles=nfiles))
 
     @staticmethod
     def result_renderer_cmdline(res, args):

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -35,9 +35,26 @@ def test_create(outdir=None):
 
 
 def test_parse_spec():
-    eq_(_parse_spec('0/3/-1'), [(0, 0), (3, 3), (0, 1)])
-    eq_(_parse_spec('4-10'), [(4, 10)])
+    eq_(_parse_spec('0/3/-1'), [
+        dict(min=0, max=0, is_dir=False, nfiles=None),
+        dict(min=3, max=3, is_dir=False, nfiles=None),
+        dict(min=0, max=1, is_dir=False, nfiles=None),
+    ])
+    eq_(_parse_spec('4-10'), [
+        dict(min=4, max=10, is_dir=False, nfiles=None),
+    ])
     eq_(_parse_spec(''), [])
+    # Extended syntax: +Nf suffix and d prefix
+    eq_(_parse_spec('2+100f'), [
+        dict(min=2, max=2, is_dir=False, nfiles=100),
+    ])
+    eq_(_parse_spec('d3+50f'), [
+        dict(min=3, max=3, is_dir=True, nfiles=50),
+    ])
+    eq_(_parse_spec('2+10f/d4+5f'), [
+        dict(min=2, max=2, is_dir=False, nfiles=10),
+        dict(min=4, max=4, is_dir=True, nfiles=5),
+    ])
 
 
 def test_create_test_dataset():


### PR DESCRIPTION
## Summary

- Extracted from #7821 (which will be pushed rebased on top of this) so that we could
  - use those benchmarks in comparison for that PR
  - minimize that PR to relevant changes (already enough)
 
What it does:
 
- Extend `create_test_dataset` spec syntax with `+Nf` suffix (file count per level), `d` prefix (plain directories instead of subdatasets), and `--nfiles` parameter
- Add ASV benchmarks for `save` and `run` on realistic dataset hierarchies (10 annex subdatasets × 1000 files each)

### `create_test_dataset` enhancements

Backward-compatible extensions to the spec syntax:

```
2+100f      2 subdatasets with 100 files each
d3+50f      3 plain directories with 50 files each
10+5f/d4+100f   10 subs (5 files) each with 4 dirs (100 files)
```

New `--nfiles` parameter sets default file count per dataset (default 1).

### Benchmarks (`benchmarks/save_run.py`)

| Benchmark | Description |
|-----------|-------------|
| `save_clean` | Standard save, 50 files (regression guard) |
| `run_simple` | End-to-end run on lightweight dataset |
| `save_heavy_hierarchy` | Recursive save on 10 subs × 1000 files, changes in 2 |
| `run_heavy_hierarchy` | run() touching 2 of 10 heavy subs |

Heavy benchmarks use `setup_cache` with tarball for fast per-invocation setup.

## Test plan

- [x] All 6 existing `test_create_test_dataset` tests pass (backward compat)
- [x] New spec syntax tests added (`+Nf`, `d` prefix)
- [x] All benchmarks verified locally via `asv run -E existing`
- [x] if CI passes, I will not delay merge to `master` to facilitate further work on that original PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
