### PR TITLE
CI: add matrix leg exercising the patool archive backend

### DIFF
--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -7,6 +7,11 @@
 - python-version: '3.10'
   extra-envs: {}
 
+# Exercise the patool backend (see PR description).
+- python-version: '3.10'
+  extra-envs:
+    DATALAD_RUNTIME_USE__PATOOL: "1"
+
 - python-version: '3.10'
   # Run all tests in a single whoop here
   # We cannot have empty -A selector, so the one which always will be fulfilled

--- a/tools/ci/test-jobs.yml
+++ b/tools/ci/test-jobs.yml
@@ -9,6 +9,7 @@
 
 # Exercise the patool backend (see PR description).
 - python-version: '3.10'
+  scenario: patool-backend
   extra-envs:
     DATALAD_RUNTIME_USE__PATOOL: "1"
 


### PR DESCRIPTION
My tests were failing locally sometimes, but not others, even when CI was green. Tracked the issue down: the difference was whether or not `7z` was installed (it's installed in my dev container on Ubuntu, but not on my Fedora system).

The tests currently fail when 7z is not installed, but every job (IIUC) installs it, so CI misses these failures. 

We don't need a separate environment though, we should be able to hit our missing coverage with `DATALAD_RUNTIME_USE__PATOOL=1`. That's what this PR adds: one matrix leg (py3.10) with that env var set.

### What's broken, by patool version

| patool | Layer 1 (kwargs leak, real usage) | Layer 2 (`.lzma` fixture, tests only) |
|---|---|---|
| ≤ 2.x, 4.0.0, 4.0.1 | absent | present |
| 4.0.2+ | **present** | present |

- **Layer 1**: patool 4.0.2 added `interactive=True` to `run_checked`, which leaks through the monkey-patched `_patool_run` into `WitlessProtocol.__init__` and raises `TypeError`. That gets swallowed by a broad `except Exception` and surfaces as `PatoolError: returned non-zero exit status 100`. Affects any non-ZIP extraction.
- **Layer 2**: `create_tree` writes xz-format bytes into a `.lzma` test fixture, which patool's `extract_lzma` (`xz --format=lzma`) rejects. Test-only — real `.lzma` files are fine.

### CI output

Did indeed fail. 

```
(3555 durations < 5s hidden.)
=========================== short test summary info ============================
FAILED ../datalad/tests/test_archives.py::test_compress_file[.xz-True] - patoolib.util.PatoolError: Command `["'/tmp/dl-miniconda-cg3ikbd0/bin/xz'", '-v', '-c', '--', "'fi le.dat'", '>', "'/tmp/datalad_temp_check_compress_filebdnnuazx/fi le.dat.xz'"]' returned non-zero exit status 2
FAILED ../datalad/tests/test_archives.py::test_compress_file[.xz-False] - patoolib.util.PatoolError: Command `["'/tmp/dl-miniconda-cg3ikbd0/bin/xz'", '-v', '-c', '--', "'fi le.dat'", '>', "'/tmp/datalad_temp_check_compress_filejqgy3kie/fi le.dat.xz'"]' returned non-zero exit status 2
= 2 failed, 1206 passed, 40 skipped, 2 xfailed, 1 xpassed, 2 warnings in 1459.59s (0:24:19) =
Error: Process completed with exit code 1.
```

### TODO

This PR is a draft because it doesn't fix the underlying issues. Its purpose is to surface them: the new leg will show red CI, and if we decide to go foward with this, we can fix those issues on this branch. 

- [x] Verify that CI fails (Test / test (3.10, 1) (pull_request)
- [x] give the job a more readable name
- [ ] fix patool issues
- [ ] maybe theres a way to do this without adding yet another CI job?