### PR TITLE
BF: propagate `-c` config overrides (and DATALAD_* env) to subprocesses

### DIFF
--- a/changelog.d/20260421_073152_yaroslav_halchenko_cli_config_override_propagation.md
+++ b/changelog.d/20260421_073152_yaroslav_halchenko_cli_config_override_propagation.md
@@ -1,0 +1,17 @@
+### 🐛 Bug Fixes
+
+- Propagate `datalad -c key=value` CLI config overrides and `DATALAD_*`
+  environment variables to subprocesses via Git's native
+  environment-based configuration mechanism (`GIT_CONFIG_COUNT` /
+  `GIT_CONFIG_KEY_N` / `GIT_CONFIG_VALUE_N`). Previously the overrides
+  were only stored in `datalad.cfg.overrides` and were invisible to
+  subprocesses spawned by commands like `datalad run`, so e.g.
+  `datalad -c user.name=Test run git config user.name` did not return
+  the override. Adapted near-verbatim from the `cli_configoverrides`
+  patch in
+  [datalad-next](https://github.com/datalad/datalad-next/blob/904ca6e/datalad_next/patches/cli_configoverrides.py),
+  with its `get_gitconfig_items_from_env` /
+  `set_gitconfig_items_in_env` helpers also added under
+  `datalad.config`.
+  Fixes [#4119](https://github.com/datalad/datalad/issues/4119)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/cli/helpers.py
+++ b/datalad/cli/helpers.py
@@ -23,6 +23,11 @@ from platformdirs import AppDirs
 
 from datalad import __version__
 # delay?
+from datalad.config import _update_from_env as _update_from_datalad_env
+from datalad.config import (
+    get_gitconfig_items_from_env,
+    set_gitconfig_items_in_env,
+)
 from datalad.support.exceptions import CapturedException
 from datalad.ui.utils import get_console_width
 from datalad.utils import is_interactive
@@ -277,3 +282,52 @@ def _parse_overrides_from_cmdline(cmdlineargs):
         for o in cmdlineargs.cfg_overrides
     )
     return overrides
+
+
+def parse_overrides_from_cmdline(cmdlineargs):
+    """Post CLI/env config overrides as ``GIT_CONFIG_*`` items in process ENV.
+
+    This enables their propagation to any subprocess (most importantly
+    commands spawned by ``datalad run``). The CLI's
+    ``datalad.cfg.reload(force=True)`` then picks them back up via
+    ``git config -l`` (which respects ``GIT_CONFIG_*``) plus
+    ``_update_from_env``, so process-wide config still reflects them.
+
+    Adapted near-verbatim from datalad-next; the body mirrors the upstream
+    wrapper one-to-one (no ``apply_patch`` glue is needed when this lives
+    inside core):
+
+      https://github.com/datalad/datalad-next/blob/904ca6e/datalad_next/patches/cli_configoverrides.py
+
+    Might exit(3) the entire process if value is not assigned.
+    """
+    # read from cmdlineargs first to error on any syntax issues
+    # before any other processing
+    cli_overrides = _parse_overrides_from_cmdline(cmdlineargs)
+
+    # reuse datalad-core implementation of datalad-specific ENV parsing
+    # for config items
+    overrides = {}
+    _update_from_datalad_env(overrides)
+
+    # let CLI settings override any ENV -- in-line with the behavior of Git
+    overrides.update(cli_overrides)
+
+    # read any existing GIT_CONFIG ENV vars and superimpose our
+    # overrides on them, repost in ENV using git-native approach.
+    # This will apply the overrides to any git(-config) calls
+    # in this process and any subprocess
+    gc_overrides = get_gitconfig_items_from_env()
+    gc_overrides.update(overrides)
+    set_gitconfig_items_in_env(gc_overrides)
+
+    # we do not actually disclose any of these overrides.
+    # the CLI runs a `datalad.cfg.reload(force=True)`
+    # immediately after executing this function and thereby
+    # pulls in the overrides we just posted into the ENV
+    # here. This change reduced the scope of
+    # `datalad.cfg.overrides` to be mere instance overrides
+    # and no longer process overrides. This rectifies the mismatch
+    # between appearance and actual impact of this information
+    # in the ConfigManager
+    return {}

--- a/datalad/cli/main.py
+++ b/datalad/cli/main.py
@@ -112,9 +112,15 @@ def main(args=sys.argv):
 
     # pull config overrides from cmdline args and put in effect
     if cmdlineargs.cfg_overrides is not None:
-        from .helpers import _parse_overrides_from_cmdline
+        from .helpers import parse_overrides_from_cmdline
+
+        # parse_overrides_from_cmdline posts the overrides into the
+        # process ENV (GIT_CONFIG_*) so subprocesses inherit them, and
+        # returns {} -- the values come back into datalad.cfg via the
+        # reload below, which re-reads `git config -l` (which honors
+        # GIT_CONFIG_*) and re-runs DATALAD_* env parsing.
         datalad.cfg.overrides.update(
-            _parse_overrides_from_cmdline(cmdlineargs)
+            parse_overrides_from_cmdline(cmdlineargs)
         )
         # enable overrides
         datalad.cfg.reload(force=True)

--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -385,6 +385,22 @@ def test_librarymode(path=None):
 
 
 @with_tempfile
+def test_cli_configoverrides(path=None):
+    # See https://github.com/datalad/datalad/issues/4119
+    Dataset(path).create()
+    try:
+        run_main([
+            '-c', 'bogusdataladtestsec.subsec=unique',
+            'run', '-d', path,
+            'git config bogusdataladtestsec.subsec',
+        ])
+    finally:
+        _clean_env_from_gitconfig_items()
+        datalad.cfg.overrides.pop('bogusdataladtestsec.subsec', None)
+        datalad.cfg.reload(force=True)
+
+
+@with_tempfile
 def test_completion(out_fn=None):
     skip_if_no_module('argcomplete')
 

--- a/datalad/cli/tests/test_main.py
+++ b/datalad/cli/tests/test_main.py
@@ -23,6 +23,7 @@ from datalad.api import (
 )
 from datalad.cmd import StdOutErrCapture
 from datalad.cmd import WitlessRunner as Runner
+from datalad.config import _clean_env_from_gitconfig_items
 from datalad.interface.base import get_interface_groups
 from datalad.tests.utils_pytest import (
     SkipTest,
@@ -376,9 +377,11 @@ def test_librarymode(path=None):
                   '-d', path, '--dry-run'])
         ok_(datalad.in_librarymode())
     finally:
-        # restore pre-test behavior
+        # restore pre-test behavior; see #4119 for the env-based propagation
         datalad.__runtime_mode = was_mode
-        datalad.cfg.overrides.pop('datalad.runtime.librarymode')
+        _clean_env_from_gitconfig_items()
+        datalad.cfg.overrides.pop('datalad.runtime.librarymode', None)
+        datalad.cfg.reload(force=True)
 
 
 @with_tempfile

--- a/datalad/config.py
+++ b/datalad/config.py
@@ -20,7 +20,13 @@ from functools import (
     lru_cache,
     wraps,
 )
+from os import environ
 from pathlib import Path
+from typing import (
+    Dict,
+    Mapping,
+    Tuple,
+)
 
 from fasteners import InterProcessLock
 
@@ -236,6 +242,115 @@ def _update_from_env(store):
     if overrides:
         store.update(overrides)
     store.update(dct)
+
+
+# Adapted near-verbatim from datalad-next/datalad_next/config/utils.py
+# (https://github.com/datalad/datalad-next/blob/904ca6e/datalad_next/config/utils.py).
+# Used to round-trip CLI/env config overrides through Git's native
+# environment-based configuration mechanism so subprocesses inherit them.
+def get_gitconfig_items_from_env() -> Mapping[str, str | Tuple[str, ...]]:
+    """Parse git-config ENV (``GIT_CONFIG_COUNT|KEY|VALUE``) and return as dict
+
+    This implementation does not use ``git-config`` directly, but aims to
+    mimic its behavior with respect to parsing the environment as much
+    as possible.
+
+    Raises
+    ------
+    ValueError
+      Whenever ``git-config`` would also error out, and includes a message
+      in the respective exception that resembles ``git-config``'s for that
+      specific case.
+
+    Returns
+    -------
+    dict
+      Configuration key-value mappings. When a key is declared multiple
+      times, the respective values are aggregated and reported as a tuple
+      for that specific key.
+    """
+    items: Dict[str, str | Tuple[str, ...]] = {}
+    for k, v in ((_get_gitconfig_var_from_env(i, 'key'),
+                  _get_gitconfig_var_from_env(i, 'value'))
+                 for i in range(_get_gitconfig_itemcount())):
+        val = items.get(k)
+        if val is None:
+            items[k] = v
+        elif isinstance(val, tuple):
+            items[k] = val + (v,)
+        else:
+            items[k] = (val, v)
+    return items
+
+
+def _get_gitconfig_itemcount() -> int:
+    try:
+        return int(environ.get('GIT_CONFIG_COUNT', '0'))
+    except (TypeError, ValueError) as e:
+        raise ValueError("bogus count in GIT_CONFIG_COUNT") from e
+
+
+def _get_gitconfig_var_from_env(nid: int, kind: str) -> str:
+    envname = f'GIT_CONFIG_{kind.upper()}_{nid}'
+    var = environ.get(envname)
+    if var is None:
+        raise ValueError(f"missing config {kind} {envname}")
+    if kind != 'key':
+        return var
+    if not var:
+        raise ValueError(f"empty config key {envname}")
+    if '.' not in var:
+        raise ValueError(f"key {envname} does not contain a section: {var}")
+    return var
+
+
+def set_gitconfig_items_in_env(items: Mapping[str, str | Tuple[str, ...]]):
+    """Set git-config ENV (``GIT_CONFIG_COUNT|KEY|VALUE``) from a mapping
+
+    Any existing declaration of configuration items in the environment is
+    replaced. Any ENV variable of a *valid* existing declaration is removed,
+    before the set configuration items are posted in the ENV.
+
+    Multi-value configuration keys are supported (values provided as a tuple).
+
+    Any item with a value of ``None`` will be posted into the ENV with an
+    empty string as value, i.e. the corresponding ``GIT_CONFIG_VALUE_{count}``
+    variable will be an empty string. ``None`` item values indicate that the
+    configuration key was unset on the command line, via the global option
+    ``-c``.
+
+    No verification (e.g., of syntax compliance) is performed.
+    """
+    _clean_env_from_gitconfig_items()
+
+    count = 0
+    for key, value in items.items():
+        # homogeneous processing of multiple value items, and single values
+        values = value if isinstance(value, tuple) else (value,)
+        for v in values:
+            environ[f'GIT_CONFIG_KEY_{count}'] = key
+            # we support None even though not an allowed input type, because
+            # of https://github.com/datalad/datalad/issues/7589
+            # this can be removed, when that issue is resolved.
+            environ[f'GIT_CONFIG_VALUE_{count}'] = '' if v is None else str(v)
+            count += 1
+    if count:
+        environ['GIT_CONFIG_COUNT'] = str(count)
+
+
+def _clean_env_from_gitconfig_items():
+    # we only care about intact specifications here, if there was cruft
+    # to start with, we have no responsibilities
+    try:
+        count = _get_gitconfig_itemcount()
+    except ValueError:
+        return
+
+    for i in range(count):
+        environ.pop(f'GIT_CONFIG_KEY_{i}', None)
+        environ.pop(f'GIT_CONFIG_VALUE_{i}', None)
+
+    environ.pop('GIT_CONFIG_COUNT', None)
 
 
 def anything2bool(val):


### PR DESCRIPTION
### Disclaimer -- AI created for the goal of transferring the fix from datalad-next!

Configuration overrides specified via `datalad -c key=value` were only
stored in `datalad.cfg.overrides` (a Python dict) and never propagated
to the process environment. This meant subprocesses spawned by commands
like `datalad run` could not see these overrides.

For example, `datalad -c user.name=Test run git config user.name`
would not return `Test` because the subprocess's git did not know
about the override.

This PR adapts datalad-next's `cli_configoverrides.py` patch
near-verbatim, plus the companion env-helper utilities it relies on.

- **Patch source**:
  [`datalad-next/datalad_next/patches/cli_configoverrides.py @ 904ca6e`](https://github.com/datalad/datalad-next/blob/904ca6e/datalad_next/patches/cli_configoverrides.py)
- **Helper source** (also ported into
  [`datalad/config.py`](https://github.com/datalad/datalad/blob/bf-cli-config-override-propagation/datalad/config.py)):
  [`datalad-next/datalad_next/config/utils.py @ 904ca6e`](https://github.com/datalad/datalad-next/blob/904ca6e/datalad_next/config/utils.py)

## Structure (mirrors upstream)

The existing parser `_parse_overrides_from_cmdline` is left untouched
as the parsing-only primitive. A new wrapper
`parse_overrides_from_cmdline` is added alongside it (matching
upstream's two-name split). The wrapper:

1. Calls `_parse_overrides_from_cmdline` to obtain CLI overrides.
2. Merges in `DATALAD_*` env vars via core's existing
   `_update_from_env` (CLI wins, in line with Git semantics).
3. Superimposes the merged dict on any pre-existing
   `GIT_CONFIG_COUNT|KEY|VALUE` env vars and re-posts via Git's
   native env-based mechanism so subprocesses inherit it.
4. Returns `{}`.

The CLI caller in `datalad/cli/main.py` is updated to call the new
wrapper. Returning `{}` matches upstream:
`datalad.cfg.reload(force=True)` runs immediately after and pulls the
values back in via `git config -l` (which respects `GIT_CONFIG_*`)
plus `_update_from_env`. This reduces the scope of
`datalad.cfg.overrides` to instance-level overrides only, rectifying
the long-standing mismatch between appearance and actual impact of
that mapping in the `ConfigManager`.

## Why a wrapper, not in-place modification?

Upstream's `parse_overrides_from_cmdline` *calls* the original
`_parse_overrides_from_cmdline` for parsing rather than re-deriving
the parser body, then `apply_patch`-replaces the original symbol on
the module. We translate that pattern one-to-one into core: keep the
parsing primitive intact, add the wrapper that calls it, and update
the caller to invoke the wrapper. No monkey-patch glue needed when
the code lives inside core itself.

## Diff vs upstream — `cli_configoverrides.py` patch

<details>
<summary>Diff vs <a href="https://github.com/datalad/datalad-next/blob/904ca6e42663823d87b46ae7d4d0b6382b24a6bf/datalad_next/patches/cli_configoverrides.py">datalad-next datalad_next/patches/cli_configoverrides.py @ 904ca6e4</a></summary>

```diff
--- datalad-next:datalad_next/patches/cli_configoverrides.py (904ca6e4)
+++ datalad:/tmp/our_cli_configoverrides_extract.py
@@ -1,22 +1,20 @@
-"""Post DataLad config overrides CLI/ENV as GIT_CONFIG items in process ENV
-
-This enables their propagation to any subprocess. This includes the
-specification of overrides via the ``datalad -c ...`` option of the
-main CLI entrypoint.
-"""
-
-from datalad.config import _update_from_env as _update_from_datalad_env
-from datalad.cli.helpers import _parse_overrides_from_cmdline
-
-from datalad_next.config.utils import (
-    get_gitconfig_items_from_env,
-    set_gitconfig_items_in_env,
-)
+def parse_overrides_from_cmdline(cmdlineargs):
+    """Post CLI/env config overrides as ``GIT_CONFIG_*`` items in process ENV.
 
-from . import apply_patch
+    This enables their propagation to any subprocess (most importantly
+    commands spawned by ``datalad run``). The CLI's
+    ``datalad.cfg.reload(force=True)`` then picks them back up via
+    ``git config -l`` (which respects ``GIT_CONFIG_*``) plus
+    ``_update_from_env``, so process-wide config still reflects them.
+
+    Adapted near-verbatim from datalad-next; the body mirrors the upstream
+    wrapper one-to-one (no ``apply_patch`` glue is needed when this lives
+    inside core):
 
+      https://github.com/datalad/datalad-next/blob/904ca6e/datalad_next/patches/cli_configoverrides.py
 
-def parse_overrides_from_cmdline(cmdlineargs):
+    Might exit(3) the entire process if value is not assigned.
+    """
     # read from cmdlineargs first to error on any syntax issues
     # before any other processing
     cli_overrides = _parse_overrides_from_cmdline(cmdlineargs)
@@ -48,10 +46,3 @@
     # in the ConfigManager
     return {}
 
-
-apply_patch(
-    'datalad.cli.helpers', None, '_parse_overrides_from_cmdline',
-    parse_overrides_from_cmdline,
-    msg='Enable posting DataLad config overrides CLI/ENV as '
-    'GIT_CONFIG items in process ENV',
-)
```

</details>


## Diff vs upstream — `config/utils.py` helpers

The block ported into `datalad/config.py` is byte-identical to
upstream apart from:

1. Module-level imports replaced by a header comment (we live inside
   `datalad/config.py`, which already imports `os`; `environ`, `Dict`,
   `Mapping`, and `Tuple` are added to the existing import block at
   the top of the file rather than re-imported here).
2. Two docstring typo fixes: *"includes an message"* →
   *"includes a message"*; *"aggregated in reported"* →
   *"aggregated and reported"*.

Logic, type signatures, f-strings, and public API are preserved
verbatim.

<details>
<summary>Diff vs <a href="https://github.com/datalad/datalad-next/blob/904ca6e42663823d87b46ae7d4d0b6382b24a6bf/datalad_next/config/utils.py">datalad-next datalad_next/config/utils.py @ 904ca6e4</a></summary>

```diff
--- datalad-next:datalad_next/config/utils.py (904ca6e4)
+++ datalad:/tmp/our_config_utils_extract.py
@@ -1,13 +1,7 @@
-from __future__ import annotations
-
-from os import environ
-from typing import (
-    Dict,
-    Mapping,
-    Tuple,
-)
-
-
+# Adapted near-verbatim from datalad-next/datalad_next/config/utils.py
+# (https://github.com/datalad/datalad-next/blob/904ca6e/datalad_next/config/utils.py).
+# Used to round-trip CLI/env config overrides through Git's native
+# environment-based configuration mechanism so subprocesses inherit them.
 def get_gitconfig_items_from_env() -> Mapping[str, str | Tuple[str, ...]]:
     """Parse git-config ENV (``GIT_CONFIG_COUNT|KEY|VALUE``) and return as dict
 
@@ -18,15 +12,15 @@
     Raises
     ------
     ValueError
-      Whenever ``git-config`` would also error out, and includes an
-      message in the respective exception that resembles ``git-config``'s
-      for that specific case.
+      Whenever ``git-config`` would also error out, and includes a message
+      in the respective exception that resembles ``git-config``'s for that
+      specific case.
 
     Returns
     -------
     dict
       Configuration key-value mappings. When a key is declared multiple
-      times, the respective values are aggregated in reported as a tuple
+      times, the respective values are aggregated and reported as a tuple
       for that specific key.
     """
     items: Dict[str, str | Tuple[str, ...]] = {}
@@ -111,3 +105,4 @@
         environ.pop(f'GIT_CONFIG_VALUE_{i}', None)
 
     environ.pop('GIT_CONFIG_COUNT', None)
+
```

</details>

- Closes #4119


TODOs
- [ ] if initial 'minimal change' testing pass, meld the two (wrapper + original) within a single function