### PR TITLE
BF: fix AltConstraints.__or__() and Constraints.__and__() mutating operands

### DIFF
--- a/changelog.d/20260421_073108_yaroslav_halchenko_altconstraints_or_mutation.md
+++ b/changelog.d/20260421_073108_yaroslav_halchenko_altconstraints_or_mutation.md
@@ -1,0 +1,11 @@
+### 🐛 Bug Fixes
+
+- Fix `AltConstraints.__or__()` and `Constraints.__and__()` mutating
+  their left-hand operand in place and returning `self`. This caused
+  silent side effects when constraint objects defined at module level
+  (e.g. `reckless_opt`) were reused across multiple `|` or `&` chains.
+  Both operators now return a new instance, preserving the original.
+  Identified via the constraint system overhaul in
+  [datalad-next](https://github.com/datalad/datalad-next).
+  Fixes [#7164](https://github.com/datalad/datalad/issues/7164)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/support/constraints.py
+++ b/datalad/support/constraints.py
@@ -422,10 +422,9 @@ class AltConstraints(_MultiConstraint):
 
     def __or__(self, other):
         if isinstance(other, AltConstraints):
-            self.constraints.extend(other.constraints)
+            return AltConstraints(*self.constraints, *other.constraints)
         else:
-            self.constraints.append(other)
-        return self
+            return AltConstraints(*self.constraints, other)
 
     def __call__(self, value):
         e_list = []
@@ -460,10 +459,9 @@ class Constraints(_MultiConstraint):
 
     def __and__(self, other):
         if isinstance(other, Constraints):
-            self.constraints.extend(other.constraints)
+            return Constraints(*self.constraints, *other.constraints)
         else:
-            self.constraints.append(other)
-        return self
+            return Constraints(*self.constraints, other)
 
     def __call__(self, value):
         for c in (self.constraints):

--- a/datalad/tests/test_constraints.py
+++ b/datalad/tests/test_constraints.py
@@ -228,6 +228,35 @@ def test_both():
     # this should always fail
     assert_raises(ValueError, lambda: c(77.0))
 
+def test_altconstraints_or_no_mutation():
+    # __or__ must return a new instance, not mutate the left operand
+    a = ct.EnsureStr() | ct.EnsureNone()
+    assert len(a.constraints) == 2
+    b = a | ct.EnsureFloat()
+    assert len(b.constraints) == 3
+    # a must be unchanged
+    assert len(a.constraints) == 2
+    assert a is not b
+    # chaining produces a flat AltConstraints
+    c = ct.EnsureStr() | ct.EnsureNone() | ct.EnsureFloat()
+    assert len(c.constraints) == 3
+    assert isinstance(c, ct.AltConstraints)
+    # merging two AltConstraints
+    d = (ct.EnsureStr() | ct.EnsureNone()) | (ct.EnsureFloat() | ct.EnsureInt())
+    assert len(d.constraints) == 4
+
+
+def test_constraints_and_no_mutation():
+    # __and__ must return a new instance, not mutate the left operand
+    a = ct.EnsureFloat() & ct.EnsureRange(min=0, max=10)
+    assert len(a.constraints) == 2
+    b = a & ct.EnsureRange(min=1, max=5)
+    assert len(b.constraints) == 3
+    # a must be unchanged
+    assert len(a.constraints) == 2
+    assert a is not b
+
+
 def test_type_str():
     assert_equal(ct._type_str((str,)), 'str')
     assert_equal(ct._type_str(str), 'str')


### PR DESCRIPTION
These operators mutated the left-hand operand in-place and returned `self`, causing silent side effects when constraint objects defined at module level (e.g. `reckless_opt`) were reused across multiple `|` or `&` chains.

For example:
    a = EnsureStr() | EnsureNone()  # AltConstraints([Str, None])
    b = a | EnsureInt()             # mutated a! a == b == [Str, None, Int]

Now both operators return a new instance, preserving the original.

This bug was identified in datalad-next's constraint system overhaul (https://github.com/datalad/datalad-next) where the constraint framework was redesigned from scratch.

- Closes #7164
