### PR TITLE
Do not fail `add-archive-content` when adding files ignored due to .gitignore rules

### DIFF
--- a/changelog.d/pr-7844.md
+++ b/changelog.d/pr-7844.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Do not fail `add-archive-content` when adding files ignored due to .gitignore rules.  [PR #7844](https://github.com/datalad/datalad/pull/7844) (by [@asmacdo](https://github.com/asmacdo))

--- a/datalad/local/add_archive_content.py
+++ b/datalad/local/add_archive_content.py
@@ -46,6 +46,7 @@ from datalad.log import (
     logging,
 )
 from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import AnnexBatchCommandError
 from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,
@@ -609,10 +610,20 @@ class AddArchiveContent(Interface):
                 lgr.debug("Adding %s to annex pointing to %s and with options "
                           "%r", target_file_path, url, annex_options)
 
-                out_json = annex.add_url_to_file(
-                    target_file_path,
-                    url, options=annex_options,
-                    batch=True)
+                try:
+                    out_json = annex.add_url_to_file(
+                        target_file_path,
+                        url, options=annex_options,
+                        batch=True)
+                except AnnexBatchCommandError as exc:
+                    if '.gitignored' in str(exc):
+                        lgr.warning(
+                            "%s matches .gitignore; skipping "
+                            "(file not added to dataset)",
+                            target_file_path)
+                        stats.skipped += 1
+                        continue
+                    raise
 
                 if 'key' in out_json and out_json['key'] is not None:
                     # annex.is_under_annex(target_file, batch=True):

--- a/datalad/local/tests/test_add_archive_content.py
+++ b/datalad/local/tests/test_add_archive_content.py
@@ -653,3 +653,13 @@ class TestAddArchiveOptions():
             , existing='overwrite'
         )
         ok_file_under_git(self.ds.path, '1.dat', annexed=True)
+
+    def test_add_archive_gitignored_files(self):
+        # Extracted archive paths matching .gitignore are skipped with a
+        # warning rather than aborting the whole add-archive-content run.
+        create_tree(self.ds.path, {'.gitignore': '*.dat\n'})
+        self.ds.save('.gitignore', to_git=True, message='add gitignore')
+
+        self.ds.add_archive_content('1.tar')
+        ok_file_under_git(self.ds.path, opj('1', 'file.txt'), annexed=True)
+        assert not lexists(opj(self.ds.path, '1', '1.dat'))


### PR DESCRIPTION
## Problem

`git annex addurl --batch` checks `.gitignore` by default. When `add-archive-content` hands it an extracted path that matches an ignore rule, addurl refuses the file and the batch run aborts on the first such path — leaving the rest of the archive's content unadded:

```
AnnexBatchCommandError: 'addurl' [Error: 'not adding logs/run.log
  which is .gitignored (use --no-check-gitignore to override)']
```

## Fix

Catch the per-file `AnnexBatchCommandError`, detect the `.gitignored` refusal, log a warning, and skip that path. The batch subprocess stays alive (the JSON response just had `success: false`), so remaining files continue to be added. The gitignored file is not placed in the dataset.

Behavior summary:

| Path matches `.gitignore` | Before this PR   | After this PR           |
|---------------------------|------------------|-------------------------|
| No                        | added to annex   | added to annex (same)   |
| Yes                       | run aborts       | skipped with a warning  |

Users who want every extracted path in regardless of ignore rules can still force it explicitly with `--annex-options='--no-check-gitignore'`.

<details><summary>Reproducer</summary>

```bash
export PS4='> '
set -x
set -eu
cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-XXXXXXX)"

mkdir -p logs
echo "some log data" > logs/run.log
echo "keep me" > keep.txt
tar czf archive.tar.gz logs/ keep.txt

datalad create -c text2git testds
cd testds
echo "logs" > .gitignore
git add .gitignore
git commit -m "add gitignore"
cp ../archive.tar.gz .
git annex add archive.tar.gz
git commit -m "add archive"

datalad add-archive-content archive.tar.gz
git status --short
ls -la
[ ! -e logs/run.log ] && echo "OK: logs/run.log skipped (gitignored)"
[ -e keep.txt ]      && echo "OK: keep.txt added"
```

</details>

<details><summary>Run on master (aborts)</summary>

```
> datalad add-archive-content archive.tar.gz
[INFO   ] Adding content of the archive archive.tar.gz into annex ...
[INFO   ] Initializing special remote datalad-archives
[ERROR  ] AnnexBatchCommandError: 'addurl' [Error, annex reported
  failure for addurl ... "note": "not adding logs/run.log which is
  .gitignored (use --no-check-gitignore to override)"]
```

</details>

<details><summary>Run with this PR (gitignored skipped, rest added)</summary>

```
> datalad add-archive-content archive.tar.gz
[INFO   ] Adding content of the archive archive.tar.gz into annex ...
[INFO   ] Initializing special remote datalad-archives
[WARNING] logs/run.log matches .gitignore; skipping (file not added to dataset)
[INFO   ] Finished adding archive.tar.gz: Files processed: 2, +git: 1, skipped: 1
add-archive-content(ok): ... (dataset)
```

</details>
