### PR TITLE
BF(TST,CI): mark flaky rerun-merges test + split full NFS cron job

### DIFF
--- a/datalad/local/tests/test_rerun_merges.py
+++ b/datalad/local/tests/test_rerun_merges.py
@@ -13,7 +13,10 @@ __docformat__ = 'restructuredtext'
 
 import os.path as op
 
+import pytest
+
 from datalad.distribution.dataset import Dataset
+from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils_pytest import (
     DEFAULT_BRANCH,
     assert_false,
@@ -521,6 +524,12 @@ def test_rerun_unrelated_run_left_nonrun_right(path=None):
 # @slow  # ~3.5sec on Yarik's laptop
 # test implementation requires checkout of non-adjusted branch
 @skip_if_adjusted_branch
+# Intermittently fails on CI with git-annex 10.20230126 (standalone): unlock
+# reports "notneeded" for `foo` after the unrelated-histories merge, but the
+# file is still read-only, so the rerun of `echo foo >>foo` errors with
+# "Permission denied". Could not reproduce locally in 100 runs with
+# git-annex 10.20260316.
+@pytest.mark.flaky(retries=2, only_on=[IncompleteResultsError])
 @with_tempfile(mkdir=True)
 def test_rerun_unrelated_mutator_left_nonrun_right(path=None):
     ds = Dataset(path).create()

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -188,7 +188,10 @@
     http_proxy: ""
     https_proxy: ""
 
-# Test under NFS mount  (full, only in master)
+# Test under NFS mount (the complement of the scoped NFS job above --
+# everything except datalad.tests and datalad.support, which are already
+# covered there). The previous "full" NFS job ran the entire suite and was
+# cancelled by GitHub's 6h job timeout on every scheduled run.
 - python-version: '3.10'
   cron-only: true
   allow-failure: true
@@ -196,6 +199,7 @@
     # give much more time to complete on NFS
     _DL_TMPDIR: "/tmp/nfsmount"
     PYTEST_FAIL_SLOW: 1200
+    TESTS_TO_PERFORM: "datalad.cli datalad.cmdline datalad.core datalad.customremotes datalad.dataset datalad.distributed datalad.distribution datalad.downloaders datalad.interface datalad.local datalad.plugin datalad.runner datalad.ui"
 
 # Causes complete laptop or travis instance crash atm, but survives in a docker
 # need to figure it out (looks like some PID explosion)


### PR DESCRIPTION
Address two CI issues surfaced by the 2026-04-17 scheduled run (https://github.com/datalad/datalad/actions/runs/24554006260):

1. `test_rerun_unrelated_mutator_left_nonrun_right` failed once in the `(3.10, true, true, 1)` job (git-annex 10.20230126 standalone, from conda).  The rerun of `echo foo >>foo` exited 2 with `/bin/sh: 1: cannot create foo: Permission denied`, even though the preceding unlock reported `notneeded` in the action summary — git-annex believed `foo` did not need unlocking, yet the working-tree copy was still read-only after the `--allow-unrelated-histories` merge.

   The same job matrix configuration (job `8_test (3.10, true, true, 1)`) passed in the same run, and 100 sequential local runs with git-annex 10.20260316 all passed, so this looks like an intermittent git-annex state issue specific to the pinned standalone 10.20230126 build.

   Mark the test with `@pytest.mark.flaky(retries=2, only_on=[IncompleteResultsError])` so a single transient failure does not break CI.  The project already uses this pattern for similar intermittent failures in `test_create_sibling_gitea.py` and `test_http.py`.  If retries keep failing, the pytest-retry output will make it obvious the issue is real rather than a one-off flake.

2. The cron-only `test (3.10, true, true, /tmp/nfsmount, 1200)` job has been cancelled by GitHub Actions' 6-hour job timeout on *every* scheduled run for the past month (verified via the API across all of April 2026 cron runs).  The job runs the full datalad suite on an NFS mount where a single test can take 600–900s (e.g. `datalad.support.tests.test_fileinfo.test_subds_path`, 909s).

   A separate scoped NFS job already covers `datalad.tests datalad.support` reliably in ~67 minutes.  Set `TESTS_TO_PERFORM` on the "full" job to the complement of that scope (every other datalad subpackage) so the two jobs together still cover the whole suite on NFS without the 6h-timeout kill.  The job keeps `allow-failure: true` and `cron-only: true`, so this change cannot make CI redder than today, only less so.


