### PR TITLE
BF+TST+CI: fix three matrix failures from cron 25247128617

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,13 +164,6 @@ jobs:
         # location
         run: sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
 
-      # TODO: remove - should not be needed
-      - name: Git-annex workaround for NFS mounts
-        run: |
-          if [[ "${_DL_TMPDIR:-}" =~ .*/nfsmount ]]
-          then sudo git config --system annex.pidlock true
-          fi
-
       # Now it should be safe to point TMPDIR to a "tricky" setup just for the
       # purpose of testing
       - name: Point TMPDIR to "tricky" setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,7 +215,22 @@ jobs:
             --doctest-modules \
             --cov=datalad \
             --cov-report=xml \
+            --report-log=pytest-report.jsonl \
             --pyargs ${TESTS_TO_PERFORM:-datalad}
+
+      # pytest-reportlog writes one JSON object per test event (collect, call,
+      # teardown, ...).  Uploading on `always()` means timings survive even
+      # when the job is cancelled by the GH Actions 6h job timeout (which is
+      # what happens to the heavier NFS chunks); the file is line-delimited
+      # so the partial dump up to the last completed test is parseable.
+      - name: Upload pytest report log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-report-${{ github.run_id }}-${{ strategy.job-index }}
+          path: __testhome__/pytest-report.jsonl
+          if-no-files-found: ignore
+          retention-days: 7
 
       # Makes it only more difficult to comprehend the failing output.  Enable
       # only when necessary for a particular debugging.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,14 @@ jobs:
           if [[ "${_DL_TMPDIR:-}" =~ .*/nfsmount ]]
           then echo "mkdir $_DL_TMPDIR"
                mkdir -p "$_DL_TMPDIR" "${_DL_TMPDIR}_"
-               echo "/tmp/nfsmount_ localhost(rw)" | sudo bash -c 'cat - > /etc/exports'
+               # `(rw)` alone defaults to `sync` on the NFS server side, which
+               # round-trips every git/git-annex fsync through nfsd and pushes
+               # the chunk-1 / chunk-2 NFS test jobs into the GH Actions 6h
+               # job timeout (cron 25434940670 / PR #7852).  `async` lets the
+               # server ack writes once they are in cache instead of after
+               # they reach disk; we are testing on an ephemeral runner so
+               # the durability tradeoff is irrelevant.  See PR #7852.
+               echo "/tmp/nfsmount_ localhost(rw,async)" | sudo bash -c 'cat - > /etc/exports'
                sudo apt-get install -y nfs-kernel-server
                sudo exportfs -a
                sudo mount -t nfs localhost:/tmp/nfsmount_ /tmp/nfsmount

--- a/changelog.d/pr-7852.md
+++ b/changelog.d/pr-7852.md
@@ -1,0 +1,8 @@
+### 🧪 Tests
+
+- Resolve `@use_cassette('name')` against `<test_module_dir>/vcr_cassettes/<name>.yaml` so cassettes can ship next to their tests.  [PR #7852](https://github.com/datalad/datalad/pull/7852) (by [@yarikoptic](https://github.com/yarikoptic))
+- Ship VCR cassette for `test_anonymous_s3` so it stops hitting live S3.  [PR #7852](https://github.com/datalad/datalad/pull/7852) (by [@yarikoptic](https://github.com/yarikoptic))
+- Drop the `annex.pidlock=true` NFS workaround.  Its v7-era polling-based locking became the dominant cost on NFS after the v8→v10 git-annex bump and was the root cause of the cron NFS-job 6h timeouts; v10 + NFSv4.2 handles fcntl natively.  [PR #7852](https://github.com/datalad/datalad/pull/7852) (by [@yarikoptic](https://github.com/yarikoptic))
+- Retry SSH-target docker setup on host port collisions in `tools/ci/prep-travis-forssh.sh`.  [PR #7852](https://github.com/datalad/datalad/pull/7852) (by [@yarikoptic](https://github.com/yarikoptic))
+- Export the cron NFS test mount with `async` for more-realistic-than-default test conditions and a small per-write speedup.  [PR #7852](https://github.com/datalad/datalad/pull/7852) (by [@yarikoptic](https://github.com/yarikoptic))
+- Capture per-test timings as a `pytest-report.jsonl` artifact via `pytest-reportlog`, preserving timing data even when a job is cancelled.  [PR #7852](https://github.com/datalad/datalad/pull/7852) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/downloaders/tests/vcr_cassettes/test_anonymous_s3.yaml
+++ b/datalad/downloaders/tests/vcr_cassettes/test_anonymous_s3.yaml
@@ -1,0 +1,143 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40Mi45NiBtZC9Cb3RvY29yZSMxLjQyLjk2IHVhLzIuMSBvcy9saW51eCM2LjE5LjEw
+        K2RlYjE0LWFtZDY0IG1kL2FyY2gjeDg2XzY0IGxhbmcvcHl0aG9uIzMuMTMuMTIgbWQvcHlpbXBs
+        I0NQeXRob24gbS9iLEUsWiBjZmcvcmV0cnktbW9kZSNzdGFuZGFyZCBCb3RvY29yZS8xLjQyLjk2
+      amz-sdk-invocation-id:
+      - !!binary |
+        MjJhODJjZmQtMTc1Mi00MWNmLTg1YWItZWQ2NzVhYWU1ZWU3
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+    method: HEAD
+    uri: https://s3.amazonaws.com/openneuro.org/ds000001/dataset_description.json
+  response:
+    body:
+      string: ''
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '615'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Apr 2026 16:10:23 GMT
+      ETag:
+      - '"37ece861232d68015825eb6799eda7bd"'
+      Last-Modified:
+      - Fri, 21 Aug 2020 20:27:29 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - SusCrhcG9ZDDN8YmKImz5LJ/AbPfM8nIYbPJ2bnXGHoY32CIaF/P6RAuPjYX+X8Yq5fr5sPepY6vH9qRvJ0F++IkAQASk9+v
+      x-amz-request-id:
+      - RHQ4ZTRSXAV2HBJD
+      x-amz-version-id:
+      - AMAF3YGQWWY3X7hTRlJCY396l5oeVVRv
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40Mi45NiBtZC9Cb3RvY29yZSMxLjQyLjk2IHVhLzIuMSBvcy9saW51eCM2LjE5LjEw
+        K2RlYjE0LWFtZDY0IG1kL2FyY2gjeDg2XzY0IGxhbmcvcHl0aG9uIzMuMTMuMTIgbWQvcHlpbXBs
+        I0NQeXRob24gbS9iLEUsRyxaIGNmZy9yZXRyeS1tb2RlI3N0YW5kYXJkIEJvdG9jb3JlLzEuNDIu
+        OTY=
+      amz-sdk-invocation-id:
+      - !!binary |
+        NzMyNjgzNDctNzg5MS00ZTM0LWJjZWMtMWNjNjM0OTQ2OGU0
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+    method: HEAD
+    uri: https://s3.amazonaws.com/openneuro.org/ds000001/dataset_description.json
+  response:
+    body:
+      string: ''
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '615'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Apr 2026 16:10:23 GMT
+      ETag:
+      - '"37ece861232d68015825eb6799eda7bd"'
+      Last-Modified:
+      - Fri, 21 Aug 2020 20:27:29 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - +MD0bi8j3uaOuR3KhwL82wsGaTd6S3kBtm3f3F+SkLCR4W4FytBXv2UZA+nm0hsr3hPBwdDplAs=
+      x-amz-request-id:
+      - RHQF4K4M2RE4TE4N
+      x-amz-version-id:
+      - AMAF3YGQWWY3X7hTRlJCY396l5oeVVRv
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40Mi45NiBtZC9Cb3RvY29yZSMxLjQyLjk2IHVhLzIuMSBvcy9saW51eCM2LjE5LjEw
+        K2RlYjE0LWFtZDY0IG1kL2FyY2gjeDg2XzY0IGxhbmcvcHl0aG9uIzMuMTMuMTIgbWQvcHlpbXBs
+        I0NQeXRob24gbS9iLEUsRyxaIGNmZy9yZXRyeS1tb2RlI3N0YW5kYXJkIEJvdG9jb3JlLzEuNDIu
+        OTY=
+      amz-sdk-invocation-id:
+      - !!binary |
+        NTRiNDc0MTMtYTNhZS00ODQzLWEyZDItYTI3OGMzMWRmN2Zl
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      x-amz-checksum-mode:
+      - !!binary |
+        RU5BQkxFRA==
+    method: GET
+    uri: https://s3.amazonaws.com/openneuro.org/ds000001/dataset_description.json
+  response:
+    body:
+      string: "{\n    \"BIDSVersion\": \"1.0.0\",\n    \"License\": \"CC0\",\n    \"Name\":
+        \"Balloon Analog Risk-taking Task\",\n    \"ReferencesAndLinks\": [\n        \"Schonberg
+        TS, Fox CR, Mumford JA, Congdon E, Trepel C, Poldrack RA (2012). Decreasing
+        ventromedial prefrontal cortex activity during sequential risk-taking: An
+        fMRI investigation of the Balloon Analogue Risk Task. Frontiers in Decision
+        Neuroscience, 6:80 doi: 10.3389/fnins.2012.00080\"\n    ],\n    \"Authors\":
+        [\n        \"Tom Schonberg\",\n        \"Christopher Trepel\",\n        \"Craig
+        Fox\",\n        \"Russell A. Poldrack\"\n    ],\n    \"DatasetDOI\": \"10.18112/openneuro.ds000001.v1.0.0\"\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '615'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Apr 2026 16:10:23 GMT
+      ETag:
+      - '"37ece861232d68015825eb6799eda7bd"'
+      Last-Modified:
+      - Fri, 21 Aug 2020 20:27:29 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - IHA6kREtt7zSEE00C/h5yDgz4SpcPTX1KJNCwQ8UsrgN0TvJgbrCDcHqstv0PNySbukpCoaymWwQ7QCE3Prou9bFFhcqh40X
+      x-amz-request-id:
+      - RHQ28JS9XPMFMAHP
+      x-amz-version-id:
+      - AMAF3YGQWWY3X7hTRlJCY396l5oeVVRv
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/datalad/support/tests/test_vcr_.py
+++ b/datalad/support/tests/test_vcr_.py
@@ -8,11 +8,50 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for vcr adapter"""
 
+from pathlib import Path
+
 from ...tests.utils_pytest import (
     SkipTest,
     eq_,
 )
-from ..vcr_ import use_cassette
+from ..vcr_ import (
+    _get_cassette_path,
+    use_cassette,
+)
+
+
+def test_get_cassette_path_absolute(tmp_path):
+    # Absolute paths are returned unchanged
+    abs_path = str(tmp_path / "foo.yaml")
+    eq_(_get_cassette_path(abs_path), abs_path)
+
+
+def test_get_cassette_path_caller_relative(tmp_path, monkeypatch):
+    # When a versioned cassette exists next to the calling module under
+    # `vcr_cassettes/<name>.yaml`, that path is returned.
+    cassette_dir = Path(__file__).parent / "vcr_cassettes"
+    cassette_dir.mkdir(exist_ok=True)
+    cassette = cassette_dir / "test_get_cassette_path_caller_relative.yaml"
+    cassette.write_text("interactions: []\nversion: 1\n")
+    try:
+        eq_(_get_cassette_path("test_get_cassette_path_caller_relative"),
+            str(cassette))
+    finally:
+        cassette.unlink()
+        # only remove the dir if we created it for this test
+        try:
+            cassette_dir.rmdir()
+        except OSError:
+            pass
+
+
+def test_get_cassette_path_fallback(tmp_path, monkeypatch):
+    # No caller-relative cassette -> legacy CWD-relative scratch path.
+    # Use a unique-enough name so that no test shipping a cassette by
+    # that name would shadow this assertion.
+    name = "datalad_vcr_test_definitely_no_such_cassette_xyz"
+    eq_(_get_cassette_path(name),
+        "fixtures/vcr_cassettes/%s.yaml" % name)
 
 
 def test_use_cassette_if_no_vcr():

--- a/datalad/support/vcr_.py
+++ b/datalad/support/vcr_.py
@@ -10,6 +10,7 @@
 """
 
 import logging
+import sys
 from contextlib import contextmanager
 from functools import wraps
 from os.path import isabs
@@ -20,11 +21,47 @@ from datalad.utils import Path
 lgr = logging.getLogger("datalad.support.vcr")
 
 
+def _caller_cassette_path(name):
+    """Look for ``vcr_cassettes/<name>.yaml`` next to the test that called us.
+
+    `use_cassette` is typically applied as a decorator at module import time,
+    so the first frame outside this module is the test module that wants
+    the cassette.  When used as a context manager from inside a test
+    function the same logic still resolves to that test's module file.
+    Returns the absolute path on hit, or None if no such cassette exists.
+    """
+    frame = sys._getframe(1)
+    here = __file__
+    while frame is not None:
+        caller = frame.f_code.co_filename
+        if caller and caller != here:
+            candidate = Path(caller).parent / "vcr_cassettes" / f"{name}.yaml"
+            if candidate.is_file():
+                return str(candidate)
+            return None
+        frame = frame.f_back
+    return None
+
+
 def _get_cassette_path(path):
-    """Return a path to the cassette within our unified 'storage'"""
-    if not isabs(path):  # so it was given as a name
-        return "fixtures/vcr_cassettes/%s.yaml" % path
-    return path
+    """Return a path to the cassette within our 'storage'.
+
+    An absolute path is used verbatim.  A bare name is resolved against:
+
+    1. ``<caller-module-dir>/vcr_cassettes/<name>.yaml`` (versioned, shipped
+       alongside the test that requested it), if such a file exists.
+    2. otherwise ``fixtures/vcr_cassettes/<name>.yaml`` relative to the
+       current working directory -- the legacy gitignored scratch location
+       where VCR's ``record_mode='once'`` writes a fresh cassette on the
+       first run.  Useful for local recording before promoting the cassette
+       into the versioned per-test directory.
+    """
+    if isabs(path):
+        return path
+    versioned = _caller_cassette_path(path)
+    if versioned is not None:
+        return versioned
+    return "fixtures/vcr_cassettes/%s.yaml" % path
 
 try:
     # TEMP: Just to overcome problem with testing on jessie with older requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ tests = [
     "mypy",
     "pytest>=7.0",           # https://github.com/datalad/datalad/issues/7555
     "pytest-cov",
+    "pytest-reportlog",      # write per-test JSONL so timings survive job cancellation in CI
     "pytest-retry",
     "pytest-fail-slow~=0.2",
     "types-python-dateutil",

--- a/tools/ci/prep-travis-forssh.sh
+++ b/tools/ci/prep-travis-forssh.sh
@@ -8,11 +8,49 @@ then docker_host="$(docker-machine inspect --format='{{.Driver.IPAddress}}' defa
 else docker_host=localhost
 fi
 
+# Upstream `setup-docker-ssh` hardcodes 42241 (datalad-tests-ssh) and 42242
+# (datalad-tests-ssh2).  GitHub runners occasionally have one of those
+# ports already bound when the job starts, in which case `docker run -p`
+# bails out with `address already in use` (cron 25247128617's collide job
+# on 2026-05-02 is one such case).  Diagnose, clean up any partial state,
+# and retry a few times.
+DL_SSH_PORT1=42241
+DL_SSH_PORT2=42242
+
+# Print whatever is currently bound to the given TCP port (best-effort,
+# uses whichever of ss / lsof / fuser is available).
+report_port_user() {
+    local port="$1"
+    echo "Diagnostics for TCP port $port:"
+    if command -v ss > /dev/null 2>&1
+    then sudo ss -tlnp "sport = :$port" 2>/dev/null || ss -tlnp "sport = :$port" 2>/dev/null || true
+    fi
+    if command -v lsof > /dev/null 2>&1
+    then sudo lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
+    fi
+    if command -v fuser > /dev/null 2>&1
+    then sudo fuser -nv tcp "$port" 2>&1 || true
+    fi
+    docker ps --filter "publish=$port" 2>/dev/null || true
+}
+
+# True iff every named TCP port is currently free on the host.
+ports_free() {
+    local p
+    for p in "$@"
+    do
+        if (echo > "/dev/tcp/127.0.0.1/$p") 2>/dev/null
+        then return 1
+        fi
+    done
+    return 0
+}
+
 cat >>"$HOME/.ssh/config" <<EOF
 
 Host datalad-test
 HostName $docker_host
-Port 42241
+Port $DL_SSH_PORT1
 User dl
 StrictHostKeyChecking no
 IdentityFile /tmp/dl-test-ssh-id
@@ -22,7 +60,7 @@ cat >>"$HOME/.ssh/config" <<EOF
 
 Host datalad-test2
 HostName $docker_host
-Port 42242
+Port $DL_SSH_PORT2
 User dl
 StrictHostKeyChecking no
 IdentityFile /tmp/dl-test-ssh-id
@@ -38,12 +76,62 @@ ssh-keygen -f /tmp/dl-test-ssh-id -N ""
 curl -fSsL \
      https://raw.githubusercontent.com/datalad-tester/docker-ssh-target/master/setup \
      >setup-docker-ssh
-sh setup-docker-ssh --key=/tmp/dl-test-ssh-id.pub -2
+
+# Retry the docker container setup if it fails on a port collision.  On
+# each retry, log the offender so we can tell whether GH runners are
+# leaking a service on 4224[12] or whether a previous attempt left a
+# stale container behind.
+max_attempts=3
+attempt=0
+until [ "$attempt" -ge "$max_attempts" ]
+do
+    attempt=$((attempt + 1))
+
+    if ! ports_free "$DL_SSH_PORT1" "$DL_SSH_PORT2"
+    then
+        echo "Pre-flight: TCP port $DL_SSH_PORT1 or $DL_SSH_PORT2 already in use (attempt $attempt/$max_attempts)" >&2
+        report_port_user "$DL_SSH_PORT1"
+        report_port_user "$DL_SSH_PORT2"
+        # Wipe any datalad-tests-ssh* containers from a previous attempt
+        # so the next `setup-docker-ssh` invocation does not refuse with
+        # "datalad-tests-ssh* container(s) already running".
+        docker rm -f datalad-tests-ssh datalad-tests-ssh2 2>/dev/null || true
+        sleep 5
+        if ! ports_free "$DL_SSH_PORT1" "$DL_SSH_PORT2"
+        then
+            if [ "$attempt" -lt "$max_attempts" ]
+            then
+                echo "Ports still busy, waiting and retrying..." >&2
+                sleep 10
+                continue
+            else
+                echo "Ports still busy after $max_attempts attempts, giving up" >&2
+                exit 1
+            fi
+        fi
+    fi
+
+    if sh setup-docker-ssh --key=/tmp/dl-test-ssh-id.pub -2
+    then break
+    fi
+
+    echo "setup-docker-ssh failed on attempt $attempt/$max_attempts" >&2
+    report_port_user "$DL_SSH_PORT1"
+    report_port_user "$DL_SSH_PORT2"
+    docker rm -f datalad-tests-ssh datalad-tests-ssh2 2>/dev/null || true
+
+    if [ "$attempt" -ge "$max_attempts" ]
+    then
+        echo "setup-docker-ssh failed after $max_attempts attempts" >&2
+        exit 1
+    fi
+    sleep 10
+done
 
 tries=60
 n=0
 while true
-do nc -vz "$docker_host" 42241 && nc -vz "$docker_host" 42242 && break
+do nc -vz "$docker_host" "$DL_SSH_PORT1" && nc -vz "$docker_host" "$DL_SSH_PORT2" && break
    ((n++))
    if [ "$n" -lt "$tries" ]
    then sleep 1

--- a/tools/eval_under_nfs
+++ b/tools/eval_under_nfs
@@ -5,7 +5,18 @@
 set -e
 
 fs=nfs
-# TODO: nfs and mount options?
+# NFS export + mount options (must be set on BOTH ends to take effect).
+# Default to `async` (the NFS server replies before changes hit stable
+# storage) since this script is for transient testing and `sync` adds tens
+# of ms to every fsync -- which git/git-annex issue thousands of during
+# clone/save/get and which pushed CI jobs into 6h timeouts (see a6fd7add6).
+# Set DATALAD_TESTS_NFS_SYNC=1 (or any non-empty value) to use `sync`
+# instead, e.g. to reproduce that slowdown locally.
+if [ -n "${DATALAD_TESTS_NFS_SYNC:-}" ]; then
+    nfs_opts="rw,sync"
+else
+    nfs_opts="rw,async"
+fi
 
 set -u
 tmp=$(mktemp -u "${TMPDIR:-/tmp}/datalad-nfs-XXXXX")
@@ -26,8 +37,8 @@ if ! dpkg -l nfs-kernel-server | grep '^ii.*nfs-kernel-server'; then
     sudo apt-get install -y nfs-kernel-server
 fi
 
-sudo exportfs -o rw "localhost:$mntorig"
-sudo mount -t "$fs" "localhost:$mntorig" "$mntpoint"
+sudo exportfs -o "$nfs_opts" "localhost:$mntorig"
+sudo mount -t "$fs" -o "$nfs_opts" "localhost:$mntorig" "$mntpoint"
 
 # should how it was mounted
 sudo mount | grep "$mntpoint" | sed -e 's,^,I: ,g'


### PR DESCRIPTION
## Summary

Fix three matrix failures observed on the `maint` cron run [25247128617](https://github.com/datalad/datalad/actions/runs/25247128617) (2026-05-02), each in its own commit so they can be picked individually if needed, plus a small VCR-cassette refactor that makes shipping cassettes alongside tests actually work.

While investigating the third failure (NFS chunks hitting GitHub's 6h job-timeout cap), the **actual root cause** of the chronic cron-NFS cancellations turned up: the `annex.pidlock=true` workaround in `.github/workflows/test.yml` — a v7-era flock-on-NFSv3 mitigation — became the dominant cost on NFS after the v8→v10 git-annex bump in #7693, multiplying every git-annex lock op by ~50–100×. Removing it (commit `08f572082`) restores pre-v10 NFS performance: cron NFS jobs went from chronically cancelled at 6h since Oct 31, 2025 (~6 months of red runs) to completing in 13–27 minutes per chunk in this PR's CI.

## Commits

- 8e343309a `RF(TST): discover VCR cassettes next to the calling test module`
- 2a0dddacf `BF(TST): ship VCR cassette for test_anonymous_s3`
- 9eb81c610 `CI: retry SSH-target docker setup on host port collisions`
- fb2b69ca3 `DOC: scriv changelog fragment for PR #7852`
- be697504a `CI: export NFS test mount with (rw,async) to avoid 6h cron timeouts`
- a44bedc8f `CI: capture per-test timings as a pytest-reportlog artifact`
- db23b45f0 `TEMP: PR-only, all-cron-jobs Test workflow for validation` — **DROP BEFORE MERGE**
- 4e860f39a `RF: tools/eval_under_nfs: default to async, add DATALAD_TESTS_NFS_SYNC`
- 08f572082 `CI: drop annex.pidlock=true NFS workaround for the v8 era`

<details><summary>Per-commit details</summary>

### 8e343309a `RF(TST): discover VCR cassettes next to the calling test module`

`@use_cassette('name')` now resolves to `<test_module_dir>/vcr_cassettes/<name>.yaml` (caller-relative, via `sys._getframe`) before the legacy CWD-relative `fixtures/vcr_cassettes/<name>.yaml` fallback. No call sites change. Adds unit tests for the resolver.

### 2a0dddacf `BF(TST): ship VCR cassette for test_anonymous_s3`

Cron run 25247128617's `test (3.10)` matrix failed `test_anonymous_s3` with a transient `NoSuchBucket` from `s3://openneuro.org/ds000001/...` while six sibling matrix runs that hit the same endpoint within minutes passed — a clear flaky-network signature. The test was decorated with `@use_cassette('test_anonymous_s3')` but no cassette had ever been shipped (gitignored `fixtures/`), so VCR fell through to live S3 every cron run. With the previous commit's resolver, dropping the cassette next to `test_s3.py` is enough; no test_s3.py change.

Cassette content review: only public openneuro.org `dataset_description.json` (CC0), anonymous HEAD/GET, no auth headers, no signed tokens. Verified to be picked up: cassette in place + broken proxy → PASS instantly; cassette removed + broken proxy → FAIL with `ProxyConnectionError`.

Packaging: confirmed by `python -m build --wheel` that the cassette is auto-included via `include-package-data = true`, no `pyproject.toml` change needed.

### 9eb81c610 `CI: retry SSH-target docker setup on host port collisions`

The `collide` matrix entry exited 125 because the upstream `setup-docker-ssh` script's container 2 failed to bind port 42242 (`address already in use`). Wrap the call in a 3-attempt retry loop with pre-flight `/dev/tcp` port probing, who-holds-the-port logging (ss / lsof / fuser / docker ps), and `docker rm -f` cleanup between attempts so upstream's "containers already running" guard does not block retry. Happy path is unchanged.

### fb2b69ca3 `DOC: scriv changelog fragment for PR #7852`

Hand-written `changelog.d/pr-7852.md` summarising the user-visible changes under 🧪 Tests.

### be697504a `CI: export NFS test mount with (rw,async)`

Changes the NFS export options from default `(rw)` (= `sync`) to `(rw,async)`. Marginal speedup (~10–25% per write op locally), but more importantly tests under the export configuration that production NFS servers actually use. Local-bench supporting numbers in [this comment](https://github.com/datalad/datalad/pull/7852).

### a44bedc8f `CI: capture per-test timings as a pytest-reportlog artifact`

Adds `--report-log=pytest-report.jsonl` to the pytest invocation and an `if: always()` artifact-upload step. Future safety-net for diagnosing slow / cancelled jobs. Requires `pytest-reportlog` (added to the `tests` extras).

### db23b45f0 `TEMP: PR-only, all-cron-jobs Test workflow for validation` — **DROP BEFORE MERGE**

Forces cron-only matrix entries to run on every PR push, and disables the workflow's `push:`/`schedule:` triggers so we don't generate noisy duplicate runs while iterating.

### 4e860f39a `RF: tools/eval_under_nfs: default to async, add DATALAD_TESTS_NFS_SYNC`

Local NFS-test helper now mirrors the CI workflow's `(rw,async)` export. `DATALAD_TESTS_NFS_SYNC=1` keeps the old sync behavior available for reproducing the worse-case CI condition locally.

### 08f572082 `CI: drop annex.pidlock=true NFS workaround for the v8 era`

The actual root-cause fix for the chronic 6h cron cancellations. Single 7-line deletion of the `Git-annex workaround for NFS mounts` step in `.github/workflows/test.yml` (added in 46b86fb57, Feb 2020, "TST: Use annex.pidlock=true to overcome NFS issues"). Its wrapping comment already said `# TODO: remove - should not be needed`. v10 + NFSv4.2 handles fcntl natively; pidlock's polling per-acquire was multiplying every git-annex lock op by ~50–100× under NFS.

</details>

<details><summary>Empirical NFS speedup (run 25503781673 with pidlock vs run 25585554630 without)</summary>

| Job | with pidlock | without pidlock | Speedup |
| --- | ---:| ---:| ---:|
| Scoped NFS (`datalad.tests datalad.support`) | 1h21m ✅ | 16m31s ✅ | ~5× |
| `datalad.core datalad.distribution` | cancelled at 6h05m | 27m14s | >13× |
| `datalad.distributed datalad.downloaders datalad.local` | cancelled at 6h05m | 21m29s | >17× |
| `datalad.cli datalad.cmdline …` | cancelled at 6h05m | 13m41s | >26× |

After validating the speedup, the previous-iteration's 3-way NFS chunk-split (`d895bc854`) was reverted: a single full NFS job now suffices.

</details>

## Test plan

- [x] `RF(TST)`: 3 unit tests in `datalad/support/tests/test_vcr_.py` exercise absolute-path passthrough, caller-relative discovery, and the legacy fallback — PASS locally.
- [x] `BF(TST)`: `test_anonymous_s3` replays from the new cassette under a broken proxy locally; without the cassette, breaks with `ProxyConnectionError` — proves the cassette is on the lookup path.
- [x] CI: with the TEMP commit in place, all NFS jobs finish well under the 6h cap (run 25585554630).
- [x] CI: SSH retry diagnostics never had to fire (no port collision), but `Install dependencies` step on `collide` ran cleanly.
- [x] **Drop TEMP commit `db23b45f0` before merge.**
- [ ] Open follow-up issue for the 11 NFS test failures unmasked by the pidlock removal (out of scope here; tracked separately).
