### PR TITLE
RF+TST: deduplicate create_sibling_ria, timeout tests, and rerun_merges setup

### DIFF
--- a/datalad/distributed/create_sibling_ria.py
+++ b/datalad/distributed/create_sibling_ria.py
@@ -64,6 +64,27 @@ from datalad.utils import (
 lgr = logging.getLogger('datalad.distributed.create_sibling_ria')
 
 
+def _parse_ria_url(url, push_url, ds_config, res_kwargs):
+    """Verify a RIA URL and return parsed components or an error result.
+
+    Returns ``(ssh_host, url_base_path, rewritten_url, local_base_path)``
+    on success or ``(None, None, None, None)`` together with a single-element
+    list of error results when the URL is invalid.  Callers that are
+    generators should yield from the error list and return.
+    """
+    try:
+        ssh_host, url_base_path, rewritten_url = \
+            verify_ria_url(push_url if push_url else url, ds_config)
+    except ValueError as e:
+        return (None, None, None, None), [get_status_dict(
+            status='error',
+            message=str(e),
+            **res_kwargs
+        )]
+    local_base_path = Path(url_path2local_path(url_base_path))
+    return (ssh_host, url_base_path, rewritten_url, local_base_path), []
+
+
 @build_doc
 class CreateSiblingRia(Interface):
     """Creates a sibling to a dataset in a RIA store
@@ -338,18 +359,11 @@ class CreateSiblingRia(Interface):
         # Note: URL parsing is done twice ATM (for top-level ds). This can't be
         # reduced to single instance, since rewriting url based on config could
         # be different for subdatasets.
-        try:
-            ssh_host, url_base_path, rewritten_url = \
-                verify_ria_url(push_url if push_url else url, ds.config)
-        except ValueError as e:
-            yield get_status_dict(
-                status='error',
-                message=str(e),
-                **res_kwargs
-            )
+        (ssh_host, url_base_path, rewritten_url, local_base_path), \
+            errs = _parse_ria_url(url, push_url, ds.config, res_kwargs)
+        if errs:
+            yield from errs
             return
-
-        local_base_path = Path(url_path2local_path(url_base_path))
 
         if ds.repo.get_hexsha() is None or ds.id is None:
             raise RuntimeError(
@@ -497,18 +511,11 @@ def _create_sibling_ria(
         storage_name = None
 
     # parse target URL
-    try:
-        ssh_host, url_base_path, rewritten_url = \
-            verify_ria_url(push_url if push_url else url, ds.config)
-    except ValueError as e:
-        yield get_status_dict(
-            status='error',
-            message=str(e),
-            **res_kwargs
-        )
+    (ssh_host, url_base_path, rewritten_url, local_base_path), \
+        errs = _parse_ria_url(url, push_url, ds.config, res_kwargs)
+    if errs:
+        yield from errs
         return
-
-    local_base_path = Path(url_path2local_path(url_base_path))
 
     git_url = decode_source_spec(
         # append dataset id to url and use magic from clone-helper:

--- a/datalad/local/tests/test_rerun_merges.py
+++ b/datalad/local/tests/test_rerun_merges.py
@@ -40,6 +40,28 @@ from datalad.tests.utils_pytest import (
 # - x_R: run commit
 
 
+def _setup_run_left_run_right(path):
+    """Create a dataset with a run on each branch merged together.
+
+    Produces the graph::
+
+        o                 d_n    (merge commit)
+        |\\
+        o |               c_r    (run on DEFAULT_BRANCH)
+        | o               b_r    (run on side)
+        |/
+        o                 a_n    (initial)
+    """
+    ds = Dataset(path).create()
+    ds_repo = ds.repo
+    ds_repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
+    ds.run("echo foo >foo")
+    ds_repo.checkout(DEFAULT_BRANCH)
+    ds.run("echo bar >bar")
+    ds_repo.merge("side", options=["-m", "Merge side"])
+    return ds, ds_repo
+
+
 @slow
 @with_tempfile(mkdir=True)
 def test_rerun_fastforwardable(path=None):
@@ -129,14 +151,7 @@ def test_rerun_fastforwardable_mutator(path=None):
 @skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_left_right_runs(path=None):
-    ds = Dataset(path).create()
-    # keep direct repo accessor to speed things up
-    ds_repo = ds.repo
-    ds_repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
-    ds.run("echo foo >foo")
-    ds_repo.checkout(DEFAULT_BRANCH)
-    ds.run("echo bar >bar")
-    ds_repo.merge("side", options=["-m", "Merge side"])
+    ds, ds_repo = _setup_run_left_run_right(path)
     # o                 d_n
     # |\
     # o |               c_r
@@ -437,14 +452,7 @@ def test_rerun_mutator_stem_nonrun_merges(path=None):
 @skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_exclude_side(path=None):
-    ds = Dataset(path).create()
-    # keep direct repo accessor to speed things up
-    ds_repo = ds.repo
-    ds_repo.checkout(DEFAULT_BRANCH, options=["-b", "side"])
-    ds.run("echo foo >foo")
-    ds_repo.checkout(DEFAULT_BRANCH)
-    ds.run("echo bar >bar")
-    ds_repo.merge("side", options=["-m", "Merge side"])
+    ds, ds_repo = _setup_run_left_run_right(path)
     # o                 d_n
     # |\
     # o |               c_r

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -524,19 +524,19 @@ def test_timeout_nothing() -> None:
     assert_true(len(timeout_queue) > 0)
 
 
-def test_timeout_stdout_stderr() -> None:
-    # Expect timeouts on stdin, stdout, stderr, and the process
-    class TestProtocol(StdOutErrCapture):
-        def __init__(self,
-                     timeout_queue: list[tuple[int, Optional[int]]]) -> None:
-            StdOutErrCapture.__init__(self)
-            self.timeout_queue = timeout_queue
-            self.counter = count()
+class _TimeoutProtocol(StdOutErrCapture):
+    def __init__(self,
+                 timeout_queue: list[tuple[int, Optional[int]]]) -> None:
+        StdOutErrCapture.__init__(self)
+        self.timeout_queue = timeout_queue
+        self.counter = count()
 
-        def timeout(self, fd: Optional[int]) -> bool:
-            self.timeout_queue.append((next(self.counter), fd))
-            return False
+    def timeout(self, fd: Optional[int]) -> bool:
+        self.timeout_queue.append((next(self.counter), fd))
+        return False
 
+
+def _run_timeout_command() -> list[tuple[int, Optional[int]]]:
     stdin_queue: Queue[Optional[bytes]] = queue.Queue()
     for i in range(12):
         stdin_queue.put(b"\x00" * 1024)
@@ -546,10 +546,16 @@ def test_timeout_stdout_stderr() -> None:
     run_command(
         py2cmd("import time;time.sleep(.5)\n"),
         stdin=stdin_queue,
-        protocol=TestProtocol,
+        protocol=_TimeoutProtocol,
         timeout=.1,
         protocol_kwargs=dict(timeout_queue=timeout_queue)
     )
+    return timeout_queue
+
+
+def test_timeout_stdout_stderr() -> None:
+    # Expect timeouts on stdout and stderr
+    timeout_queue = _run_timeout_command()
 
     # Expect at least one timeout for stdout and stderr.
     # there might be more.
@@ -560,38 +566,16 @@ def test_timeout_stdout_stderr() -> None:
 
 
 def test_timeout_process() -> None:
-    # Expect timeouts on stdin, stdout, stderr, and the process
-    class TestProtocol(StdOutErrCapture):
-        def __init__(self,
-                     timeout_queue: list[tuple[int, Optional[int]]]) -> None:
-            StdOutErrCapture.__init__(self)
-            self.timeout_queue = timeout_queue
-            self.counter = count()
-
-        def timeout(self, fd: Optional[int]) -> bool:
-            self.timeout_queue.append((next(self.counter), fd))
-            return False
-
-    stdin_queue: Queue[Optional[bytes]] = queue.Queue()
-    for i in range(12):
-        stdin_queue.put(b"\x00" * 1024)
-    stdin_queue.put(None)
-
-    timeout_queue: list[tuple[int, Optional[int]]] = []
-    run_command(
-        py2cmd("import time;time.sleep(.5)\n"),
-        stdin=stdin_queue,
-        protocol=TestProtocol,
-        timeout=.1,
-        protocol_kwargs=dict(timeout_queue=timeout_queue)
-    )
+    # Expect timeouts on stdout, stderr, and the process
+    timeout_queue = _run_timeout_command()
 
     # Expect at least one timeout for stdout and stderr.
-    # there might be more.
     sources = (1, 2)
     assert_true(len(timeout_queue) >= len(sources))
     for source in sources:
         assert_true(any(fd == source for _, fd in timeout_queue))
+    # Also expect at least one process-level timeout (fd=None)
+    assert_true(any(fd is None for _, fd in timeout_queue))
 
 
 def test_exit_3() -> None:


### PR DESCRIPTION
## Summary

Deduplication pass targeting the highest-value clones found by jscpd (37 clusters, 0.69% overall):

- 097e1c21f `RF: extract _parse_ria_url helper to deduplicate URL verification` — the identical try/except `verify_ria_url` + `url_path2local_path` block in `create_sibling_ria.py` (lines 341-354 and 500-513) is now a single `_parse_ria_url()` helper
- 7e087dbfa `TST: deduplicate timeout tests in test_nonasyncrunner` — `test_timeout_stdout_stderr` and `test_timeout_process` were 100% identical (36 lines); extracted shared `_TimeoutProtocol` and `_run_timeout_command()`; also fixed `test_timeout_process` to actually assert on process-level timeouts (`fd is None`)
- 8c88d7800 `TST: extract _setup_run_left_run_right helper in test_rerun_merges` — the 8-line merge-graph setup repeated across `test_rerun_left_right_runs` and `test_rerun_exclude_side` is now `_setup_run_left_run_right(path)`

### Skipped

RIA test setup duplication across `test_ria_basics.py` / `test_ria_git_remote.py` / `test_ora_http.py` (77 lines, 3 files) — the blocks vary enough in URL construction, layout versions, and extra parameters that a shared helper would need too many arguments and hurt readability.
