### PR TITLE
chore: deduplicate code across interface docs, create-sibling, s3, and benchmarks

### DIFF
--- a/benchmarks/cli.py
+++ b/benchmarks/cli.py
@@ -7,25 +7,15 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Benchmarks for DataLad CLI"""
 
-import os
-import os.path as osp
-import sys
 from subprocess import call
 
-from .common import SuprocBenchmarks
+from .common import StartupBenchmarks
 
 
-class startup(SuprocBenchmarks):
+class startup(StartupBenchmarks):
     """
     Benchmarks for datalad command startup
     """
-
-    def setup(self):
-        # we need to prepare/adjust PATH to point to installed datalad
-        # We will base it on taking sys.executable
-        python_path = osp.dirname(sys.executable)
-        self.env = os.environ.copy()
-        self.env['PATH'] = '%s:%s' % (python_path, self.env.get('PATH', ''))
 
     def time_usage_advice(self):
         call(["datalad"], env=self.env)

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -101,6 +101,17 @@ class SuprocBenchmarks(object):
         print("BM: "+ str(msg % tuple(args)))
 
 
+class StartupBenchmarks(SuprocBenchmarks):
+    """Base for benchmarks that need datalad on PATH."""
+
+    def setup(self):
+        # we need to prepare/adjust PATH to point to installed datalad
+        # We will base it on taking sys.executable
+        python_path = op.dirname(sys.executable)
+        self.env = os.environ.copy()
+        self.env['PATH'] = '%s:%s' % (python_path, self.env.get('PATH', ''))
+
+
 class SampleSuperDatasetBenchmarks(SuprocBenchmarks):
     """
     Setup a sample hierarchy of datasets to be used

--- a/benchmarks/core.py
+++ b/benchmarks/core.py
@@ -18,7 +18,10 @@ from datalad.runner import (
     StdOutErrCapture,
 )
 
-from .common import SuprocBenchmarks
+from .common import (
+    StartupBenchmarks,
+    SuprocBenchmarks,
+)
 
 # Some tracking example -- may be we should track # of datasets.datalad.org
 #import gc
@@ -32,17 +35,10 @@ scripts_dir = osp.join(osp.dirname(__file__), 'scripts')
 heavyout_cmd = "{} 1000".format(osp.join(scripts_dir, 'heavyout'))
 
 
-class startup(SuprocBenchmarks):
+class startup(StartupBenchmarks):
     """
     Benchmarks for datalad commands startup
     """
-
-    def setup(self):
-        # we need to prepare/adjust PATH to point to installed datalad
-        # We will base it on taking sys.executable
-        python_path = osp.dirname(sys.executable)
-        self.env = os.environ.copy()
-        self.env['PATH'] = '%s:%s' % (python_path, self.env.get('PATH', ''))
 
     def time_import(self):
         call([sys.executable, "-c", "import datalad"])

--- a/changelog.d/pr-7841.md
+++ b/changelog.d/pr-7841.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- chore: deduplicate code across interface docs, create-sibling, s3, and benchmarks.  [PR #7841](https://github.com/datalad/datalad/pull/7841) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/cli/interface.py
+++ b/datalad/cli/interface.py
@@ -1,7 +1,10 @@
 """Utilities and definitions for DataLad command interfaces"""
 
 # TODO this should be a dochelper
-from datalad.interface.base import dedent_docstring
+from datalad.interface.base import (
+    _strip_rst_roles,
+    dedent_docstring,
+)
 
 # Some known extensions and their commands to suggest whenever lookup fails
 _known_extension_commands = {
@@ -80,18 +83,7 @@ def alter_interface_docs_for_cmdline(docs):
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE | re.DOTALL)
-    # remove :role:`...` RST markup for cmdline docs
-    docs = re.sub(
-        r':\S+:`[^`]*`[\\]*',
-        lambda match: ':'.join(match.group(0).split(':')[2:]).strip('`\\'),
-        docs,
-        flags=re.MULTILINE | re.DOTALL)
-    # make the handbook doc references more accessible
-    # the URL is a redirect configured at readthedocs
-    docs = re.sub(
-        r'(handbook:[0-9]-[0-9]*)',
-        '\\1 (http://handbook.datalad.org/symbols)',
-        docs)
+    docs = _strip_rst_roles(docs)
     # remove None constraint. In general, `None` on the cmdline means don't
     # give option at all, but specifying `None` explicitly is practically
     # impossible

--- a/datalad/distributed/create_sibling_ghlike.py
+++ b/datalad/distributed/create_sibling_ghlike.py
@@ -498,6 +498,18 @@ class _GitHubLike(object):
         )
         return self.repo_create_response(r)
 
+    def _is_repo_already_exists(self, r, response):
+        """Check if a repo creation response indicates the repo already exists.
+
+        Override in subclasses to handle platform-specific response formats.
+
+        Returns
+        -------
+        bool
+        """
+        return (r.status_code == requests.codes.unprocessable
+                and 'already exist' in response.get('message', ''))
+
     def repo_create_response(self, r):
         """Handling of repo creation request responses
 
@@ -528,8 +540,7 @@ class _GitHubLike(object):
                 # perform some normalization
                 **self.normalize_repo_properties(response)
             )
-        elif r.status_code == requests.codes.unprocessable and \
-                'already exist' in response.get('message', ''):
+        elif self._is_repo_already_exists(r, response):
             return dict(
                 status='impossible',
                 message='repository already exists',

--- a/datalad/distributed/create_sibling_gitea.py
+++ b/datalad/distributed/create_sibling_gitea.py
@@ -36,47 +36,10 @@ class _Gitea(_GOGS):
         'annex-ignore': 'true',
     }
 
-    def repo_create_response(self, r):
-        """
-        At present the only difference from the GHlike implementation
-        is the detection of an already existing via a proper 409 response.
-        """
-        try:
-            response = r.json()
-        except Exception as e:
-            lgr.debug('Cannot get JSON payload of %s [%s]' , r, e)
-            response = {}
-        lgr.debug('%s responded with %s %s', self.fullname, r, response)
-        if r.status_code == requests.codes.created:
-            return dict(
-                status='ok',
-                preexisted=False,
-                # perform some normalization
-                reponame=response.get('name'),
-                private=response.get('private'),
-                clone_url=response.get('clone_url'),
-                ssh_url=response.get('ssh_url'),
-                html_url=response.get('html_url'),
-                # and also return in full
-                host_response=response,
-            )
-        elif r.status_code == requests.codes.conflict and \
-                'already exist' in response.get('message', ''):
-            return dict(
-                status='impossible',
-                message='repository already exists',
-                preexisted=True,
-            )
-        elif r.status_code in (self.response_code_unauthorized,
-                               requests.codes.forbidden):
-            return dict(
-                status='error',
-                message=('unauthorized: %s', response.get('message')),
-            )
-        # make sure any error-like situation causes noise
-        r.raise_for_status()
-        # catch-all
-        raise RuntimeError(f'Unexpected host response: {response}')
+    def _is_repo_already_exists(self, r, response):
+        # Gitea reports existing repos via 409 Conflict
+        return (r.status_code == requests.codes.conflict
+                and 'already exist' in response.get('message', ''))
 
 
 @build_doc

--- a/datalad/distributed/create_sibling_github.py
+++ b/datalad/distributed/create_sibling_github.py
@@ -59,47 +59,11 @@ class _GitHub(_GitHubLike):
         'datalad-push-default-first': 'true'
     }
 
-    def repo_create_response(self, r):
-        """
-        At present the only difference from the GHlike implementation
-        is the detection of an already existing repo in a 422 response.
-        """
-        try:
-            response = r.json()
-        except Exception as e:
-            lgr.debug('Cannot get JSON payload of %s [%s]' , r, e)
-            response = {}
-        lgr.debug('%s responded with %s %s', self.fullname, r, response)
-        if r.status_code == requests.codes.created:
-            return dict(
-                status='ok',
-                preexisted=False,
-                # perform some normalization
-                reponame=response.get('name'),
-                private=response.get('private'),
-                clone_url=response.get('clone_url'),
-                ssh_url=response.get('ssh_url'),
-                html_url=response.get('html_url'),
-                # and also return in full
-                host_response=response,
-            )
-        elif r.status_code == requests.codes.unprocessable and \
-                any('already exist' in e.get('message', '')
-                    for e in response.get('errors', [])):
-            return dict(
-                status='impossible',
-                message='repository already exists',
-                preexisted=True,
-            )
-        elif r.status_code == self.response_code_unauthorized:
-            return dict(
-                status='error',
-                message=('unauthorized: %s', response.get('message')),
-            )
-        # make sure any error-like situation causes noise
-        r.raise_for_status()
-        # catch-all
-        raise RuntimeError(f'Unexpected host response: {response}')
+    def _is_repo_already_exists(self, r, response):
+        # GitHub reports existing repos via 422 with an errors array
+        return (r.status_code == requests.codes.unprocessable
+                and any('already exist' in e.get('message', '')
+                        for e in response.get('errors', [])))
 
     def repo_delete_request(self, orguser, reponame):
         r = requests.delete(

--- a/datalad/distributed/tests/test_create_sibling_ghlike.py
+++ b/datalad/distributed/tests/test_create_sibling_ghlike.py
@@ -10,8 +10,12 @@
 import logging
 import os
 from os.path import basename
-from unittest.mock import patch
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
+import pytest
 import requests
 
 from datalad.api import (
@@ -199,3 +203,68 @@ def check4real(testcmd, testdir, credential, api, delete_endpoint,
                 reponame)
         else:
             resp.raise_for_status()
+
+
+def _mock_response(status_code):
+    """Create a mock requests.Response with given status code."""
+    r = MagicMock()
+    r.status_code = status_code
+    return r
+
+
+@pytest.mark.ai_generated
+def test_is_repo_already_exists_ghlike():
+    from datalad.distributed.create_sibling_ghlike import _GitHubLike
+    obj = _GitHubLike.__new__(_GitHubLike)
+
+    # base: 422 + 'already exist' in message -> True
+    r = _mock_response(requests.codes.unprocessable)
+    assert obj._is_repo_already_exists(r, {'message': 'already exist'})
+
+    # base: 422 without 'already exist' -> False
+    assert not obj._is_repo_already_exists(r, {'message': 'other error'})
+    assert not obj._is_repo_already_exists(r, {})
+
+    # base: wrong status code -> False
+    r = _mock_response(requests.codes.conflict)
+    assert not obj._is_repo_already_exists(r, {'message': 'already exist'})
+
+
+@pytest.mark.ai_generated
+def test_is_repo_already_exists_github():
+    from datalad.distributed.create_sibling_github import _GitHub
+    obj = _GitHub.__new__(_GitHub)
+
+    # GitHub: 422 + errors array with 'already exist' -> True
+    r = _mock_response(requests.codes.unprocessable)
+    assert obj._is_repo_already_exists(
+        r, {'errors': [{'message': 'already exist'}]})
+
+    # GitHub: 422 + errors without 'already exist' -> False
+    assert not obj._is_repo_already_exists(
+        r, {'errors': [{'message': 'other'}]})
+    assert not obj._is_repo_already_exists(r, {'errors': []})
+    assert not obj._is_repo_already_exists(r, {})
+
+    # GitHub: wrong status code -> False
+    r = _mock_response(requests.codes.conflict)
+    assert not obj._is_repo_already_exists(
+        r, {'errors': [{'message': 'already exist'}]})
+
+
+@pytest.mark.ai_generated
+def test_is_repo_already_exists_gitea():
+    from datalad.distributed.create_sibling_gitea import _Gitea
+    obj = _Gitea.__new__(_Gitea)
+
+    # Gitea: 409 + 'already exist' in message -> True
+    r = _mock_response(requests.codes.conflict)
+    assert obj._is_repo_already_exists(r, {'message': 'already exist'})
+
+    # Gitea: 409 without 'already exist' -> False
+    assert not obj._is_repo_already_exists(r, {'message': 'other'})
+    assert not obj._is_repo_already_exists(r, {})
+
+    # Gitea: wrong status code -> False
+    r = _mock_response(requests.codes.unprocessable)
+    assert not obj._is_repo_already_exists(r, {'message': 'already exist'})

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -199,6 +199,24 @@ def dedent_docstring(text):
         return textwrap.dedent(text)
 
 
+def _strip_rst_roles(docs):
+    """Strip RST role markup and enhance handbook reference links.
+
+    Used by both cmdline and Python API doc processors to remove
+    ``:role:`text``` markup and add URLs to handbook references.
+    """
+    docs = re.sub(
+        r':\S+:`[^`]*`[\\]*',
+        lambda match: ':'.join(match.group(0).split(':')[2:]).strip('`\\'),
+        docs,
+        flags=re.MULTILINE | re.DOTALL)
+    docs = re.sub(
+        r'(handbook:[0-9]-[0-9]*)',
+        '\\1 (http://handbook.datalad.org/symbols)',
+        docs)
+    return docs
+
+
 def alter_interface_docs_for_api(docs):
     """Apply modifications to interface docstrings for Python API use."""
     # central place to alter the impression of docstrings,
@@ -234,18 +252,7 @@ def alter_interface_docs_for_api(docs):
         docs,
         flags=re.MULTILINE | re.DOTALL)
     if 'DATALAD_SPHINX_RUN' not in os.environ:
-        # remove :role:`...` RST markup for cmdline docs
-        docs = re.sub(
-            r':\S+:`[^`]*`[\\]*',
-            lambda match: ':'.join(match.group(0).split(':')[2:]).strip('`\\'),
-            docs,
-            flags=re.MULTILINE | re.DOTALL)
-        # make the handbook doc references more accessible
-        # the URL is a redirect configured at readthedocs
-        docs = re.sub(
-            r'(handbook:[0-9]-[0-9]*)',
-            '\\1 (http://handbook.datalad.org/symbols)',
-            docs)
+        docs = _strip_rst_roles(docs)
     docs = re.sub(
         r'^([ ]*)\|\| REFLOW \>\>\n(.*?)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(2), subsequent_indent=match.group(1)),

--- a/datalad/support/s3.py
+++ b/datalad/support/s3.py
@@ -195,18 +195,19 @@ def gen_bucket_test0_nonversioned():
     return _gen_bucket_test0('datalad-test0-nonversioned', versioned=False)
 
 
-def gen_bucket_test1_dirs():
-    bucket_name = 'datalad-test1-dirs-versioned'
+def _gen_versioned_bucket(bucket_name):
+    """Create a versioned S3 test bucket with web access and public policy."""
     bucket = gen_test_bucket(bucket_name)
     bucket.Versioning().enable()
-
-    # Enable web access to that bucket to everyone
     bucket.Website().put(
         WebsiteConfiguration={"IndexDocument": {"Suffix": "index.html"}}
     )
     set_bucket_public_access_policy(bucket)
+    return bucket, VersionedFilesPool(bucket)
 
-    files = VersionedFilesPool(bucket)
+
+def gen_bucket_test1_dirs():
+    bucket, files = _gen_versioned_bucket('datalad-test1-dirs-versioned')
 
     files("d1", load="")  # creating an empty file
     # then we would like to remove that d1 as a file and make a directory out of it
@@ -218,17 +219,7 @@ def gen_bucket_test1_dirs():
 def gen_bucket_test2_obscurenames_versioned():
     # in principle bucket name could also contain ., but boto doesn't digest it
     # well
-    bucket_name = 'datalad-test2-obscurenames-versioned'
-    bucket = gen_test_bucket(bucket_name)
-    bucket.Versioning().enable()
-
-    # Enable web access to that bucket to everyone
-    bucket.Website().put(
-        WebsiteConfiguration={"IndexDocument": {"Suffix": "index.html"}}
-    )
-    set_bucket_public_access_policy(bucket)
-
-    files = VersionedFilesPool(bucket)
+    bucket, files = _gen_versioned_bucket('datalad-test2-obscurenames-versioned')
 
     # http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
     files("f 1", load="")
@@ -244,17 +235,7 @@ def gen_bucket_test2_obscurenames_versioned():
 
 def gen_bucket_test1_manydirs():
     # to test crawling with flexible subdatasets making decisions
-    bucket_name = 'datalad-test1-manydirs-versioned'
-    bucket = gen_test_bucket(bucket_name)
-    bucket.Versioning().enable()
-
-    # Enable web access to that bucket to everyone
-    bucket.Website().put(
-        WebsiteConfiguration={"IndexDocument": {"Suffix": "index.html"}}
-    )
-    set_bucket_public_access_policy(bucket)
-
-    files = VersionedFilesPool(bucket)
+    bucket, files = _gen_versioned_bucket('datalad-test1-manydirs-versioned')
 
     files("d1", load="")  # creating an empty file
     # then we would like to remove that d1 as a file and make a directory out of it

--- a/datalad/tests/test_s3.py
+++ b/datalad/tests/test_s3.py
@@ -10,6 +10,13 @@
 
 """
 
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+import pytest
+
 from datalad.downloaders.tests.utils import get_test_providers
 from datalad.support.network import URL
 from datalad.support.s3 import (
@@ -114,3 +121,26 @@ def test_version_url_deleted():
     eq_(get_versioned_url(url), turl)
     # too heavy for verification!
     #eq_(get_versioned_url(url, verify=True), turl)
+
+
+@pytest.mark.ai_generated
+def test_gen_versioned_bucket():
+    from datalad.support.s3 import (
+        VersionedFilesPool,
+        _gen_versioned_bucket,
+    )
+
+    mock_bucket = MagicMock()
+    with patch('datalad.support.s3.gen_test_bucket',
+               return_value=mock_bucket) as mock_gen, \
+         patch('datalad.support.s3.set_bucket_public_access_policy') as mock_policy:
+        bucket, files = _gen_versioned_bucket('test-bucket')
+
+    mock_gen.assert_called_once_with('test-bucket')
+    mock_bucket.Versioning().enable.assert_called_once()
+    mock_bucket.Website().put.assert_called_once_with(
+        WebsiteConfiguration={"IndexDocument": {"Suffix": "index.html"}}
+    )
+    mock_policy.assert_called_once_with(mock_bucket)
+    assert bucket is mock_bucket
+    assert isinstance(files, VersionedFilesPool)


### PR DESCRIPTION
- Extract _strip_rst_roles() in interface/base.py, used by both alter_interface_docs_for_api() and alter_interface_docs_for_cmdline() to remove RST role markup and enhance handbook links.

- Add _is_repo_already_exists() hook to _GitHubLike base class so GitHub and Gitea override only the "already exists" detection (3 lines each) instead of the entire repo_create_response method (~40 lines each). GOGS/GIN inherit the base behavior unchanged.

- Extract _gen_versioned_bucket() in support/s3.py to consolidate repeated versioned S3 bucket setup (versioning, website config, public policy) across three gen_bucket_test*() functions.

- Extract StartupBenchmarks class in benchmarks/common.py with shared PATH setup, used by both benchmarks/cli.py and core.py.


