### PR TITLE
BF(TST): probe filesystem capability in test_py2_unicode_command

### DIFF
--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -57,6 +57,7 @@ from datalad.tests.utils_pytest import (
     assert_status,
     create_tree,
     eq_,
+    fs_supports_filename,
     known_failure_windows,
     neq_,
     ok_,
@@ -184,6 +185,13 @@ def test_basics(path=None, nodspath=None):
 def test_py2_unicode_command(path=None):
     if not FILESYSTEM_SUPPORTS_UTF8:
         pytest.skip("requires UTF-8 filesystem encoding for unicode args")
+    # FILESYSTEM_SUPPORTS_UTF8 is a process-level encoding announcement
+    # (sys.getfilesystemencoding()), not a per-mount capability check.
+    # CrippledFS variants like vfat advertise UTF-8 (because the OS-level
+    # locale is UTF-8) yet still reject non-ASCII or trailing-space names.
+    # Probe the actual tempdir before proceeding.
+    if not fs_supports_filename(path, u"bβ0.dat"):
+        pytest.skip("filesystem under %s rejects non-ASCII names" % path)
     # Avoid OBSCURE_FILENAME to avoid windows-breakage (gh-2929).
     ds = Dataset(path).create()
     touch_cmd = "import sys; open(sys.argv[1], 'w').write('')"
@@ -194,11 +202,12 @@ def test_py2_unicode_command(path=None):
     assert_repo_status(ds.path)
     ok_exists(op.join(path, u"bβ0.dat"))
 
-    # somewhat desperate attempt to detect our own Github CI tests on a
-    # crippled filesystem (VFAT) that is so crippled that it doesn't handle
-    # what is needed here. It just goes mad with encoded bytestrings:
-    # CommandError: ''python -c '"'"'import sys; open(sys.argv[1], '"'"'"'"'"'"'"'"'w'"'"'"'"'"'"'"'"').write('"'"'"'"'"'"'"'"''"'"'"'"'"'"'"'"')'"'"' '"'"' β1 '"'"''' failed with exitcode 1 under /crippledfs/
-    if not on_windows and os.environ.get('TMPDIR', None) != '/crippledfs':  # FIXME
+    # Some CrippledFS mounts (notably vfat) accept "bβ0.dat" but still
+    # reject leading/trailing-space names like " β1 ". Probe for the
+    # worst-case name actually used below to decide whether to run this
+    # block. Subsumes the previous hardcoded TMPDIR == '/crippledfs'
+    # workaround.
+    if not on_windows and fs_supports_filename(path, u" β1 "):
         ds.run([sys.executable, "-c", touch_cmd, u"bβ1.dat"])
         assert_repo_status(ds.path)
         ok_exists(op.join(path, u"bβ1.dat"))

--- a/datalad/tests/test_tests_utils_pytest.py
+++ b/datalad/tests/test_tests_utils_pytest.py
@@ -55,6 +55,7 @@ from datalad.tests.utils_pytest import (
     assert_str_equal,
     assert_true,
     eq_,
+    fs_supports_filename,
     get_most_obscure_supported_name,
     ignore_nose_capturing_stdout,
     known_failure_githubci_win,
@@ -216,6 +217,18 @@ def test_get_most_obscure_supported_name():
     # from more complex to simpler ones
     ok_(len(OBSCURE_FILENAMES[0]) > len(OBSCURE_FILENAMES[-1]))
     print(repr(n))
+
+
+@with_tempfile(mkdir=True)
+def test_fs_supports_filename(tdir=None):
+    # A vanilla ASCII name is universally accepted, and the helper
+    # cleans up after itself.
+    assert_true(fs_supports_filename(tdir, "plain"))
+    assert_false(op.exists(op.join(tdir, "plain")))
+    # NUL byte is rejected by every filesystem and surfaces as
+    # ValueError from os.mkdir on POSIX, OSError on Windows -- the
+    # helper catches both.
+    assert_false(fs_supports_filename(tdir, "bad\x00name"))
 
 
 def test_keeptemp_via_env_variable():

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1477,6 +1477,43 @@ if not (FILESYSTEM_SUPPORTS_UTF8 := (sys.getfilesystemencoding().lower() == 'utf
 OBSCURE_FILENAME_PARTS += [' ', '.datc', ' ']
 
 
+def fs_supports_filename(tdir, name):
+    """Return True iff `name` can be created as a directory under `tdir`.
+
+    Probes actual filesystem capability rather than relying on a
+    process-level encoding announcement. CrippledFS variants (vfat,
+    exfat, etc.) reject characters and trailing spaces even when the
+    process advertises UTF-8 via ``sys.getfilesystemencoding()``, so a
+    real ``mkdir`` is the only reliable check. The created directory is
+    removed before return.
+
+    Parameters
+    ----------
+    tdir : str
+      Existing directory under which to attempt creation.
+    name : str
+      Candidate basename to probe.
+
+    Returns
+    -------
+    bool
+      True if the filesystem accepted the name (and it was cleaned up),
+      False otherwise.
+    """
+    target = opj(tdir, name)
+    try:
+        os.mkdir(target)
+    except (OSError, ValueError):
+        return False
+    try:
+        os.rmdir(target)
+    except OSError:
+        # Created but couldn't clean up -- still counts as supported,
+        # leftover lives under the caller's tempdir which is its problem.
+        pass
+    return True
+
+
 @with_tempfile(mkdir=True)
 def get_most_obscure_supported_name(tdir, return_candidates=False):
     """Return the most obscure filename that the filesystem would support under TEMPDIR


### PR DESCRIPTION
## Summary

Make `test_py2_unicode_command` filesystem-capability-aware so it stops failing on user-provided CrippledFS tempdirs (e.g. vfat).

The existing skip is guarded only by `FILESYSTEM_SUPPORTS_UTF8`, which is `sys.getfilesystemencoding().lower() == 'utf-8'` — a process-level *encoding announcement*, not a per-mount probe. On vfat the OS-level locale is UTF-8, so the gate passes, yet the filesystem still rejects characters and trailing spaces; the test then fails with `OSError([Errno 22] Invalid argument)` on names like `' β1 '`. The legacy `os.environ.get('TMPDIR', None) != '/crippledfs'` workaround at the inner block only caught the historical AppVeyor path.

## Changes

- `datalad/tests/utils_pytest.py` — new `fs_supports_filename(tdir, name)` helper. Attempts `os.mkdir` on the candidate name under `tdir`, cleans up, and reports the boolean. Catches `(OSError, ValueError)`. Pattern parallels the inner probe in `get_most_obscure_supported_name`.
- `datalad/core/local/tests/test_run.py` — after the `FILESYSTEM_SUPPORTS_UTF8` fast-path skip, also skip when the actual tempdir rejects `bβ0.dat` (the simplest unicode name used). Replace the hardcoded `'/crippledfs'` check with `fs_supports_filename(path, u" β1 ")` — the worst-case trailing-space name that vfat actually refuses.
- `datalad/tests/test_tests_utils_pytest.py` — unit test for the new helper covering accept-and-cleanup and a universally-rejected NUL-byte name.

## Why two filename probes, not one

`bβ0.dat` and `' β1 '` are not equivalent: some CrippledFS variants accept the former and reject the latter (this is what was observed on the vfat scratch dir used during development). Probing each independently allows the outer test body to run when only the trailing-space subset is rejected — strictly more coverage than a blanket skip.

## Test plan

- [x] tmpfs (default `DATALAD_TESTS_TEMP_DIR`): full `test_run.py` + `test_save.py` — passes (no change).
- [x] vfat (`DATALAD_TESTS_TEMP_DIR=<vfat mount>`): `test_py2_unicode_command` no longer fails; outer assertions run, inner trailing-space block correctly skipped.
- [x] NFS (`DATALAD_TESTS_TEMP_DIR=<nfs mount>`): full suite passes (no change).

No production code is touched — this is a test-infrastructure fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
