### PR TITLE
BF: save - error out on path arguments that did not match any file

### DIFF
--- a/changelog.d/20260504_130540_yaroslav_halchenko_save_404_error.md
+++ b/changelog.d/20260504_130540_yaroslav_halchenko_save_404_error.md
@@ -1,0 +1,11 @@
+### 🐛 Bug Fixes
+
+- `save` now emits an `error` result record for each path argument that
+  does not match any file known to git and does not exist on the
+  filesystem, instead of silently exiting with success. This restores
+  behavior in line with `git add` / `git commit` and the now-removed
+  `datalad add`. Mixed invocations (some matching paths, some not) save
+  the matching paths and still exit non-zero.
+  Fixes [#7840](https://github.com/datalad/datalad/issues/7840) and
+  [#3844](https://github.com/datalad/datalad/issues/3844)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -22,6 +22,7 @@ from datalad.distribution.dataset import (
     EnsureDataset,
     datasetmethod,
     require_dataset,
+    resolve_path,
 )
 from datalad.interface.base import (
     Interface,
@@ -219,6 +220,13 @@ class Save(Interface):
 
         # use status() to do all discovery and annotation of paths
         paths_by_ds = {}
+        # When path arguments were given, track every path Status() reported
+        # (ok/clean/error/deleted/...). Used below to detect input paths that
+        # did not match anything known to git (gh-7840, gh-3844): `git
+        # ls-files` silently drops such paths, so we have to flag them here.
+        # Skip allocating/populating the set when no path was passed -- save's
+        # most common invocation -- to avoid any per-record overhead.
+        seen_status_paths = set() if path else None
         for s in Status()(
                 # ATTN: it is vital to pass the `dataset` argument as it,
                 # and not a dataset instance in order to maintain the path
@@ -236,6 +244,8 @@ class Save(Interface):
                 # below
                 #on_failure='ignore',
                 result_renderer='disabled'):
+            if seen_status_paths is not None:
+                seen_status_paths.add(ut.Path(s['path']))
             if s['status'] == 'error':
                 # Downstream code can't do anything with these. Let the caller
                 # decide their fate.
@@ -251,6 +261,44 @@ class Save(Interface):
                      'path', 'parentds', 'refds', 'status', 'action',
                      'logger')}
             paths_by_ds[s['parentds']] = ds_status
+
+        # For each input path, yield an `error` record if it matched neither a
+        # `git ls-files`-reported path (Status yielded nothing for it) nor an
+        # existing on-disk entry. Without this, `datalad save typo_path` exits
+        # 0 silently, which has bitten users in scripted contexts (gh-7840,
+        # gh-3844). Mirrors `git add` / `git commit` on `pathspec did not
+        # match any file(s)`.
+        # Performance: per-path work is O(1) (set lookup + one stat); the
+        # parents-of-seen set is built lazily, only on the rare deleted-
+        # directory case (`rm -rf d; datalad save d`).
+        ancestor_paths = None
+        for p in path:
+            resolved = resolve_path(p, dataset)
+            if resolved in seen_status_paths:
+                # Status reported this path directly (clean/modified/deleted
+                # /untracked/error/...).
+                continue
+            if resolved.exists() or resolved.is_symlink():
+                # legitimate untracked or clean tree element; not unmatched.
+                continue
+            if ancestor_paths is None:
+                ancestor_paths = set()
+                for sp in seen_status_paths:
+                    ancestor_paths.update(sp.parents)
+            if resolved in ancestor_paths:
+                # a directory whose individual contents were reported (e.g.
+                # the `rm -rf d` case above where Status sees deletions).
+                continue
+            yield dict(
+                action='save',
+                refds=ds.path,
+                type='file',
+                path=str(resolved),
+                status='error',
+                message=("path %r did not match any file(s) known to git",
+                         str(p)),
+                logger=lgr,
+            )
 
         lgr.debug('Determined %i datasets for saving from input arguments',
                   len(paths_by_ds))

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -1212,3 +1212,82 @@ def test_check_for_openfiles_invalid_config(tmp_path):
     ):
         with assert_raises(ValueError):
             ds.repo._check_for_openfiles({'dummy.txt': {}}, 'bogus')
+
+
+@with_tempfile(mkdir=True)
+def test_save_unmatched_path(path=None):
+    # gh-7840 / gh-3844: a path argument that does not match any file
+    # known to git and does not exist on disk must produce an error
+    # record so save exits non-zero (mirroring `git add`/`git commit`).
+    ds = Dataset(path).create(annex=False)
+    (ds.pathobj / 'real_file').write_text('hi')
+    ds.save(message='initial')
+
+    # 1) sole nonexistent path -> error result, no save happens
+    res = ds.save(path='nope', message='m', on_failure='ignore',
+                  result_renderer='disabled')
+    assert_in_results(
+        res,
+        action='save',
+        status='error',
+        path=str(ds.pathobj / 'nope'),
+    )
+    # the original input path is included in the rendered message
+    err = [r for r in res if r['status'] == 'error'][0]
+    assert_in('nope', err['message'][1] if isinstance(err['message'], tuple)
+              else err['message'])
+
+    # 2) mixed existing+nonexistent: existing one is saved, error is reported
+    (ds.pathobj / 'real_file').write_text('changed')
+    res = ds.save(path=['real_file', 'no_such_path'], message='m',
+                  on_failure='ignore', result_renderer='disabled')
+    assert_in_results(res, action='save', status='error',
+                      path=str(ds.pathobj / 'no_such_path'))
+    assert_in_results(res, action='add', status='ok',
+                      path=str(ds.pathobj / 'real_file'))
+
+    # 3) existing empty directory is NOT flagged as unmatched
+    (ds.pathobj / 'empty_dir').mkdir()
+    res = ds.save(path='empty_dir', message='m', on_failure='ignore',
+                  result_renderer='disabled')
+    assert_result_count(res, 0, status='error')
+
+    # 4) existing clean tracked file is NOT flagged as unmatched
+    res = ds.save(path='real_file', message='m', on_failure='ignore',
+                  result_renderer='disabled')
+    assert_result_count(res, 0, status='error')
+
+    # 5) outside-refds path is reported once (by status), not duplicated by save
+    bogus = op.join(op.dirname(path), 'definitely_not_in_refds_xxx')
+    res = ds.save(path=bogus, message='m', on_failure='ignore',
+                  result_renderer='disabled')
+    # exactly one error, coming from status (not a save-side duplicate)
+    errs = [r for r in res if r['status'] == 'error']
+    eq_(len(errs), 1)
+    eq_(errs[0]['action'], 'status')
+
+    # 6) nonexistent paths inside a subdataset and a sub-subdataset are
+    #    detected and reported with the resolved path (covers nested-dataset
+    #    sorting via Status's get_paths_by_ds).
+    sub = ds.create('sub')
+    subsub = sub.create(op.join('sub', 'subsub'))  # noqa: F841
+    res = ds.save(path=op.join('sub', 'subsub', 'no_such_thing'),
+                  message='m', on_failure='ignore', result_renderer='disabled')
+    assert_in_results(
+        res, action='save', status='error',
+        path=str(ds.pathobj / 'sub' / 'subsub' / 'no_such_thing'))
+    res = ds.save(path=op.join('sub', 'no_such_thing_in_sub'), message='m',
+                  on_failure='ignore', result_renderer='disabled')
+    assert_in_results(
+        res, action='save', status='error',
+        path=str(ds.pathobj / 'sub' / 'no_such_thing_in_sub'))
+
+    # 7) deleted directory (whole tree removed from disk) is NOT flagged as
+    #    unmatched: Status reports its individual deletions, save commits them.
+    (ds.pathobj / 'gone' / 'a').mkdir(parents=True)
+    (ds.pathobj / 'gone' / 'a' / 'inner.txt').write_text('x')
+    ds.save(message='setup gone-tree')
+    rmtree(str(ds.pathobj / 'gone'))
+    res = ds.save(path='gone', message='m', on_failure='ignore',
+                  result_renderer='disabled')
+    assert_result_count(res, 0, status='error')


### PR DESCRIPTION
`datalad save <typo_path>` used to exit 0 silently with no record at all, because `git ls-files` (the engine behind `Status`/`diffstatus`) silently drops pathspecs that match nothing.  This bit users in scripted contexts, e.g. when forgetting `-m` and accidentally passing the message as a path, or when shell expansion produced an unintended positional argument: the script kept going under the impression that the save had succeeded.

After the Status() loop, walk each input path argument and emit a `save(error)` record for any path that:

  * was not reported by Status (no clean/modified/deleted/untracked /error record for that exact path), AND
  * does not exist on the filesystem (and is not a symlink), AND
  * has no Status-reported descendant (the `rm -rf d; datalad save d` case, where Status sees the individual deletions under `d`).

The standard `_process_results` machinery turns those into a non-zero exit code via `IncompleteResultsError`, mirroring `git add` / `git commit` semantics on `pathspec did not match any file(s)`. With save's default `on_failure='continue'` a mixed call like `datalad save existing_file typo_path` saves the existing file and still exits non-zero.

Performance:
  * No path argument given (the most common invocation): the tracking set stays None, no Path() allocation per Status record, no per-path loop -- zero overhead vs. before.
  * Per input path: one resolve_path + one set lookup + one stat; the parents-of-seen ancestor set is built lazily and only on the rare deleted-directory case, then reused across all paths.

Earlier partial work in 15a30a467 ("Return error results on encountering invalid paths", 2022) fixed the same class of bug for the `--annex` codepath via `git ls-files --error-unmatch`; its commit message explicitly noted that the plain-git path was still silent and should be addressed.  This change closes that gap for `save`.

- Fixes #7840
- Partially addresses #3844

Made with claude code (commit has co-authorship header)

TODOs:
- [ ] see how CI reacts, in particular on benchmarks
- [ ] adjust commit message that it is only partial fix for #3844
- [ ] try and improve testing on sub-datasets (potentially just RF testing to add to existing test instead of dedicated one)
- [ ] potentially look more, in the logic were we do paths "sorting", may be we could avoid additional looping etc
