### PR TITLE
Test patool in CI

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -636,6 +636,17 @@
             "avatar_url": [
                 "https://avatars.githubusercontent.com/u/108482432?v=4"
             ]
+        },
+        {
+            "login": "jkonieczny2",
+            "name": "jkonieczny2",
+            "contributions": [
+                "code"
+            ],
+            "profile": "https://github.com/jkonieczny2",
+            "avatar_url": [
+                "https://avatars.githubusercontent.com/u/14842795?v=4"
+            ]
         }
     ],
     "contributorsPerLine": 7

--- a/.tributors
+++ b/.tributors
@@ -329,5 +329,9 @@
     "just-meng": {
         "name": "Jiameng Wu",
         "blog": "https://github.com/just-meng"
+    },
+    "jkonieczny2": {
+        "name": "jkonieczny2",
+        "blog": "https://github.com/jkonieczny2"
     }
 }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.808846.svg)](https://doi.org/10.5281/zenodo.808846)
 [![RRID](https://img.shields.io/badge/RRID-SCR__003931-blue)](https://identifiers.org/RRID:SCR_003931)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-57-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-58-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Distribution
@@ -256,6 +256,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/just-meng"><img src="https://avatars.githubusercontent.com/u/108482432?v=4?s=100" width="100px;" alt="Jiameng Wu"/><br /><sub><b>Jiameng Wu</b></sub></a><br /><a href="https://github.com/datalad/datalad/commits?author=just-meng" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/jkonieczny2"><img src="https://avatars.githubusercontent.com/u/14842795?v=4?s=100" width="100px;" alt="jkonieczny2"/><br /><sub><b>jkonieczny2</b></sub></a><br /><a href="https://github.com/datalad/datalad/commits?author=jkonieczny2" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/benchmarks/save_run.py
+++ b/benchmarks/save_run.py
@@ -1,0 +1,196 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Benchmarks for save and run operations on realistic dataset hierarchies.
+
+These benchmarks cover:
+- Standard save on a small dataset -- regression guard
+- Standard save on a heavy hierarchy (10 annex subs × 1000 files)
+- run() on a heavy hierarchy
+
+Tagging convention: benchmark classes set ``tags = ['ai_generated']``
+to mirror ``@pytest.mark.ai_generated`` in the test suite.  ASV has
+no marks system; tags are a project convention for grep/filtering.
+"""
+
+import os
+import os.path as op
+import tarfile
+import tempfile
+
+from datalad.api import (
+    Dataset,
+    create_test_dataset,
+)
+from datalad.utils import (
+    create_tree,
+    get_tempfile_kwargs,
+    rmtree,
+    rotree,
+)
+
+from .common import SuprocBenchmarks
+
+# ---- helpers ---------------------------------------------------------------
+
+# Heavy hierarchy uses a manual helper (not create_test_dataset) because
+# we need predictable subdataset names (sub00..sub09) to modify specific
+# subs in setup().  create_test_dataset randomizes leading dirs.
+
+N_SUBS = 10
+N_FILES_PER_SUB = 1000
+
+
+def _create_heavy_hierarchy(ds_path):
+    """Create a super-dataset with N_SUBS annex subdatasets, each containing
+    N_FILES_PER_SUB tracked files.  Uses default annex repos to benchmark
+    the realistic code path.
+    """
+    ds = Dataset(ds_path).create()
+    for si in range(N_SUBS):
+        sub = ds.create(f"sub{si:02d}")
+        tree = {
+            f"file_{fi:04d}.txt": f"sub{si} file {fi}"
+            for fi in range(N_FILES_PER_SUB)
+        }
+        create_tree(sub.path, tree)
+        sub.save(message=f"sub{si:02d}: {N_FILES_PER_SUB} files")
+    # A few top-level tracked files
+    tree = {f"top_{i:02d}.txt": f"top {i}" for i in range(20)}
+    create_tree(ds.path, tree)
+    ds.save(message="hierarchy with heavy subs")
+    return ds
+
+
+def _extract_tar(tarpath, dsname, counter_cls):
+    """Extract a tarball to a fresh tempdir, return (tempdir, ds_path)."""
+    tempdir = tempfile.mkdtemp(
+        **get_tempfile_kwargs({}, prefix="bm_"))
+    with tarfile.open(tarpath) as tar:
+        tar.extractall(tempdir)
+    epath = op.join(tempdir, dsname)
+    epath_unique = epath + str(counter_cls.ds_count)
+    os.rename(epath, epath_unique)
+    counter_cls.ds_count += 1
+    return tempdir, epath_unique
+
+
+# ---- benchmarks: small / flat ---------------------------------------------
+
+
+class save_clean(SuprocBenchmarks):
+    """Baseline: standard save without fr= (Status-based path).
+
+    Guards against regressions in the save code path.
+    Uses create_test_dataset for a single dataset with 50 files.
+    """
+    tags = ['ai_generated']
+
+    def setup(self):
+        tempdir = tempfile.mkdtemp(
+            **get_tempfile_kwargs({}, prefix="bm_save_clean"))
+        self.remove_paths.append(tempdir)
+        dss = create_test_dataset(
+            op.join(tempdir, "ds"), spec='0', seed=0, nfiles=50)
+        self.ds = Dataset(dss[0])
+        # Dirty 5 files for save to pick up
+        for i in range(5):
+            (self.ds.pathobj / f"file{i}.dat").write_text("modified")
+
+    def time_save(self):
+        self.ds.save(message="benchmark save")
+
+
+class run_simple(SuprocBenchmarks):
+    """End-to-end run() benchmark on a lightweight single dataset."""
+    tags = ['ai_generated']
+
+    def setup(self):
+        tempdir = tempfile.mkdtemp(
+            **get_tempfile_kwargs({}, prefix="bm_run"))
+        self.remove_paths.append(tempdir)
+        dss = create_test_dataset(
+            op.join(tempdir, "ds"), spec='0', seed=0, nfiles=5)
+        self.ds = Dataset(dss[0])
+
+    def time_run(self):
+        self.ds.run('echo plain > plain_file', result_renderer='disabled')
+
+
+# ---- benchmarks: heavy hierarchy ------------------------------------------
+# 10 subdatasets × 1000 tracked files each.
+# Measures the cost of recursive save/run scanning a large tree
+# when only 2 of 10 subdatasets have changes.
+
+
+class save_heavy_hierarchy(SuprocBenchmarks):
+    """save on a heavy hierarchy (10 subs × 1000 files).
+
+    Benchmarks standard recursive save after modifying files in only
+    2 of 10 subdatasets.
+
+    setup_cache creates the hierarchy once (expensive ~30s);
+    setup extracts it and makes minimal changes.
+    """
+    tags = ['ai_generated']
+
+    timeout = 3600
+    dsname = 'bm_heavy'
+    _tarfile = 'bm_heavy.tar'
+    ds_count = 0
+
+    def setup_cache(self):
+        _create_heavy_hierarchy(self.dsname)
+        self._tarfile = op.realpath(self._tarfile)
+        rotree(self.dsname, ro=False, chmod_files=False)
+        with tarfile.open(self._tarfile, "w") as tar:
+            tar.add(self.dsname, recursive=True)
+        rmtree(self.dsname)
+
+    def setup(self):
+        tempdir, ds_path = _extract_tar(
+            self._tarfile, self.dsname, self.__class__)
+        self.remove_paths.append(tempdir)
+        self.ds = Dataset(ds_path)
+        # Add a new file in 2 of 10 subdatasets (the rest stay clean).
+        # We create new files rather than modifying existing ones because
+        # annexed files are read-only symlinks.
+        for si in (0, 5):
+            sub = Dataset(op.join(ds_path, f"sub{si:02d}"))
+            (sub.pathobj / "new_file.txt").write_text("added by setup")
+
+    def time_save(self):
+        """Standard recursive save — the baseline."""
+        self.ds.save(recursive=True, message="bm save")
+
+
+class run_heavy_hierarchy(SuprocBenchmarks):
+    """End-to-end run() on a heavy hierarchy.
+
+    Command touches 2 of 10 subdatasets: creates a file in each.
+    Measures the full run pipeline on a realistic tree.
+    """
+    tags = ['ai_generated']
+
+    timeout = 3600
+    dsname = 'bm_heavy'
+    _tarfile = 'bm_heavy.tar'
+    ds_count = 0
+
+    setup_cache = save_heavy_hierarchy.setup_cache
+
+    def setup(self):
+        tempdir, ds_path = _extract_tar(
+            self._tarfile, self.dsname, self.__class__)
+        self.remove_paths.append(tempdir)
+        self.ds = Dataset(ds_path)
+
+    def time_run(self):
+        """run() that creates files in 2 subs (no inner git commits)."""
+        self.ds.run(
+            'echo new > sub00/new_file.txt && echo new > sub05/new_file.txt',
+            result_renderer='disabled')

--- a/changelog.d/20260407_cfg_proc_install.md
+++ b/changelog.d/20260407_cfg_proc_install.md
@@ -1,0 +1,5 @@
+### 🚀 Enhancements and New Features
+
+- Add `--cfg-proc` option to `install`, `clone`, and `get` to run configuration procedures on datasets post-installation.
+  Fixes [#7468](https://github.com/datalad/datalad/issues/7468) via [PR #7477](https://github.com/datalad/datalad/pull/7477)
+  (by [@bpinsard](https://github.com/bpinsard))

--- a/changelog.d/pr-7839.md
+++ b/changelog.d/pr-7839.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- NF+BM: extend create_test_dataset spec, add save/run benchmarks on heavy hierarchies.  [PR #7839](https://github.com/datalad/datalad/pull/7839) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -217,6 +217,15 @@ class Clone(Interface):
             because both a regular branch and the git-annex branch are
             required. Note that a version in a RIA URL takes precedence over
             '--branch'."""),
+        cfg_proc=Parameter(
+            args=("-c", "--cfg-proc"),
+            metavar="PROC",
+            action='append',
+            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
+            on the installed dataset. Use
+            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
+            to get a list of available procedures, such as cfg_text2git.
+            """),
         description=location_description,
         reckless=reckless_opt,
         message=save_message_opt,
@@ -234,6 +243,7 @@ class Clone(Interface):
             description=None,
             reckless=None,
             message=None,
+            cfg_proc=None,
         ):
         # did we explicitly get a dataset to install into?
         # if we got a dataset, path will be resolved against it.
@@ -327,6 +337,7 @@ class Clone(Interface):
                 result_props,
                 cfg=None if ds is None else ds.config,
                 clone_opts=git_clone_opts,
+                cfg_proc=cfg_proc,
                 ):
             if r['status'] in ['error', 'impossible']:
                 clone_failure = True
@@ -412,7 +423,8 @@ def clone_dataset(
         result_props=None,
         cfg=None,
         checkout_gitsha=None,
-        clone_opts=None):
+        clone_opts=None,
+        cfg_proc=None):
     """Internal helper to perform cloning without sanity checks (assumed done)
 
     This helper does not handle any saving of subdataset modification or adding
@@ -445,6 +457,8 @@ def clone_dataset(
       Options passed to git-clone. Note that for RIA URLs, the version is
       translated to a --branch argument, and that will take precedence over a
       --branch argument included in this value.
+    cfg_proc : list of str, optional
+      List of procedures to be run on the cloned datasets.
 
     Yields
     ------
@@ -542,6 +556,15 @@ def clone_dataset(
         )
         rmtree(destds.path, children_only=dest_path_existed)
         return
+
+    from datalad.local.run_procedure import _get_proc_configs
+    cfg_proc_specs = _get_proc_configs(cfg_proc, destds) if cfg_proc else []
+    for cfg_proc_spec in cfg_proc_specs:
+        yield from destds.run_procedure(
+            cfg_proc_spec,
+            result_renderer='disabled',
+            return_type='generator',
+        )
 
     # yield successful clone of the base dataset now, as any possible
     # subdataset clone down below will not alter the Git-state of the

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -557,6 +557,7 @@ def clone_dataset(
         rmtree(destds.path, children_only=dest_path_existed)
         return
 
+    # import in function to circumvent circular import issue
     from datalad.local.run_procedure import _get_proc_configs
     cfg_proc_specs = _get_proc_configs(cfg_proc, destds) if cfg_proc else []
     for cfg_proc_spec in cfg_proc_specs:

--- a/datalad/core/distributed/clone.py
+++ b/datalad/core/distributed/clone.py
@@ -28,6 +28,7 @@ from datalad.interface.base import (
     eval_results,
 )
 from datalad.interface.common_opts import (
+    cfg_proc_opt,
     location_description,
     reckless_opt,
     save_message_opt,
@@ -217,15 +218,7 @@ class Clone(Interface):
             because both a regular branch and the git-annex branch are
             required. Note that a version in a RIA URL takes precedence over
             '--branch'."""),
-        cfg_proc=Parameter(
-            args=("-c", "--cfg-proc"),
-            metavar="PROC",
-            action='append',
-            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
-            on the installed dataset. Use
-            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
-            to get a list of available procedures, such as cfg_text2git.
-            """),
+        cfg_proc=cfg_proc_opt,
         description=location_description,
         reckless=reckless_opt,
         message=save_message_opt,

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -1754,6 +1754,14 @@ def test_url_mapping_specs():
 
 
 @with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_clone_withcfg(src_path=None, dest=None):
+    src = create(src_path)
+    ds = clone(src_path, dest, cfg_proc=['yoda'])
+    assert (ds.pathobj / 'README.md').exists()
+
+
+@with_tempfile(mkdir=True)
 def test_clone_self_referential_remote(path=None):
     """Test that cloning doesn't recurse infinitely when a remote points to itself
 

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -341,25 +341,8 @@ class Create(Interface):
             yield res
             return
 
-        # Check if specified cfg_proc(s) can be discovered, storing
-        # the results so they can be used when the time comes to run
-        # the procedure. If a procedure cannot be found, raise an
-        # error to prevent creating the dataset.
-        cfg_proc_specs = []
-        if cfg_proc:
-            discovered_procs = tbds.run_procedure(
-                discover=True,
-                result_renderer='disabled',
-                return_type='list',
-            )
-            for cfg_proc_ in cfg_proc:
-                for discovered_proc in discovered_procs:
-                    if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
-                        cfg_proc_specs.append(discovered_proc)
-                        break
-                else:
-                    raise ValueError("Cannot find procedure with name "
-                                     "'%s'" % cfg_proc_)
+        from datalad.local.run_procedure import _get_proc_configs
+        cfg_proc_specs = _get_proc_configs(cfg_proc, tbds) if cfg_proc else []
 
         if initopts is not None and isinstance(initopts, list):
             initopts = {'_from_cmdline_': initopts}

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -40,6 +40,7 @@ from datalad.interface.common_opts import (
     location_description,
     save_message_opt,
 )
+from datalad.local.run_procedure import _get_proc_configs
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
     EnsureKeyChoice,
@@ -341,7 +342,6 @@ class Create(Interface):
             yield res
             return
 
-        from datalad.local.run_procedure import _get_proc_configs
         cfg_proc_specs = _get_proc_configs(cfg_proc, tbds) if cfg_proc else []
 
         if initopts is not None and isinstance(initopts, list):

--- a/datalad/core/local/create.py
+++ b/datalad/core/local/create.py
@@ -37,6 +37,7 @@ from datalad.interface.base import (
     eval_results,
 )
 from datalad.interface.common_opts import (
+    cfg_proc_opt,
     location_description,
     save_message_opt,
 )
@@ -175,16 +176,7 @@ class Create(Interface):
             doc="""Configure the repository to use fake dates. The date for a
             new commit will be set to one second later than the latest commit
             in the repository. This can be used to anonymize dates."""),
-        cfg_proc=Parameter(
-            args=("-c", "--cfg-proc"),
-            metavar="PROC",
-            action='append',
-            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
-            on the created dataset. Use
-            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
-            to get a list of available procedures, such as cfg_text2git.
-            """
-        ),
+        cfg_proc=cfg_proc_opt,
         message=save_message_opt,
     )
 

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -136,10 +136,14 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2, nfiles=1):
     RepoClass = GitRepo if random.randint(0, 1) else AnnexRepo
     lgr.info("Generating repo of class %s under %s", RepoClass, path)
     repo = RepoClass(path, create=True)
-    # Create tracked files
+    # Create tracked files.  Consume one random.randint for the first
+    # filename to preserve RNG sequence compatibility with the original
+    # code that used random filenames (callers with fixed seeds depend
+    # on the RNG producing the same dataset structure).
     fns = []
+    first_file_id = random.randint(1, 1000)
     for fi in range(nfiles):
-        fn = opj(path, "file%d.dat" % fi)
+        fn = opj(path, "file%d.dat" % (first_file_id if fi == 0 else fi))
         with open(fn, 'w') as f:
             f.write(fn)
         fns.append(fn)

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -137,11 +137,13 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2, nfiles=1):
     lgr.info("Generating repo of class %s under %s", RepoClass, path)
     repo = RepoClass(path, create=True)
     # Create tracked files
+    fns = []
     for fi in range(nfiles):
         fn = opj(path, "file%d.dat" % fi)
         with open(fn, 'w') as f:
             f.write(fn)
-    repo.add('.', git=True)
+        fns.append(fn)
+    repo.add(fns, git=True)
     repo.commit(msg="Added %d file(s)" % nfiles)
 
     yield path

--- a/datalad/distribution/create_test_dataset.py
+++ b/datalad/distribution/create_test_dataset.py
@@ -43,12 +43,38 @@ lgr = logging.getLogger('datalad.distribution.tests')
 
 
 def _parse_spec(spec):
-    out = []   # will return a list of tuples (min, max) for each layer
+    """Parse a hierarchy spec string into a list of level descriptors.
+
+    Each level is separated by ``/`` and has the form::
+
+        [d]min[-max][+Nf]
+
+    ``d`` prefix makes entries plain directories instead of subdatasets.
+    ``+Nf`` suffix adds N tracked files to each dataset at that level
+    (default: 1 file per dataset, as before).
+
+    Returns a list of dicts with keys: min, max, is_dir, nfiles.
+    """
+    out = []
     if not spec:
         return out
     for ilevel, level in enumerate(spec.split('/')):
         if not level:
             continue
+
+        is_dir = False
+        nfiles = None  # None means "use the nfiles parameter default"
+
+        # Check for +Nf suffix (e.g., "2+100f")
+        if '+' in level and level.endswith('f'):
+            level, nf_str = level.rsplit('+', 1)
+            nfiles = int(nf_str[:-1])  # strip trailing 'f'
+
+        # Check for 'd' prefix (plain directory, not subdataset)
+        if level.startswith('d'):
+            is_dir = True
+            level = level[1:]
+
         minmax = level.split('-')
         if len(minmax) == 1:  # only abs number specified
             minmax = int(minmax[0])
@@ -58,17 +84,20 @@ def _parse_spec(spec):
             if not min_:  # might be omitted entirely
                 min_ = 0
             if not max_:
-                raise ValueError("Specify max number at level %d. Full spec was: %s"
-                                 % (ilevel, spec))
+                raise ValueError(
+                    "Specify max number at level %d. Full spec was: %s"
+                    % (ilevel, spec))
             min_ = int(min_)
             max_ = int(max_)
         else:
-            raise ValueError("Must have only min-max at level %d" % ilevel)
-        out.append((min_, max_))
+            raise ValueError(
+                "Must have only min-max at level %d" % ilevel)
+
+        out.append(dict(min=min_, max=max_, is_dir=is_dir, nfiles=nfiles))
     return out
 
 
-def _makeds(path, levels, ds=None, max_leading_dirs=2):
+def _makeds(path, levels, ds=None, max_leading_dirs=2, nfiles=1):
     """Create a hierarchy of datasets
 
     Used recursively, with current invocation generating datasets for the
@@ -79,14 +108,17 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
     path : str
       Path to the top directory under which dataset will be created.
       If relative -- relative to current directory
-    levels : list of list
-      List of specifications for :func:`random.randint` call per each level.
+    levels : list of dict
+      List of level descriptors from :func:`_parse_spec`.
     ds : Dataset, optional
       Super-dataset which would contain a new dataset (thus its path would be
       a parent of path. Note that ds needs to be installed.
     max_leading_dirs : int, optional
       Up to how many leading directories within a dataset could lead to a
       sub-dataset
+    nfiles : int, optional
+      Number of files to create in each dataset (default 1).  Per-level
+      ``+Nf`` spec overrides this.
 
     Yields
     ------
@@ -104,12 +136,13 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
     RepoClass = GitRepo if random.randint(0, 1) else AnnexRepo
     lgr.info("Generating repo of class %s under %s", RepoClass, path)
     repo = RepoClass(path, create=True)
-    # let's create some dummy file and add it to the beast
-    fn = opj(path, "file%d.dat" % random.randint(1, 1000))
-    with open(fn, 'w') as f:
-        f.write(fn)
-    repo.add(fn, git=True)
-    repo.commit(msg="Added %s" % fn)
+    # Create tracked files
+    for fi in range(nfiles):
+        fn = opj(path, "file%d.dat" % fi)
+        with open(fn, 'w') as f:
+            f.write(fn)
+    repo.add('.', git=True)
+    repo.commit(msg="Added %d file(s)" % nfiles)
 
     yield path
 
@@ -118,16 +151,37 @@ def _makeds(path, levels, ds=None, max_leading_dirs=2):
         ds_ = Dataset(path)
         # Process the levels
         level, levels_ = levels[0], levels[1:]
-        nrepos = random.randint(*level)  # how many subds to generate
-        for irepo in range(nrepos):
-            # we would like to have up to 2 leading dirs
-            subds_path = opj(*(['d%i' % i
-                                for i in range(random.randint(0, max_leading_dirs+1))]
-                               + ['r%i' % irepo]))
-            subds_fpath = opj(path, subds_path)
-            # yield all under
-            for d in _makeds(subds_fpath, levels_, ds=ds_):
-                yield d
+        nchildren = random.randint(level['min'], level['max'])
+        child_nfiles = level.get('nfiles') or nfiles
+
+        for ichild in range(nchildren):
+            if level['is_dir']:
+                # Plain directory with files, not a subdataset
+                dirname = "dir%d" % ichild
+                dirpath = opj(path, dirname)
+                os.makedirs(dirpath, exist_ok=True)
+                for fi in range(child_nfiles):
+                    fn = opj(dirpath, "file%d.dat" % fi)
+                    with open(fn, 'w') as f:
+                        f.write(fn)
+                repo.add(dirname, git=True)
+            else:
+                # Subdataset
+                # we would like to have up to 2 leading dirs
+                subds_path = opj(
+                    *(['d%i' % i
+                       for i in range(
+                           random.randint(0, max_leading_dirs + 1))]
+                      + ['r%i' % ichild]))
+                subds_fpath = opj(path, subds_path)
+                # yield all under
+                for d in _makeds(subds_fpath, levels_, ds=ds_,
+                                 nfiles=child_nfiles):
+                    yield d
+
+        if level['is_dir']:
+            # Commit the directories we just created
+            repo.commit(msg="Added %d directories" % nchildren)
 
     if ds:
         assert ds.is_installed()
@@ -150,27 +204,46 @@ class CreateTestDataset(Interface):
         spec=Parameter(
             args=("--spec",),
             doc="""\
-            spec for hierarchy, defined as a min-max (min could be omitted to assume 0)
-            defining how many (random number from min to max) of sub-datasets to generate
-            at any given level of the hierarchy.  Each level separated from each other with /.
-            Example:  1-3/-2  would generate from 1 to 3 subdatasets at the top level, and
-            up to two within those at the 2nd level
+            spec for hierarchy.  Each level is separated by ``/`` and has
+            the form ``[d]min[-max][+Nf]``.
+
+            ``min-max`` defines how many (random from min to max)
+            sub-datasets to generate at that level (min can be omitted
+            to assume 0).
+
+            Prefix ``d`` makes entries plain directories instead of
+            subdatasets (e.g. ``d3`` creates 3 dirs with files).
+
+            Suffix ``+Nf`` creates N tracked files per entry at that
+            level (overrides --nfiles for that level).
+
+            Examples::
+
+                1-3/-2        1–3 subdatasets at L1, up to 2 at L2
+                2+100f/-2     2 subs at L1 each with 100 files, up to 2 at L2
+                10/d5+50f     10 subs, each containing 5 plain dirs with 50 files
             """,
             constraints=EnsureStr() | EnsureNone()),
         seed=Parameter(
             args=("--seed",),
             doc="""seed for rng""",
             constraints=EnsureInt() | EnsureNone()),
-
+        nfiles=Parameter(
+            args=("--nfiles",),
+            doc="""number of files to create in each dataset (default 1).
+            Per-level +Nf suffix in spec overrides this.""",
+            constraints=EnsureInt() | EnsureNone()),
     )
 
     @staticmethod
-    def __call__(path=None, *, spec=None, seed=None):
+    def __call__(path=None, *, spec=None, seed=None, nfiles=None):
         levels = _parse_spec(spec)
 
         if seed is not None:
             # TODO: if to be used within a bigger project we shouldn't seed main RNG
             random.seed(seed)
+        if nfiles is None:
+            nfiles = 1
         if path is None:
             kw = get_tempfile_kwargs({}, prefix="ds")
             path = tempfile.mkdtemp(**kw)
@@ -180,7 +253,7 @@ class CreateTestDataset(Interface):
             os.makedirs(path)
 
         # now we should just make it happen and return list of all the datasets
-        return list(_makeds(path, levels))
+        return list(_makeds(path, levels, nfiles=nfiles))
 
     @staticmethod
     def result_renderer_cmdline(res, args):

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -402,7 +402,7 @@ def _install_subds_from_flexible_source(ds, sm, **kwargs):
 
 
 def _install_necessary_subdatasets(
-        ds, path, reckless, refds_path, description=None):
+        ds, path, reckless, refds_path, description=None, cfg_proc=None):
     """Installs subdatasets of `ds`, that are necessary to obtain in order
     to have access to `path`.
 
@@ -438,7 +438,8 @@ def _install_necessary_subdatasets(
                 Dataset(cur_subds['parentds']),
                 cur_subds,
                 reckless=reckless,
-                description=description):
+                description=description,
+                cfg_proc=cfg_proc):
             if res.get('action', None) == 'install':
                 if res['status'] == 'ok':
                     # report installation, whether it helped or not
@@ -472,7 +473,8 @@ def _install_necessary_subdatasets(
 
 
 def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=None,
-                 refds_path=None, description=None, jobs=None, producer_only=False):
+                 refds_path=None, description=None, jobs=None, producer_only=False,
+                 cfg_proc=None):
     if isinstance(recursion_limit, int) and recursion_limit <= 0:
         return
     # install using helper that give some flexibility regarding where to
@@ -511,7 +513,8 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
         else:
             # TODO: here we need another "ds"!  is it within "sub"?
             yield from _install_subds_from_flexible_source(
-                Dataset(ds_path), sub, reckless=reckless, description=description)
+                Dataset(ds_path), sub, reckless=reckless, description=description,
+                cfg_proc=cfg_proc)
 
         if not subds.is_installed():
             # an error result was emitted, and the external consumer can decide
@@ -528,6 +531,7 @@ def _recursive_install_subds_underneath(ds, recursion_limit, reckless, start=Non
                 reckless=reckless,
                 refds_path=refds_path,
                 jobs=jobs,
+                cfg_proc=cfg_proc,
                 producer_only=True  # we will be adding to producer queue
         ):
             producer_consumer.add_to_producer_queue(res)
@@ -557,6 +561,7 @@ def _install_targetpath(
         refds_path,
         description,
         jobs=None,
+        cfg_proc=None,
 ):
     """Helper to install as many subdatasets as needed to verify existence
     of a target path
@@ -588,7 +593,12 @@ def _install_targetpath(
     else:
         # we don't have it yet. is it in a subdataset?
         for res in _install_necessary_subdatasets(
-                ds, target_path, reckless, refds_path, description=description):
+                ds,
+                target_path,
+                reckless,
+                refds_path,
+                description=description,
+                cfg_proc=cfg_proc):
             if (target_path.is_symlink() or target_path.exists()):
                 # this dataset brought the path, mark for annex
                 # processing outside
@@ -645,6 +655,7 @@ def _install_targetpath(
             refds_path=refds_path,
             description=description,
             jobs=jobs,
+            cfg_proc=cfg_proc,
     ):
         # yield immediately so errors could be acted upon
         # outside, before we continue
@@ -866,6 +877,15 @@ class Get(Interface):
             doc="""whether to obtain data for all file handles. If disabled, `get`
             operations are limited to dataset handles.[CMD:  This option prevents data
             for file handles from being obtained CMD]"""),
+        cfg_proc=Parameter(
+            args=("-c", "--cfg-proc"),
+            metavar="PROC",
+            action='append',
+            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
+            on the installed subdataset. Use
+            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
+            to get a list of available procedures, such as cfg_text2git.
+            """),
         description=location_description,
         reckless=reckless_opt,
         jobs=jobs_opt)
@@ -881,6 +901,7 @@ class Get(Interface):
             recursive=False,
             recursion_limit=None,
             get_data=True,
+            cfg_proc=None,
             description=None,
             reckless=None,
             jobs='auto',
@@ -950,6 +971,7 @@ class Get(Interface):
                             refds_path,
                             description,
                             jobs=jobs,
+                            cfg_proc=cfg_proc,
                     ):
                         # fish out the datasets that 'contains' a targetpath
                         # and store them for later
@@ -994,6 +1016,7 @@ class Get(Interface):
                         refds_path,
                         description,
                         jobs=jobs,
+                        cfg_proc=cfg_proc,
                 ):
                     known_ds = res['path'] in content_by_ds
                     if res.get('status', None) in ('ok', 'notneeded') and \

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -29,6 +29,7 @@ from datalad.interface.base import (
     eval_results,
 )
 from datalad.interface.common_opts import (
+    cfg_proc_opt,
     jobs_opt,
     location_description,
     reckless_opt,
@@ -877,15 +878,7 @@ class Get(Interface):
             doc="""whether to obtain data for all file handles. If disabled, `get`
             operations are limited to dataset handles.[CMD:  This option prevents data
             for file handles from being obtained CMD]"""),
-        cfg_proc=Parameter(
-            args=("-c", "--cfg-proc"),
-            metavar="PROC",
-            action='append',
-            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
-            on the installed subdataset. Use
-            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
-            to get a list of available procedures, such as cfg_text2git.
-            """),
+        cfg_proc=cfg_proc_opt,
         description=location_description,
         reckless=reckless_opt,
         jobs=jobs_opt)

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -177,6 +177,15 @@ class Install(Interface):
             args=("-g", "--get-data",),
             doc="""if given, obtain all data content too""",
             action="store_true"),
+        cfg_proc=Parameter(
+            args=("-c", "--cfg-proc"),
+            metavar="PROC",
+            action='append',
+            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
+            on the installed dataset. Use
+            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
+            to get a list of available procedures, such as cfg_text2git.
+            """),
         description=location_description,
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
@@ -198,6 +207,7 @@ class Install(Interface):
             recursion_limit=None,
             reckless=None,
             jobs="auto",
+            cfg_proc=None,
             branch=None):
 
         # normalize path argument to be equal when called from cmdline and
@@ -222,6 +232,7 @@ class Install(Interface):
             # annex_opts=annex_opts,
             reckless=reckless,
             jobs=jobs,
+            cfg_proc=cfg_proc,
         )
 
         # did we explicitly get a dataset to install into?
@@ -234,6 +245,9 @@ class Install(Interface):
             common_kwargs['dataset'] = dataset
         # pre-compute for results below
         refds_path = ds if ds is None else ds.path
+
+        # assure cfg_proc is a list (relevant if used via Python API)
+        cfg_proc = ensure_list(cfg_proc)
 
         # switch into the two scenarios without --source:
         # 1. list of URLs
@@ -389,7 +403,8 @@ class Install(Interface):
             return_type='generator',
             result_renderer='disabled',
             result_filter=None,
-            on_failure='ignore')
+            on_failure='ignore',
+            cfg_proc=cfg_proc,)
         # helper
         as_ds = YieldDatasets()
         destination_dataset = None
@@ -422,6 +437,7 @@ class Install(Interface):
                     **common_kwargs):
                 r['refds'] = refds_path
                 yield r
+
         # at this point no further post-processing should be necessary,
         # `clone` and `get` must have done that (incl. parent handling)
         # if not, bugs should be fixed in those commands

--- a/datalad/distribution/install.py
+++ b/datalad/distribution/install.py
@@ -27,6 +27,7 @@ from datalad.interface.base import (
     eval_results,
 )
 from datalad.interface.common_opts import (
+    cfg_proc_opt,
     jobs_opt,
     location_description,
     reckless_opt,
@@ -177,15 +178,7 @@ class Install(Interface):
             args=("-g", "--get-data",),
             doc="""if given, obtain all data content too""",
             action="store_true"),
-        cfg_proc=Parameter(
-            args=("-c", "--cfg-proc"),
-            metavar="PROC",
-            action='append',
-            doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
-            on the installed dataset. Use
-            [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
-            to get a list of available procedures, such as cfg_text2git.
-            """),
+        cfg_proc=cfg_proc_opt,
         description=location_description,
         recursive=recursion_flag,
         recursion_limit=recursion_limit,

--- a/datalad/distribution/tests/test_create_test_dataset.py
+++ b/datalad/distribution/tests/test_create_test_dataset.py
@@ -35,9 +35,26 @@ def test_create(outdir=None):
 
 
 def test_parse_spec():
-    eq_(_parse_spec('0/3/-1'), [(0, 0), (3, 3), (0, 1)])
-    eq_(_parse_spec('4-10'), [(4, 10)])
+    eq_(_parse_spec('0/3/-1'), [
+        dict(min=0, max=0, is_dir=False, nfiles=None),
+        dict(min=3, max=3, is_dir=False, nfiles=None),
+        dict(min=0, max=1, is_dir=False, nfiles=None),
+    ])
+    eq_(_parse_spec('4-10'), [
+        dict(min=4, max=10, is_dir=False, nfiles=None),
+    ])
     eq_(_parse_spec(''), [])
+    # Extended syntax: +Nf suffix and d prefix
+    eq_(_parse_spec('2+100f'), [
+        dict(min=2, max=2, is_dir=False, nfiles=100),
+    ])
+    eq_(_parse_spec('d3+50f'), [
+        dict(min=3, max=3, is_dir=True, nfiles=50),
+    ])
+    eq_(_parse_spec('2+10f/d4+5f'), [
+        dict(min=2, max=2, is_dir=False, nfiles=10),
+        dict(min=4, max=4, is_dir=True, nfiles=5),
+    ])
 
 
 def test_create_test_dataset():

--- a/datalad/distribution/tests/test_get.py
+++ b/datalad/distribution/tests/test_get.py
@@ -902,3 +902,15 @@ def test_get_non_existing(origin_path=None, clone_path=None):
 
     assert_result_count(res, 1, status="impossible",
                         message="path does not exist")
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_get_recursive_withcfg(src_path=None, dest=None):
+    src = create(src_path)
+    subds = src.create('subds')
+    subsubds = src.create('subds/subsubds')
+    ds = clone(src_path, dest)
+    ds.get('subds', recursive=True, cfg_proc=['yoda'])
+    assert (ds.pathobj / 'subds' / 'README.md').exists()
+    assert (ds.pathobj / 'subds' / 'subsubds' / 'README.md').exists()

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -1057,3 +1057,22 @@ def test_install_recursive_github(path=None):
     ]):
         ds = install(source=url, path=opj(path, "clone%i" % i), recursive=True)
         eq_(len(ds.subdatasets(recursive=True, state='present')), 2)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_install_withcfg(src_path=None, dest=None):
+    src = create(src_path)
+    ds = install(path=dest, source=src_path, cfg_proc=['yoda'])
+
+    assert (ds.pathobj / 'README.md').exists()
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_recursive_install_withcfg(src_path=None, dest=None):
+    src = create(src_path)
+    src.create('subds')
+    ds = install(path=dest, source=src_path, recursive=True, cfg_proc=['yoda'])
+
+    assert (ds.pathobj / 'README.md').exists()
+    assert (ds.pathobj / 'subds' / 'README.md').exists()

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -1061,14 +1061,6 @@ def test_install_recursive_github(path=None):
 
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-def test_install_withcfg(src_path=None, dest=None):
-    src = create(src_path)
-    ds = install(path=dest, source=src_path, cfg_proc=['yoda'])
-
-    assert (ds.pathobj / 'README.md').exists()
-
-@with_tempfile(mkdir=True)
-@with_tempfile(mkdir=True)
 def test_recursive_install_withcfg(src_path=None, dest=None):
     src = create(src_path)
     src.create('subds')

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -154,6 +154,16 @@ save_message_opt = Parameter(
     doc="""a description of the state or the changes made to a dataset.""",
     constraints=EnsureStr() | EnsureNone())
 
+cfg_proc_opt = Parameter(
+    args=("-c", "--cfg-proc"),
+    metavar="PROC",
+    action='append',
+    doc="""Run cfg_PROC procedure(s) (can be specified multiple times)
+    on the dataset. Use
+    [PY: `run_procedure(discover=True)` PY][CMD: run-procedure --discover CMD]
+    to get a list of available procedures, such as cfg_text2git.
+    """)
+
 message_file_opt = Parameter(
     args=("-F", "--message-file"),
     doc="""take the commit message from this file. This flag is

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -515,3 +515,25 @@ class RunProcedure(Interface):
 
         else:
             generic_result_renderer(res)
+
+
+def _get_proc_configs(names, ds):
+    """Get specifications for discovered procedures.
+
+     If not a single procedure found, raises `ValueError`
+     """
+    cfg_proc_specs = []
+    discovered_procs = ds.run_procedure(
+        discover=True,
+        result_renderer='disabled',
+        return_type='list',
+    )
+    for cfg_proc_ in names:
+        for discovered_proc in discovered_procs:
+            if discovered_proc['procedure_name'] == 'cfg_' + cfg_proc_:
+                cfg_proc_specs.append(discovered_proc)
+                break
+        else:
+            raise ValueError("Cannot find procedure with name "
+                             "'%s'" % cfg_proc_)
+    return cfg_proc_specs

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -7,6 +7,11 @@
 - python-version: '3.10'
   extra-envs: {}
 
+# Exercise the patool backend (see PR description).
+- python-version: '3.10'
+  extra-envs:
+    DATALAD_RUNTIME_USE__PATOOL: "1"
+
 - python-version: '3.10'
   # Run all tests in a single whoop here
   # We cannot have empty -A selector, so the one which always will be fulfilled


### PR DESCRIPTION
My tests were failing locally sometimes, but not others, even when CI was green. Tracked the issue down: the difference was whether or not `7z` was installed (it's installed in my dev container on Ubuntu, but not on my Fedora system).

The tests currently fail when 7z is not installed, but every job (IIUC) installs it, so CI misses these failures. 

We don't need a separate environment though, we should be able to hit our missing coverage with `DATALAD_RUNTIME_USE__PATOOL=1`. That's what this PR adds: one matrix leg (py3.10) with that env var set.

### What's broken, by patool version

| patool | Layer 1 (kwargs leak, real usage) | Layer 2 (`.lzma` fixture, tests only) |
|---|---|---|
| ≤ 2.x, 4.0.0, 4.0.1 | absent | present |
| 4.0.2+ | **present** | present |

- **Layer 1**: patool 4.0.2 added `interactive=True` to `run_checked`, which leaks through the monkey-patched `_patool_run` into `WitlessProtocol.__init__` and raises `TypeError`. That gets swallowed by a broad `except Exception` and surfaces as `PatoolError: returned non-zero exit status 100`. Affects any non-ZIP extraction.
- **Layer 2**: `create_tree` writes xz-format bytes into a `.lzma` test fixture, which patool's `extract_lzma` (`xz --format=lzma`) rejects. Test-only — real `.lzma` files are fine.

### Note

This PR is a draft because it doesn't fix the underlying issues. Its purpose is to surface them: the new leg will show red CI on every PR until either the patool backend is fixed or the `archive_utils_patool` fallback is retired.


### PR checklist

- [ ] Provide an overview of the changes you're making and explain why you're proposing them.
- [ ] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title;
  or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).
- [ ] Include `Fixes #NNN` somewhere in the description and `scriv` changelog entry if this PR addresses an existing issue.
- [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
  Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
- [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
- [ ] **Delete these instructions**. :-)

Thanks for contributing!
