### PR TITLE
BF: skip pointless `git push --dry-run` for special remotes in push

### DIFF
--- a/changelog.d/20260421_073136_yaroslav_halchenko_push_skip_dryrun_special.md
+++ b/changelog.d/20260421_073136_yaroslav_halchenko_push_skip_dryrun_special.md
@@ -1,0 +1,12 @@
+### 🏎 Performance
+
+- `datalad push` no longer runs a pointless `git push --dry-run` and
+  refspec computation when the target is a git-annex special remote
+  (e.g. WebDAV, S3, directory) that has no git URL. This was wasteful
+  at best and could cause errors or significant slowdowns for remotes
+  like WebDAV. The `target_is_git_remote` check is now performed before
+  the dry-run block and guards the entire dry-run + refspec computation.
+  Ported from the `push_optimize` patch in
+  [datalad-next](https://github.com/datalad/datalad-next).
+  Fixes [#6657](https://github.com/datalad/datalad/issues/6657)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -524,78 +524,90 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
     # cache repo type
     is_annex_repo = isinstance(ds.repo, AnnexRepo)
 
-    # TODO prevent this when `target` is a special remote
-    # (possibly redo) a push attempt to figure out what needs pushing
-    # do this on the main target only, and apply the result to all
-    # dependencies
-    try:
-        if _target:
-            # only do it when an explicit target was given, otherwise
-            # we can reuse the result from the auto-probing above
-            wannabe_gitpush = repo.push(
-                remote=target,
-                git_options=['--dry-run'])
-    except Exception as e:
+    # determine early whether target is a git remote (has a URL) vs a
+    # pure special remote, to skip pointless git operations on the latter
+    # (see https://github.com/datalad/datalad/issues/6657)
+    target_is_git_remote = repo.config.get(
+        'remote.{}.url'.format(target), None) is not None
+
+    if target_is_git_remote:
+        # (possibly redo) a push attempt to figure out what needs pushing
+        # do this on the main target only, and apply the result to all
+        # dependencies
+        try:
+            if _target:
+                # only do it when an explicit target was given, otherwise
+                # we can reuse the result from the auto-probing above
+                wannabe_gitpush = repo.push(
+                    remote=target,
+                    git_options=['--dry-run'])
+        except Exception as e:
+            lgr.debug(
+                'Dry-run push to check push configuration failed, '
+                'assume no configuration: %s', e)
+            wannabe_gitpush = []
+        refspecs2push = [
+            # if an upstream branch is set, go with it
+            p['from_ref']
+            if ds.config.get(
+                # refs come in as refs/heads/<branchname>
+                # need to cut the prefix
+                'branch.{}.remote'.format(p['from_ref'][11:]),
+                None) == target and ds.config.get(
+                    'branch.{}.merge'.format(p['from_ref'][11:]),
+                    None)
+            # if not, define target refspec explicitly to avoid having to
+            # set an upstream branch, which would happen implicitly from
+            # a users POV, and may also be hard to decide when publication
+            # dependencies are present
+            else '{}:{}'.format(p['from_ref'], p['to_ref'])
+            for p in wannabe_gitpush
+            # TODO: what if a publication dependency doesn't have it yet
+            # should we not attempt to push, because the main target has it?
+            if 'uptodate' not in p['operations'] and (
+                # cannot think of a scenario where we would want to push a
+                # managed branch directly, instead of the corresponding branch
+                'refs/heads/adjusted' not in p['from_ref'])
+        ]
+        # TODO this is not right with managed branches
+        active_branch = repo.get_active_branch()
+        if active_branch and is_annex_repo:
+            # we could face a managed branch, in which case we need to
+            # determine the actual one and make sure it is sync'ed with the
+            # managed one, and push that one instead. following methods can
+            # be called unconditionally
+            repo.localsync(managed_only=True)
+            active_branch = repo.get_corresponding_branch(
+                active_branch) or active_branch
+
+        if not refspecs2push and not active_branch:
+            # nothing was set up for push, and we have no active branch
+            # this is a weird one, let's confess and stop here
+            # I don't think we need to support such a scenario
+            if not active_branch:
+                yield dict(
+                    res_kwargs,
+                    status='impossible',
+                    message=
+                    'There is no active branch, cannot determine remote '
+                    'branch'
+                )
+                return
+
+        # make sure that we always push the active branch (the context for
+        # the potential path arguments) and the annex branch -- because we
+        # claim to know better than any git config
+        must_have_branches = [active_branch] if active_branch else []
+        if is_annex_repo:
+            must_have_branches.append('git-annex')
+        for branch in must_have_branches:
+            _append_branch_to_refspec_if_needed(ds, refspecs2push, branch)
+    else:
         lgr.debug(
-            'Dry-run push to check push configuration failed, '
-            'assume no configuration: %s', e)
-        wannabe_gitpush = []
-    refspecs2push = [
-        # if an upstream branch is set, go with it
-        p['from_ref']
-        if ds.config.get(
-            # refs come in as refs/heads/<branchname>
-            # need to cut the prefix
-            'branch.{}.remote'.format(p['from_ref'][11:]),
-            None) == target and ds.config.get(
-                'branch.{}.merge'.format(p['from_ref'][11:]),
-                None)
-        # if not, define target refspec explicitly to avoid having to
-        # set an upstream branch, which would happen implicitly from
-        # a users POV, and may also be hard to decide when publication
-        # dependencies are present
-        else '{}:{}'.format(p['from_ref'], p['to_ref'])
-        for p in wannabe_gitpush
-        # TODO: what if a publication dependency doesn't have it yet
-        # should we not attempt to push, because the main target has it?
-        if 'uptodate' not in p['operations'] and (
-            # cannot think of a scenario where we would want to push a
-            # managed branch directly, instead of the corresponding branch
-            'refs/heads/adjusted' not in p['from_ref'])
-    ]
-    # TODO this is not right with managed branches
-    active_branch = repo.get_active_branch()
-    if active_branch and is_annex_repo:
-        # we could face a managed branch, in which case we need to
-        # determine the actual one and make sure it is sync'ed with the
-        # managed one, and push that one instead. following methods can
-        # be called unconditionally
-        repo.localsync(managed_only=True)
-        active_branch = repo.get_corresponding_branch(
-            active_branch) or active_branch
-
-    if not refspecs2push and not active_branch:
-        # nothing was set up for push, and we have no active branch
-        # this is a weird one, let's confess and stop here
-        # I don't think we need to support such a scenario
-        if not active_branch:
-            yield dict(
-                res_kwargs,
-                status='impossible',
-                message=
-                'There is no active branch, cannot determine remote '
-                'branch'
-            )
-            return
-
-    # make sure that we always push the active branch (the context for the
-    # potential path arguments) and the annex branch -- because we claim
-    # to know better than any git config
-    must_have_branches = [active_branch] if active_branch else []
-    if is_annex_repo:
-        must_have_branches.append('git-annex')
-    for branch in must_have_branches:
-        _append_branch_to_refspec_if_needed(ds, refspecs2push, branch)
+            "Target '%s' is not a git remote, "
+            "skipping git push dry-run and refspec computation",
+            target)
+        refspecs2push = []
 
     # we know what to push and where, now dependency processing first
     for r in publish_depends:
@@ -613,10 +625,6 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
             pbars,
             got_path_arg=got_path_arg,
         )
-
-    # and lastly the primary push target
-    target_is_git_remote = repo.config.get(
-        'remote.{}.url'.format(target), None) is not None
 
     # git-annex data copy
     #


### PR DESCRIPTION
`_push()` unconditionally ran `git push --dry-run` to determine refspecs, even when the target is a git-annex special remote (e.g. WebDAV, S3, directory) that has no git URL. This was wasteful at best and could cause errors or significant slowdowns for remotes like WebDAV.

The fix moves the `target_is_git_remote` check (based on `remote.<name>.url` existence) before the dry-run block and guards the entire dry-run + refspec computation with it. For pure special remotes, the function now skips straight to publication dependencies and data transfer.

The original code even had a TODO comment acknowledging this:
  "# TODO prevent this when `target` is a special remote"

Ported from datalad-next's `push_optimize.py` patch (https://github.com/datalad/datalad-next), which replaces `_push()` entirely with a restructured version. This commit takes a more surgical approach: the same logical change but preserving the existing code structure for minimal diff on the maintenance branch.

- Closes #6657

