### PR TITLE
BF(TST): add signal_timeout helper and bound test_gin_cloning

### DIFF
--- a/changelog.d/pr-7859.md
+++ b/changelog.d/pr-7859.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- BF(TST): add signal_timeout helper and bound test_gin_cloning.  [PR #7859](https://github.com/datalad/datalad/pull/7859) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -70,6 +70,7 @@ from datalad.tests.utils_pytest import (
     patch_config,
     serve_path_via_http,
     set_date,
+    signal_timeout,
     skip_if_adjusted_branch,
     skip_if_no_network,
     skip_if_on_windows,
@@ -1557,12 +1558,29 @@ def test_clone_unborn_head_sub(path=None):
 
 
 @skip_if_no_network
-@pytest.mark.flaky(retries=3, delay=5, only_on=[IncompleteResultsError])
+# A 50s signal_timeout bounds slow-but-responsive gin (observed at 417s) so
+# the global --fail-slow=60 from .github/workflows/test.yml is never tripped
+# on a successful run; on expiry the resulting TimeoutError is retried by
+# @flaky, falling through to a hard fail only if the slowness persists.
+@pytest.mark.flaky(retries=3, delay=5,
+                   only_on=[IncompleteResultsError, TimeoutError])
 @with_tempfile
 def test_gin_cloning(path=None):
-    # can we clone a public ds anoynmously from gin and retrieve content
+    # can we clone a public ds anonymously from gin and retrieve content
     try:
-        ds = clone('https://gin.g-node.org/datalad/datalad-ci-target', path)
+        with signal_timeout(50):
+            ds = clone('https://gin.g-node.org/datalad/datalad-ci-target', path)
+            ok_(ds.is_installed())
+            annex_path = op.join('annex', 'two')
+            git_path = op.join('git', 'one')
+            eq_(ds.repo.file_has_content(annex_path), False)
+            eq_(ds.repo.is_under_annex(git_path), False)
+            result = ds.get(annex_path)
+            assert_result_count(result, 1)
+            assert_status('ok', result)
+            eq_(result[0]['path'], op.join(ds.path, annex_path))
+            ok_file_has_content(op.join(ds.path, annex_path), 'two\n')
+            ok_file_has_content(op.join(ds.path, git_path), 'one\n')
     except IncompleteResultsError as e:
         # gin.g-node.org is occasionally unavailable to CI runners: it has
         # been seen returning HTTP 403 to GitHub-hosted Azure ranges, and
@@ -1581,17 +1599,6 @@ def test_gin_cloning(path=None):
                 + msg.split('\n', 1)[0][:200]
             )
         raise
-    ok_(ds.is_installed())
-    annex_path = op.join('annex', 'two')
-    git_path = op.join('git', 'one')
-    eq_(ds.repo.file_has_content(annex_path), False)
-    eq_(ds.repo.is_under_annex(git_path), False)
-    result = ds.get(annex_path)
-    assert_result_count(result, 1)
-    assert_status('ok', result)
-    eq_(result[0]['path'], op.join(ds.path, annex_path))
-    ok_file_has_content(op.join(ds.path, annex_path), 'two\n')
-    ok_file_has_content(op.join(ds.path, git_path), 'one\n')
 
 
 # TODO: git-annex-init fails in the second clone call below when this is

--- a/datalad/tests/test_tests_utils_pytest.py
+++ b/datalad/tests/test_tests_utils_pytest.py
@@ -12,7 +12,9 @@ import logging
 import os
 import platform
 import random
+import signal
 import sys
+import time
 
 try:
     # optional direct dependency we might want to kick out
@@ -77,6 +79,7 @@ from datalad.tests.utils_pytest import (
     rmtemp,
     run_under_dir,
     serve_path_via_http,
+    signal_timeout,
     skip_if,
     skip_if_no_module,
     skip_if_no_network,
@@ -693,3 +696,65 @@ def test_assert_raises():
 
     assert_raises((ValueError, TypeError), raise_TypeError)
     assert_raises((ValueError, TypeError), raise_ValueError)
+
+
+#
+# signal_timeout
+#
+
+_HAS_SIGALRM = hasattr(signal, "SIGALRM")
+
+
+@pytest.mark.skipif(not _HAS_SIGALRM, reason="needs SIGALRM (Unix)")
+@pytest.mark.parametrize(
+    ("budget", "block_for", "expect_timeout"),
+    [
+        (1.0, 0.05, False),    # finishes well under budget
+        (0.5, 0.0, False),     # zero-cost block, never sleeps
+        (0.05, 0.5, True),     # block exceeds tight budget
+        (0.1, 1.0, True),      # block clearly exceeds budget
+    ],
+    ids=["under_budget", "instant", "tight_over", "clear_over"],
+)
+def test_signal_timeout_fires(budget, block_for, expect_timeout):
+    t0 = time.monotonic()
+    if expect_timeout:
+        with assert_raises(TimeoutError) as cm:
+            with signal_timeout(budget):
+                time.sleep(block_for)
+        # message reports the configured budget
+        assert_in(str(budget), str(cm.value))
+        # fired at roughly the budget, not after the full sleep
+        elapsed = time.monotonic() - t0
+        ok_(elapsed < block_for, msg=f"elapsed={elapsed} block_for={block_for}")
+        ok_(elapsed >= budget * 0.9,
+            msg=f"fired too early: elapsed={elapsed} budget={budget}")
+    else:
+        with signal_timeout(budget):
+            time.sleep(block_for)
+
+
+@pytest.mark.skipif(not _HAS_SIGALRM, reason="needs SIGALRM (Unix)")
+def test_signal_timeout_disarms_on_clean_exit():
+    """No alarm machinery is left armed after a successful exit."""
+    with signal_timeout(60):
+        pass
+    eq_(signal.getitimer(signal.ITIMER_REAL), (0.0, 0.0))
+
+
+@pytest.mark.skipif(not _HAS_SIGALRM, reason="needs SIGALRM (Unix)")
+def test_signal_timeout_disarms_on_user_exception():
+    """Alarm is disarmed even when the with-block raises a non-timeout error."""
+    with assert_raises(RuntimeError):
+        with signal_timeout(60):
+            raise RuntimeError("boom")
+    eq_(signal.getitimer(signal.ITIMER_REAL), (0.0, 0.0))
+
+
+def test_signal_timeout_noop_without_sigalrm(monkeypatch):
+    """On platforms lacking SIGALRM the helper is a no-op (does not raise)."""
+    monkeypatch.delattr(signal, "SIGALRM", raising=False)
+    # Tight budget + non-trivial block; if the helper were active it would fire,
+    # but with SIGALRM removed it must be a pure no-op.
+    with signal_timeout(0.001):
+        time.sleep(0.05)

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -12,6 +12,7 @@ import base64
 import lzma
 import multiprocessing
 import multiprocessing.queues
+import signal
 import ssl
 import textwrap
 from difflib import unified_diff
@@ -2087,3 +2088,58 @@ def usecase(f):
     Should be used in combination with @slow and @turtle if slow.
     """
     return attr('usecase')(f)
+
+
+@contextmanager
+def signal_timeout(seconds):
+    """Bound the enclosed block to ``seconds`` wall-clock seconds via SIGALRM.
+
+    Raise :class:`TimeoutError` from inside whatever syscall the block is
+    currently blocked in once the budget is exceeded. Sub-second budgets
+    are supported via :func:`signal.setitimer`. No-op on platforms that
+    lack ``SIGALRM`` (notably Windows).
+
+    This sits alongside the @slow/@turtle/@integration *selection* tags
+    and the per-test ``@pytest.mark.fail_slow`` *budget reporter*: it is
+    the only one of the three that can actually interrupt a running
+    test. It is intended to be paired with ``@pytest.mark.flaky``
+    (``pytest-retry``), with :class:`TimeoutError` listed in
+    ``only_on=`` so an environmental hiccup gets retried, e.g.::
+
+        @pytest.mark.flaky(retries=3, delay=5,
+                           only_on=[IncompleteResultsError, TimeoutError])
+        def test_foo(...):
+            with signal_timeout(50):
+                ...  # network-bound work that should normally finish well under 50s
+
+    Why a local helper instead of ``pytest-timeout``: as of pytest-timeout
+    2.4.0, a triggered timeout in the SIGALRM handler is signalled by
+    calling ``pytest.fail(...)`` [1]_ which raises the generic
+    ``_pytest.outcomes.Failed`` -- there is no dedicated exception class
+    to filter on. On non-Unix platforms it instead calls ``os._exit(1)``
+    [2]_, which leaves nothing for retry plugins to catch. No upstream
+    issue has been opened requesting a distinct exception type (search
+    of `pytest-dev/pytest-timeout` issues/PRs as of 2026-05; the closest
+    is gh-56 [3]_, about retry interaction, closed without a custom-exc
+    proposal). Until that gap closes, this helper raises a plain
+    :class:`TimeoutError` so ``pytest-retry``'s ``only_on=[...]`` can
+    match it cleanly.
+
+    .. [1] https://github.com/pytest-dev/pytest-timeout/blob/ddabc934535081a5bf9ba7c9ca5b494aeaf8f665/pytest_timeout.py#L502
+    .. [2] https://github.com/pytest-dev/pytest-timeout/blob/ddabc934535081a5bf9ba7c9ca5b494aeaf8f665/pytest_timeout.py#L542
+    .. [3] https://github.com/pytest-dev/pytest-timeout/issues/56
+    """
+    if not hasattr(signal, "SIGALRM"):
+        yield
+        return
+
+    def _handler(signum, frame):
+        raise TimeoutError(f"signal_timeout: exceeded {seconds}s")
+
+    prev = signal.signal(signal.SIGALRM, _handler)
+    signal.setitimer(signal.ITIMER_REAL, float(seconds))
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, prev)


### PR DESCRIPTION
## Summary

Follow-up to merged #7851. After that PR, `test_gin_cloning` was still observed failing in CI as:

```
FAILED ../datalad/core/distributed/tests/test_clone.py::test_gin_cloning
  - Test passed but took too long to run: Duration 417.43355967900004s > 60.0s
```

i.e. the test passed but the CI-wide `--fail-slow=60` (`.github/workflows/test.yml`) flipped the report to `failed` after the fact. The earlier `@flaky(only_on=[IncompleteResultsError])` cannot catch that — the call has already succeeded by the time `pytest-fail-slow` rewrites the outcome in `pytest_runtest_makereport`.

## Fix

Add a generic `signal_timeout(seconds)` helper to `datalad/tests/utils_pytest.py` (alongside the existing `@slow`/`@turtle`/`@integration` markers) and wire `test_gin_cloning` to use it.

### `signal_timeout(seconds)` (datalad/tests/utils_pytest.py)

`@contextmanager` that arms `signal.SIGALRM` (via `signal.setitimer`, so sub-second budgets work) and raises a plain `TimeoutError` from inside whatever syscall the block is in once the budget is exceeded. No-op on platforms that lack `SIGALRM` (notably Windows).

Sits alongside the trio of related but distinct primitives in this codebase:
- `@slow` / `@turtle` / `@integration` — *selection* tags, do not enforce time
- `@pytest.mark.fail_slow(N)` — *budget reporter*, lets the test run to completion then flips outcome to failed
- `signal_timeout(N)` — the only one of the three that can actually **interrupt** a running test

Designed to pair with `@pytest.mark.flaky(only_on=[…, TimeoutError])` from `pytest-retry`, so an environmental hiccup is retried rather than red-flagged on first attempt.

### Why not `pytest-timeout`

Considered but not adopted. As of pytest-timeout 2.4.0:
- The `signal` method calls [`pytest.fail(...)`](https://github.com/pytest-dev/pytest-timeout/blob/ddabc934535081a5bf9ba7c9ca5b494aeaf8f665/pytest_timeout.py#L502) which raises the generic `_pytest.outcomes.Failed`. Adding `Failed` to `@flaky(only_on=...)` would retry on every assertion failure — too broad.
- The `thread` method (used on Windows) calls [`os._exit(1)`](https://github.com/pytest-dev/pytest-timeout/blob/ddabc934535081a5bf9ba7c9ca5b494aeaf8f665/pytest_timeout.py#L542). The process dies and no exception escapes — retry plugins cannot intervene at all.

A search of `pytest-dev/pytest-timeout` issues + PRs (as of 2026-05-07) found no open feature request for a dedicated exception class to enable retry-plugin filtering. The closest hit is [#56 "Not working when retrying"](https://github.com/pytest-dev/pytest-timeout/issues/56), closed without proposing one.

The full rationale and permalinks are captured in the `signal_timeout` docstring so the next person evaluating pytest-timeout adoption finds it.

### `test_gin_cloning` (datalad/core/distributed/tests/test_clone.py)

- 50 s budget — comfortably under the 60 s `--fail-slow` ceiling, so any single successful attempt cannot trip it.
- `@flaky(retries=3, delay=5, only_on=[IncompleteResultsError, TimeoutError])` — covers both the form `clone()` wraps the alarm into when SIGALRM fires inside its threaded runner, and bare `TimeoutError` when it fires during the post-clone assertions / `ds.get(...)`.

## Test plan

- [x] **7 parametric unit tests** in `datalad/tests/test_tests_utils_pytest.py` for `signal_timeout`: under-budget, zero-cost block, tight-over, clear-over, clean-exit disarm, user-exception disarm, and SIGALRM-absent no-op fallback. All pass locally in 0.58 s.
- [x] **End-to-end retry behaviour** verified locally by patching `signal_timeout` to a 1 s budget in-process: `pytest-retry` retries exactly `1 + retries=3 = 4` times before failing, with both `IncompleteResultsError` and `TimeoutError` covered by `only_on`.
- [x] Pre-commit hooks (isort, codespell, trailing whitespace) pass.
- [ ] CI: confirm a healthy `test_gin_cloning` run still passes within the 50 s budget (it normally takes well under that).

## Follow-up (not in this PR)

A rollout plan for further `signal_timeout` adoption is staged locally at `.git-meta/SIGNAL_TIMEOUT_ROLLOUT.md` and will be promoted into a tracking issue. Tier A candidates are the four sibling `datalad/distributed/tests/test_create_sibling_{github,gin,gitea,gogs}.py` tests, which mirror this fix's shape exactly. Tier B (case-by-case: `test_install.py`, `test_http.py`, `test_gitrepo.py`, …) and Tier C (already-`@slow` tests, local-fixture tests, runner stall-detection tests — explicitly excluded) are also enumerated there.
