### PR TITLE
RF: typed StatusRecord (dataclass+Mapping) for result records

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -34,7 +34,10 @@ from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
 )
-from datalad.interface.results import annexjson2result
+from datalad.interface.results import (
+    StatusRecord,
+    annexjson2result,
+)
 from datalad.interface.utils import render_action_summary
 from datalad.log import log_progress
 from datalad.support.annexrepo import AnnexRepo
@@ -213,7 +216,7 @@ class Push(Interface):
             # to enable the use case of pushing to a target that
             # a superdataset doesn't know, but some subdatasets to
             # (in combination with '--on-failure ignore')
-            yield dict(
+            yield StatusRecord.from_kwargs(
                 res_kwargs,
                 status='error',
                 path=ds.path,
@@ -273,7 +276,7 @@ class Push(Interface):
                     potential_remote = potential_remote[0]
                 hint = "{} matches a sibling name and not a path. " \
                       "Forgot --to?".format(potential_remote)
-                yield dict(
+                yield StatusRecord.from_kwargs(
                     res_kwargs,
                     status='notneeded',
                     message=hint,
@@ -284,7 +287,7 @@ class Push(Interface):
                 # there's no matching path and we have generated a hint on
                 # fixing the call - we can return now
                 return
-            yield dict(
+            yield StatusRecord.from_kwargs(
                 res_kwargs,
                 status='notneeded',
                 message='Given constraints did not match any changes to publish',
@@ -459,7 +462,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
             except CommandError as e:
                 if 'Please make sure you have the correct access rights' in e.stderr:
                     # there is a default push target but we have no permission
-                    yield dict(
+                    yield StatusRecord.from_kwargs(
                         res_kwargs,
                         status='impossible',
                         message='Attempt to push to default target resulted in following '
@@ -474,7 +477,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
                 'assume no configuration: %s', e)
             target = set()
         if not len(target):
-            yield dict(
+            yield StatusRecord.from_kwargs(
                 res_kwargs,
                 status='impossible',
                 message='No push target given, and none could be '
@@ -484,7 +487,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
         elif len(target) > 1:
             # dunno if this can ever happen, but if it does, report
             # nicely
-            yield dict(
+            yield StatusRecord.from_kwargs(
                 res_kwargs,
                 status='error',
                 message=(
@@ -500,7 +503,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
 
     if not target:
         if _target not in repo.get_remotes():
-            yield dict(
+            yield StatusRecord.from_kwargs(
                 res_kwargs,
                 status='error',
                 message=(
@@ -585,7 +588,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
             # this is a weird one, let's confess and stop here
             # I don't think we need to support such a scenario
             if not active_branch:
-                yield dict(
+                yield StatusRecord.from_kwargs(
                     res_kwargs,
                     status='impossible',
                     message=
@@ -760,7 +763,7 @@ def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
             else 'impossible'
         )
         refspec = '{}:{}'.format(pr['from_ref'], pr['to_ref'])
-        yield dict(
+        yield StatusRecord.from_kwargs(
             res_kwargs,
             status=status,
             target=pr['remote'],
@@ -802,7 +805,7 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
             # still nothing
             # rather than barfing tons of messages for each file, do one
             # for the entire dataset
-            yield dict(
+            yield StatusRecord.from_kwargs(
                 res_kwargs,
                 action='copy',
                 status='impossible'
@@ -848,7 +851,7 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
     ]
     if got_path_arg:
         for c in [c for c in to_transfer if not c.get('has_content', False)]:
-            yield dict(
+            yield StatusRecord.from_kwargs(
                 res_kwargs,
                 type=c['type'],
                 path=c['path'],
@@ -923,7 +926,7 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
 
     for annex_key, paths in repkey_paths.items():
         for path in paths:
-            yield dict(
+            yield StatusRecord.from_kwargs(
                 res_kwargs, action='copy', type='file', status='notneeded',
                 path=path, annexkey=annex_key,
                 message='Another file points to the same key')

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -34,6 +34,7 @@ from datalad.interface.common_opts import (
     recursion_limit,
     save_message_opt,
 )
+from datalad.interface.results import StatusRecord
 from datalad.interface.utils import (
     discover_dataset_trace_to_targets,
     get_tree_roots,
@@ -371,12 +372,12 @@ class Save(Interface):
                 yield from save_ds((ds.pathobj, dict()), version_tag=version_tag)
 
             else:
-                yield dict(action='save',
-                           type='dataset',
-                           path=ds.path,
-                           refds=ds.path,
-                           status='notneeded',
-                           logger=lgr)
+                yield StatusRecord(action='save',
+                                   type='dataset',
+                                   path=ds.path,
+                                   refds=ds.path,
+                                   status='notneeded',
+                                   logger=lgr)
             return
 
         # TODO: in principle logging could be improved to go not by a dataset

--- a/datalad/core/local/status.py
+++ b/datalad/core/local/status.py
@@ -37,6 +37,7 @@ from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
 )
+from datalad.interface.results import StatusRecord
 from datalad.interface.utils import generic_result_renderer
 from datalad.support.constraints import (
     EnsureChoice,
@@ -185,7 +186,7 @@ def yield_dataset_status(ds, paths, annexinfo, untracked, recursion_limit,
     subds_statuscalls = []
     for path, props in status.items():
         cpath = ds.pathobj / path.relative_to(repo_path)
-        yield dict(
+        yield StatusRecord.from_kwargs(
             props,
             path=str(cpath),
             # report the dataset path rather than the repo path to avoid
@@ -417,7 +418,7 @@ class Status(Interface):
                     reporting_order='depth-first'):
                 if 'status' not in r:
                     r['status'] = 'ok'
-                yield dict(
+                yield StatusRecord.from_kwargs(
                     r,
                     refds=ds_path,
                     action='status',

--- a/datalad/distribution/siblings.py
+++ b/datalad/distribution/siblings.py
@@ -41,7 +41,10 @@ from datalad.interface.common_opts import (
     recursion_flag,
     recursion_limit,
 )
-from datalad.interface.results import get_status_dict
+from datalad.interface.results import (
+    StatusRecord,
+    get_status_dict,
+)
 from datalad.interface.utils import generic_result_renderer
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (
@@ -596,11 +599,12 @@ def _configure_remote(
                         'location={}'.format(remote_url),
                         'autoenable=true'])
                 else:
-                    yield dict(
+                    yield StatusRecord.from_kwargs(
+                        result_props,
                         status='impossible',
                         message='cannot configure as a common data source, '
                                 'URL protocol is not http or https',
-                        **result_props)
+                    )
     #
     # place configure steps that also work for 'here' below
     #
@@ -767,14 +771,14 @@ def _enable_remote(ds, repo, name, res_kwargs, **unused_kwargs):
         **res_kwargs)
 
     if not isinstance(repo, AnnexRepo):
-        yield dict(
+        yield StatusRecord.from_kwargs(
             result_props,
             status='impossible',
             message='cannot enable sibling of non-annex dataset')
         return
 
     if name is None:
-        yield dict(
+        yield StatusRecord.from_kwargs(
             result_props,
             status='error',
             message='require `name` of sibling to enable')
@@ -785,7 +789,7 @@ def _enable_remote(ds, repo, name, res_kwargs, **unused_kwargs):
     remote_info = sp_remotes.get(name, None)
 
     if remote_info is None:
-        yield dict(
+        yield StatusRecord.from_kwargs(
             result_props,
             status='impossible',
             message=("cannot enable sibling '%s', not known", name))
@@ -800,7 +804,7 @@ def _enable_remote(ds, repo, name, res_kwargs, **unused_kwargs):
             # let's consult the credential store
             hostname = urlparse(remote_info.get('url', '')).netloc
             if not hostname:
-                yield dict(
+                yield StatusRecord.from_kwargs(
                     result_props,
                     status='impossible',
                     message="cannot determine remote host, credential lookup for webdav access is not possible, and not credentials were supplied")
@@ -813,7 +817,7 @@ def _enable_remote(ds, repo, name, res_kwargs, **unused_kwargs):
                         password=os.environ.get('WEBDAV_PASSWORD', None))
                 except KeyboardInterrupt:
                     # user hit Ctrl-C
-                    yield dict(
+                    yield StatusRecord.from_kwargs(
                         result_props,
                         status='impossible',
                         message="credentials are required for sibling access, abort")

--- a/datalad/interface/base.py
+++ b/datalad/interface/base.py
@@ -682,8 +682,10 @@ def _has_eval_results_call(cls):
 def eval_results(wrapped):
     """Decorator for return value evaluation of datalad commands.
 
-    Note, this decorator is only compatible with commands that return
-    status dict sequences!
+    Note, this decorator is only compatible with commands that yield
+    result records (typed :class:`~datalad.interface.results.StatusRecord`
+    instances are preferred; plain ``dict`` is also accepted and is
+    coerced to ``StatusRecord`` at the central pipeline boundary).
 
     Two basic modes of operation are supported: 1) "generator mode" that
     `yields` individual results, and 2) "list mode" that returns a sequence of

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -311,13 +311,11 @@ class StatusRecord(MutableMapping):
     exception: Any = _UNSET
     exception_traceback: Any = _UNSET
     exit_code: Any = _UNSET
-    # Common "in-the-wild" fields promoted from extras in v2.3 because they
-    # are explicitly listed in result_records.rst as observed across
-    # commands. They are not mandatory; producers continue to opt in.
-    bytesize: Any = _UNSET          # entity size in bytes (int)
+    # Cross-type fields confirmed by the v2.6 sweep (and grep in
+    # gitrepo.py) to apply to both ``type='dataset'`` and
+    # ``type='file'`` records — they remain on the base class.
     gitshasum: Any = _UNSET         # SHA1 of the entity
     prev_gitshasum: Any = _UNSET    # SHA1 of a previous state
-    key: Any = _UNSET               # git-annex key (when type == 'file')
 
     # --- escape hatch for arbitrary action-specific keys ---
     _extras: dict = field(default_factory=dict, repr=False)
@@ -329,12 +327,10 @@ class StatusRecord(MutableMapping):
     _DECLARED_FIELDS: ClassVar[tuple] = ()
     _DECLARED_FIELDS_SET: ClassVar[frozenset] = frozenset()
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        cls._DECLARED_FIELDS = tuple(
-            f.name for f in fields(cls) if not f.name.startswith('_')
-        )
-        cls._DECLARED_FIELDS_SET = frozenset(cls._DECLARED_FIELDS)
+    # Subclasses must call ``_bootstrap_declared_fields(cls)`` after the
+    # ``@dataclass`` decorator runs (see helper defined below the class).
+    # ``__init_subclass__`` cannot do this for us because it fires before
+    # ``@dataclass`` has processed the subclass body.
 
     def __post_init__(self) -> None:
         # v2.6 telemetry: record any pre-loaded extras at construction time
@@ -507,12 +503,98 @@ class StatusRecord(MutableMapping):
         return f'{type(self).__name__}({dict(self)!r})'
 
 
-# bootstrap _DECLARED_FIELDS on the base class itself (__init_subclass__ only
-# runs for subclasses).
-StatusRecord._DECLARED_FIELDS = tuple(
-    f.name for f in fields(StatusRecord) if not f.name.startswith('_')
-)
-StatusRecord._DECLARED_FIELDS_SET = frozenset(StatusRecord._DECLARED_FIELDS)
+def _bootstrap_declared_fields(cls: 'type[StatusRecord]') -> None:
+    """Refresh ``_DECLARED_FIELDS`` / ``_DECLARED_FIELDS_SET`` on a
+    ``StatusRecord`` subclass after the ``@dataclass`` decorator has
+    applied.
+
+    ``__init_subclass__`` runs during class creation — before the
+    ``@dataclass`` decorator has processed the subclass body — so it
+    only sees inherited fields. Subclasses must re-bootstrap after the
+    decorator runs. The base class is bootstrapped manually below; new
+    subclasses defined elsewhere should call this helper after
+    ``@dataclass``.
+    """
+    cls._DECLARED_FIELDS = tuple(
+        f.name for f in fields(cls) if not f.name.startswith('_')
+    )
+    cls._DECLARED_FIELDS_SET = frozenset(cls._DECLARED_FIELDS)
+
+
+# bootstrap _DECLARED_FIELDS on the base class itself.
+_bootstrap_declared_fields(StatusRecord)
+
+
+# ---------------------------------------------------------------------------
+# Specialised subclasses introduced in v2.6 per the runtime extras-key
+# telemetry sweep (see ``docs/designs/status-record.md`` v2.6 outcome and
+# ``.git-meta/v26_report.md``). Each subclass extends the base with fields
+# that the data showed clustering tightly with a specific entity type.
+#
+# Subclasses are purely additive; the base ``StatusRecord`` is unchanged
+# semantically — extras flow through the same Mapping API regardless.
+# Producers opt in by constructing the subclass directly (or via
+# ``FileStatusRecord.from_kwargs(...)`` etc.). Consumers do not need to
+# change: ``isinstance(r, StatusRecord)`` is True for any subclass and
+# the Mapping contract is preserved.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(eq=False)
+class FileStatusRecord(StatusRecord):
+    """Result record for file / symlink entities.
+
+    Adds typed fields that the v2.6 runtime audit showed concentrate on
+    ``type='file'`` results and appear at ≥2 distinct in-tree call sites.
+    Most of these come from ``GitRepo.status()`` /
+    ``get_content_annexinfo()`` and ``annexjson2result()``.
+
+    File-specific fields previously declared on the base class
+    (``bytesize``, ``key`` — promoted in v1+v2.3 from a static grep)
+    have been moved here in v2.6 because the runtime data confirmed
+    they are strictly file-scoped.
+    """
+
+    # Moved from base in v2.6 — runtime audit confirmed file-only use.
+    bytesize: Any = _UNSET            # entity size in bytes (int)
+    key: Any = _UNSET                 # git-annex key (canonical name)
+
+    # Promoted in v2.6 from extras based on the sweep
+    # (see .git-meta/v26_report.md):
+    annexkey: Any = _UNSET            # 9 frames, 213 occurrences — alt
+                                      # name for ``key``; kept distinct
+                                      # because producers populate them
+                                      # via different code paths
+    backend: Any = _UNSET             # 2 frames, 22 occ
+    has_content: Any = _UNSET         # 2 frames, 18 occ
+    hashdirlower: Any = _UNSET        # 2 frames,  4 occ
+    hashdirmixed: Any = _UNSET        # 2 frames,  4 occ
+    humansize: Any = _UNSET           # 2 frames, 22 occ
+    keyname: Any = _UNSET             # 2 frames, 22 occ
+    mtime: Any = _UNSET               # 2 frames, 22 occ
+    objloc: Any = _UNSET              # 2 frames, 18 occ
+
+
+@dataclass(eq=False)
+class SiblingStatusRecord(StatusRecord):
+    """Result record for sibling / git-remote entities.
+
+    Adds the canonical sibling name. The remaining sibling-specific
+    keys observed in the v2.6 sweep are either hyphenated git-config
+    style identifiers (``annex-uuid``, ``annex-ignore``, ``annex-*``,
+    ``datalad-publish-depends``) — which cannot be Python attributes
+    and therefore must stay in ``_extras`` — or single-call-site
+    fields that fail the ≥2 promotion rule. ``url`` is kept in extras
+    for now (single call site at sweep time); promote in a future PR
+    if a second producer adds it.
+    """
+
+    name: Any = _UNSET                # 8 frames, 120 occ
+
+
+# refresh declared-fields cache on each subclass now that @dataclass has run
+_bootstrap_declared_fields(FileStatusRecord)
+_bootstrap_declared_fields(SiblingStatusRecord)
 
 
 def as_status_record(res: Mapping) -> 'StatusRecord':

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 __docformat__ = 'restructuredtext'
 
 import logging
+import os
 from collections.abc import (
     Iterable,
     Iterator,
@@ -64,6 +65,21 @@ success_status_map = {
     'impossible': 'failure',
     'error': 'failure',
 }
+
+# Canonical status values per docs/source/design/result_records.rst.
+# Used by StatusRecord to validate status assignments in v2.4 strict mode.
+_VALID_STATUSES = frozenset(success_status_map)
+
+
+def _strict_mode_enabled() -> bool:
+    """Whether StatusRecord runs in strict mode.
+
+    Controlled by ``DATALAD_STATUSRECORD_STRICT`` environment variable
+    (truthy values: ``1``, ``true``, ``yes`` — case-insensitive). Off by
+    default so existing producers and extensions are unaffected.
+    """
+    v = os.environ.get('DATALAD_STATUSRECORD_STRICT', '').strip().lower()
+    return v in ('1', 'true', 'yes')
 
 
 # ---------------------------------------------------------------------------
@@ -213,10 +229,34 @@ class StatusRecord(MutableMapping):
             except KeyError:
                 pass
             return
+        # v2.4 opt-in unknown-key warning. Off by default so existing
+        # producers and extensions are unaffected. Enable via
+        # DATALAD_STATUSRECORD_STRICT=1. Status-value validation is in
+        # __setattr__ so it catches both dict-style and dataclass-init
+        # paths.
+        if key not in self._DECLARED_FIELDS_SET and _strict_mode_enabled():
+            lgr.warning(
+                "StatusRecord: unknown key %r assigned to extras "
+                "(strict mode is on)", key)
         if key in self._DECLARED_FIELDS_SET:
             setattr(self, key, value)
         else:
             self._extras[key] = value
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # v2.4 opt-in status-value validation. Catches both
+        # ``StatusRecord(status=v)`` (auto-generated dataclass __init__
+        # routes through __setattr__) and ``r.status = v`` and
+        # ``r['status'] = v`` (which calls setattr on declared fields).
+        if name == 'status' \
+                and value is not _UNSET \
+                and value is not None \
+                and value not in _VALID_STATUSES \
+                and _strict_mode_enabled():
+            raise ValueError(
+                f"invalid status value {value!r}; "
+                f"expected one of {sorted(_VALID_STATUSES)}")
+        super().__setattr__(name, value)
 
     def __delitem__(self, key: str) -> None:
         if key in self._DECLARED_FIELDS_SET:

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -14,8 +14,12 @@ from __future__ import annotations
 
 __docformat__ = 'restructuredtext'
 
+import atexit
+import json
 import logging
 import os
+import traceback
+from collections import defaultdict
 from collections.abc import (
     Iterable,
     Iterator,
@@ -80,6 +84,157 @@ def _strict_mode_enabled() -> bool:
     """
     v = os.environ.get('DATALAD_STATUSRECORD_STRICT', '').strip().lower()
     return v in ('1', 'true', 'yes')
+
+
+# ---------------------------------------------------------------------------
+# v2.6: runtime extras-key telemetry
+#
+# When ``DATALAD_STATUSRECORD_TRACE=1`` is set in the environment, every
+# write of a key into ``StatusRecord._extras`` is recorded with the
+# topmost in-tree call site, the producing ``action`` / ``type`` (where
+# known on the record at that point), the value's Python type, and a
+# few example values. On process exit the accumulated buckets are
+# serialised to JSONL at ``DATALAD_STATUSRECORD_TRACE_PATH`` (default
+# ``/tmp/datalad_statusrecord_trace.jsonl``).
+#
+# The output drives the v2.6 promote-or-subclass redo per
+# ``docs/designs/status-record.md``: a static grep is structurally
+# incomplete (it misses dynamic key construction in addurls, helpers
+# that spread ``**res_kwargs`` from closures, etc.); the runtime audit
+# replaces it with real data.
+#
+# When trace is off (the default), the only cost on the hot path is
+# one cached-bool check.
+# ---------------------------------------------------------------------------
+
+# Frames inside these files are skipped when locating the producer call
+# site — they are part of the StatusRecord plumbing, not the producer.
+_TRACE_SKIP_FILES = (
+    'datalad/interface/results.py',
+    'datalad/interface/utils.py',
+    # standard library / framework frames are skipped via the
+    # 'datalad/' substring check below
+)
+
+_TRACE_ENABLED: Optional[bool] = None
+_TRACE_BUCKETS: dict = defaultdict(lambda: {
+    'count': 0,
+    'actions': defaultdict(int),
+    'types': defaultdict(int),
+    'value_types': defaultdict(int),
+    'examples': [],
+})
+
+
+def _trace_enabled() -> bool:
+    """Whether runtime extras-key telemetry is on.
+
+    Controlled by ``DATALAD_STATUSRECORD_TRACE`` (truthy: ``1`` /
+    ``true`` / ``yes``). The result is cached on first read so the hot
+    path stays cheap when off.
+    """
+    global _TRACE_ENABLED
+    if _TRACE_ENABLED is None:
+        v = os.environ.get(
+            'DATALAD_STATUSRECORD_TRACE', '').strip().lower()
+        _TRACE_ENABLED = v in ('1', 'true', 'yes')
+    return _TRACE_ENABLED
+
+
+def _trace_reset() -> None:
+    """Clear cached enabled-state and accumulated buckets.
+
+    Test-only helper; resets module state between sweeps so unit tests
+    can drive the env var with ``monkeypatch``.
+    """
+    global _TRACE_ENABLED
+    _TRACE_ENABLED = None
+    _TRACE_BUCKETS.clear()
+
+
+def _trace_top_frame() -> str:
+    """Find the topmost in-tree call site, skipping plumbing frames.
+
+    Walks the stack from innermost to outermost and returns the
+    deepest frame inside ``datalad/`` that is *not* part of the
+    StatusRecord plumbing. Returned as ``"datalad/...:lineno"`` so it
+    groups well in the JSONL output. Returns ``<no-in-tree-caller>``
+    if the call stack contains no datalad/ producer frame (synthetic
+    REPL invocations, third-party callers, etc.).
+    """
+    for frame in reversed(traceback.extract_stack()):
+        path = frame.filename
+        if 'datalad/' not in path:
+            continue
+        if any(skip in path for skip in _TRACE_SKIP_FILES):
+            continue
+        idx = path.rfind('datalad/')
+        return f"{path[idx:]}:{frame.lineno}"
+    return '<no-in-tree-caller>'
+
+
+def _trace_record_extra(
+    key: str,
+    value: Any,
+    action: Any,
+    type_: Any,
+) -> None:
+    """Record a single extras-key write. No-op when trace is off."""
+    if not _trace_enabled():
+        return
+    frame = _trace_top_frame()
+    bucket = _TRACE_BUCKETS[(key, frame)]
+    bucket['count'] += 1
+    if action is not None and action is not _UNSET:
+        bucket['actions'][str(action)] += 1
+    if type_ is not None and type_ is not _UNSET:
+        bucket['types'][str(type_)] += 1
+    bucket['value_types'][type(value).__name__] += 1
+    if len(bucket['examples']) < 3:
+        try:
+            bucket['examples'].append(repr(value)[:200])
+        except Exception:
+            pass
+
+
+def _trace_dump() -> None:
+    """Serialise accumulated extras-key buckets to JSONL.
+
+    Runs at process exit via ``atexit``. Also callable explicitly for
+    test harnesses. No-op when trace is off or no records were
+    captured. Output path is ``DATALAD_STATUSRECORD_TRACE_PATH`` or
+    ``/tmp/datalad_statusrecord_trace.jsonl``.
+    """
+    if not _trace_enabled() or not _TRACE_BUCKETS:
+        return
+    path = os.environ.get(
+        'DATALAD_STATUSRECORD_TRACE_PATH',
+        '/tmp/datalad_statusrecord_trace.jsonl')
+    try:
+        with open(path, 'w') as f:
+            for (key, frame), bucket in sorted(_TRACE_BUCKETS.items()):
+                rec = {
+                    'key': key,
+                    'frame': frame,
+                    'count': bucket['count'],
+                    'actions': dict(bucket['actions']),
+                    'types': dict(bucket['types']),
+                    'value_types': dict(bucket['value_types']),
+                    'examples': bucket['examples'],
+                }
+                f.write(json.dumps(rec) + '\n')
+        # also leave a hint in the log so humans notice the file
+        lgr.info(
+            'StatusRecord extras-key telemetry written to %s '
+            '(%d distinct (key, frame) clusters)',
+            path, len(_TRACE_BUCKETS))
+    except Exception as exc:
+        # best-effort; do not break process exit on telemetry I/O
+        lgr.debug(
+            'StatusRecord telemetry dump failed: %s', exc)
+
+
+atexit.register(_trace_dump)
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +336,16 @@ class StatusRecord(MutableMapping):
         )
         cls._DECLARED_FIELDS_SET = frozenset(cls._DECLARED_FIELDS)
 
+    def __post_init__(self) -> None:
+        # v2.6 telemetry: record any pre-loaded extras at construction time
+        # so we capture from_kwargs / direct ``StatusRecord(_extras=...)``
+        # call paths in addition to post-construction __setitem__ paths.
+        if self._extras and _trace_enabled():
+            action = getattr(self, 'action', _UNSET)
+            type_ = getattr(self, 'type', _UNSET)
+            for k, v in self._extras.items():
+                _trace_record_extra(k, v, action, type_)
+
     # ---- permissive construction from arbitrary kwargs -----------------
     @classmethod
     def from_kwargs(
@@ -234,10 +399,17 @@ class StatusRecord(MutableMapping):
         # DATALAD_STATUSRECORD_STRICT=1. Status-value validation is in
         # __setattr__ so it catches both dict-style and dataclass-init
         # paths.
-        if key not in self._DECLARED_FIELDS_SET and _strict_mode_enabled():
-            lgr.warning(
-                "StatusRecord: unknown key %r assigned to extras "
-                "(strict mode is on)", key)
+        if key not in self._DECLARED_FIELDS_SET:
+            if _strict_mode_enabled():
+                lgr.warning(
+                    "StatusRecord: unknown key %r assigned to extras "
+                    "(strict mode is on)", key)
+            # v2.6 telemetry: record post-construction extras writes.
+            # No-op when DATALAD_STATUSRECORD_TRACE is off.
+            _trace_record_extra(
+                key, value,
+                getattr(self, 'action', _UNSET),
+                getattr(self, 'type', _UNSET))
         if key in self._DECLARED_FIELDS_SET:
             setattr(self, key, value)
         else:

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -343,7 +343,7 @@ StatusRecord._DECLARED_FIELDS = tuple(
 StatusRecord._DECLARED_FIELDS_SET = frozenset(StatusRecord._DECLARED_FIELDS)
 
 
-def as_status_record(res: Any) -> 'StatusRecord':
+def as_status_record(res: Mapping) -> 'StatusRecord':
     """Coerce a result record to a :class:`StatusRecord`.
 
     Returns ``res`` unchanged if it is already a ``StatusRecord``;
@@ -451,7 +451,7 @@ def results_from_paths(
     status: Optional[str] = None,
     message: Optional[str] = None,
     exception: Exception | CapturedException | None = None,
-) -> Iterator[dict[str, Any]]:
+) -> Iterator[StatusRecord]:
     """
     Helper to yield analog result dicts for each path in a sequence.
 
@@ -568,8 +568,8 @@ translate_annex_notes = {
 }
 
 
-def annexjson2result(d: dict[str, Any], ds: Dataset, **kwargs: Any) -> dict[str, Any]:
-    """Helper to convert an annex JSON result to a datalad result dict
+def annexjson2result(d: dict[str, Any], ds: Dataset, **kwargs: Any) -> StatusRecord:
+    """Helper to convert an annex JSON result to a datalad result record
 
     Info from annex is rather heterogeneous, partly because some of it
     our support functions are faking.
@@ -689,7 +689,7 @@ def results_from_annex_noinfo(
     noinfo_file_msg: str,
     noinfo_status: str = 'notneeded',
     **kwargs: Any
-) -> Iterator[dict[str, Any]]:
+) -> Iterator[StatusRecord]:
     """Helper to yield results based on what information git annex did no give us.
 
     The helper assumes that the annex command returned without an error code,

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -18,6 +18,12 @@ import logging
 from collections.abc import (
     Iterable,
     Iterator,
+    MutableMapping,
+)
+from dataclasses import (
+    dataclass,
+    field,
+    fields,
 )
 from os.path import (
     isabs,
@@ -30,6 +36,7 @@ from os.path import (
 )
 from typing import (
     Any,
+    ClassVar,
     Optional,
 )
 
@@ -58,6 +65,234 @@ success_status_map = {
 }
 
 
+# ---------------------------------------------------------------------------
+# StatusRecord: typed result record that also implements MutableMapping
+#
+# Designed to be a drop-in replacement for the plain dict that
+# ``get_status_dict()`` historically returned. The class declares the
+# documented result-record fields (see ``docs/source/design/result_records.rst``)
+# as typed attributes, while any unknown / domain-specific keys are stored in
+# an internal ``_extras`` mapping so that:
+#
+#   * existing dict-style consumers (``r['k']``, ``r.get('k')``, ``'k' in r``,
+#     ``r['k'] = v``, ``dict(r)``, ``r.items()``, JSON serialization, hook
+#     match, pickling, etc.) keep working unchanged;
+#   * new code may use typed attribute access (``r.status``, ``r.path``);
+#   * the visible "key set" mirrors the old dict: a declared field is only
+#     reported as present when it has been explicitly set to a non-None value.
+#
+# See ``docs/designs/status-record.md`` for the migration plan.
+# ---------------------------------------------------------------------------
+
+# A sentinel to distinguish "field never set" from "explicitly set to None".
+# Plain ``None`` is a valid value for several fields (``message`` etc.) so we
+# need an unambiguous unset marker for declared fields. The marker is hidden
+# from external consumers: __getitem__/__contains__/__iter__ treat _UNSET as
+# "absent", and __setitem__ writing _UNSET routes through __delitem__.
+_UNSET: Any = object()
+
+
+@dataclass(eq=False)
+class StatusRecord(MutableMapping):
+    """Typed DataLad result record.
+
+    Behaves as both a dataclass (typed attribute access for declared fields)
+    and a :class:`MutableMapping` (dict-style access for backward
+    compatibility). Unknown / domain-specific keys are stored in an internal
+    extras mapping and are spliced into the Mapping view transparently.
+
+    Examples
+    --------
+    >>> r = StatusRecord(action='get', path='/x', status='ok')
+    >>> r['status']
+    'ok'
+    >>> r.status
+    'ok'
+    >>> 'status' in r
+    True
+    >>> r['custom'] = 42         # routed into extras
+    >>> r['custom']
+    42
+    >>> sorted(r.keys())
+    ['action', 'custom', 'path', 'status']
+    """
+
+    # --- documented result-record fields ---
+    # All default to a sentinel so that, just like the legacy dict, a field
+    # is only "present" once explicitly assigned a non-_UNSET value. The
+    # public type of each field is documented in
+    # ``docs/source/design/result_records.rst``; the runtime annotations stay
+    # ``Any`` to keep this v1 change minimal-diff and avoid forcing strict
+    # types on existing call sites that pass ``None`` etc.
+    action: Any = _UNSET
+    path: Any = _UNSET
+    status: Any = _UNSET
+    type: Any = _UNSET
+    message: Any = _UNSET
+    logger: Any = _UNSET
+    refds: Any = _UNSET
+    parentds: Any = _UNSET
+    state: Any = _UNSET
+    error_message: Any = _UNSET
+    exception: Any = _UNSET
+    exception_traceback: Any = _UNSET
+    exit_code: Any = _UNSET
+
+    # --- escape hatch for arbitrary action-specific keys ---
+    _extras: dict = field(default_factory=dict, repr=False)
+
+    # Declared field names in declaration order, plus a frozenset for O(1)
+    # membership tests. Computed once per class in __init_subclass__ / via
+    # the bootstrap below the class body for the base class. ClassVar keeps
+    # @dataclass from treating these as instance fields.
+    _DECLARED_FIELDS: ClassVar[tuple] = ()
+    _DECLARED_FIELDS_SET: ClassVar[frozenset] = frozenset()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._DECLARED_FIELDS = tuple(
+            f.name for f in fields(cls) if not f.name.startswith('_')
+        )
+        cls._DECLARED_FIELDS_SET = frozenset(cls._DECLARED_FIELDS)
+
+    # ---- permissive construction from arbitrary kwargs -----------------
+    @classmethod
+    def from_kwargs(
+        cls,
+        _mapping: Optional[Mapping] = None,
+        /,
+        **kwargs: Any,
+    ) -> 'StatusRecord':
+        """Construct from a mapping and/or arbitrary keyword arguments.
+
+        Mirrors :func:`dict` merge semantics: a positional mapping
+        provides the base, and keyword arguments override matching keys.
+        Unknown keys are routed into ``_extras``. Used by producers that
+        spread an existing result-kwargs dict and add or override fields,
+        e.g.::
+
+            yield StatusRecord.from_kwargs(res_kwargs, status='ok')
+
+        For the kwargs-only case (no base mapping), simply omit the
+        positional argument::
+
+            yield StatusRecord.from_kwargs(action='get', custom='v')
+        """
+        merged = dict(_mapping) if _mapping is not None else {}
+        merged.update(kwargs)
+        declared = {k: v for k, v in merged.items()
+                    if k in cls._DECLARED_FIELDS_SET}
+        extras = {k: v for k, v in merged.items()
+                  if k not in cls._DECLARED_FIELDS_SET}
+        return cls(**declared, _extras=extras)
+
+    # ---- MutableMapping protocol ------------------------------------
+    def __getitem__(self, key: str) -> Any:
+        if key in self._DECLARED_FIELDS_SET:
+            v = getattr(self, key)
+            if v is _UNSET:
+                raise KeyError(key)
+            return v
+        return self._extras[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if value is _UNSET:
+            # treat as deletion to keep "_UNSET means absent" invariant
+            try:
+                del self[key]
+            except KeyError:
+                pass
+            return
+        if key in self._DECLARED_FIELDS_SET:
+            setattr(self, key, value)
+        else:
+            self._extras[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        if key in self._DECLARED_FIELDS_SET:
+            if getattr(self, key) is _UNSET:
+                raise KeyError(key)
+            setattr(self, key, _UNSET)
+        else:
+            del self._extras[key]
+
+    def __iter__(self) -> Iterator[str]:
+        for name in self._DECLARED_FIELDS:
+            if getattr(self, name) is not _UNSET:
+                yield name
+        yield from self._extras
+
+    def __len__(self) -> int:
+        n = sum(1 for f in self._DECLARED_FIELDS
+                if getattr(self, f) is not _UNSET)
+        return n + len(self._extras)
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        if key in self._DECLARED_FIELDS_SET:
+            return getattr(self, key) is not _UNSET
+        return key in self._extras
+
+    def copy(self) -> 'StatusRecord':
+        """Return a shallow copy as a fresh ``StatusRecord`` (or subclass).
+
+        Mirrors ``dict.copy()`` for backward compatibility with code that
+        treats result records as dicts (e.g. test helpers like
+        ``_without_command`` in ``test_foreach_dataset.py`` that mutate
+        a copy of each result). The result is a new instance of the same
+        concrete class — ``FileStatusRecord.copy()`` returns a
+        ``FileStatusRecord`` — and ``_extras`` is also shallow-copied so
+        in-place mutation on the copy does not leak back.
+        """
+        return type(self).from_kwargs(self)
+
+    # ---- equality with dict and other StatusRecord ------------------
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, StatusRecord):
+            return dict(self) == dict(other)
+        if isinstance(other, dict):
+            return dict(self) == other
+        return NotImplemented
+
+    def __ne__(self, other: object) -> bool:
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
+    # explicit __hash__ disabled (Mapping-style equality is mutation-sensitive)
+    __hash__ = None  # type: ignore[assignment]
+
+    # ---- pickling ---------------------------------------------------
+    # Default dataclass pickling round-trips ``__dict__`` verbatim, but the
+    # _UNSET sentinel does not survive identity comparison after unpickling
+    # (``object()`` instances become fresh objects). Round-trip via the
+    # public Mapping view instead.
+    def __getstate__(self) -> dict:
+        return dict(self)
+
+    def __setstate__(self, state: dict) -> None:
+        for name in self._DECLARED_FIELDS:
+            object.__setattr__(self, name, _UNSET)
+        object.__setattr__(self, '_extras', {})
+        for k, v in state.items():
+            self[k] = v
+
+    # ---- repr / debugging -------------------------------------------
+    def __repr__(self) -> str:
+        # mirror plain dict repr so log output etc. doesn't change shape
+        return f'{type(self).__name__}({dict(self)!r})'
+
+
+# bootstrap _DECLARED_FIELDS on the base class itself (__init_subclass__ only
+# runs for subclasses).
+StatusRecord._DECLARED_FIELDS = tuple(
+    f.name for f in fields(StatusRecord) if not f.name.startswith('_')
+)
+StatusRecord._DECLARED_FIELDS_SET = frozenset(StatusRecord._DECLARED_FIELDS)
+
+
 def get_status_dict(
     action: Optional[str] = None,
     ds: Optional[Dataset] = None,
@@ -70,14 +305,14 @@ def get_status_dict(
     exception: Exception | CapturedException | None = None,
     error_message: str | tuple | None = None,
     **kwargs: Any,
-) -> dict[str, Any]:
+) -> StatusRecord:
     # `type` is intentionally not `type_` or something else, as a mismatch
     # with the dict key 'type' causes too much pain all over the place
     # just for not shadowing the builtin `type` in this function
-    """Helper to create a result dictionary.
+    """Helper to create a result record.
 
-    Most arguments match their key in the resulting dict, and their given
-    values are simply assigned to the result record under these keys.  Only
+    Most arguments match their key in the resulting record, and their given
+    values are simply assigned to the record under these keys.  Only
     exceptions are listed here.
 
     Parameters
@@ -95,10 +330,14 @@ def get_status_dict(
 
     Returns
     -------
-    dict
+    StatusRecord
+        A record that behaves like a dict for backward-compatible
+        consumers (subscription, ``.get()``, ``in``, iteration, JSON
+        serialization, etc.) and exposes typed attributes for the
+        documented fields.
     """
 
-    d: dict[str, Any] = {}
+    d: StatusRecord = StatusRecord()
     if action is not None:
         d['action'] = action
     if ds:

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -18,6 +18,7 @@ import logging
 from collections.abc import (
     Iterable,
     Iterator,
+    Mapping,
     MutableMapping,
 )
 from dataclasses import (
@@ -293,6 +294,23 @@ StatusRecord._DECLARED_FIELDS = tuple(
 StatusRecord._DECLARED_FIELDS_SET = frozenset(StatusRecord._DECLARED_FIELDS)
 
 
+def as_status_record(res: Any) -> 'StatusRecord':
+    """Coerce a result record to a :class:`StatusRecord`.
+
+    Returns ``res`` unchanged if it is already a ``StatusRecord``;
+    otherwise wraps the mapping in a fresh ``StatusRecord`` so downstream
+    code can rely on typed attribute access. Used at the central pipeline
+    entry (``_process_results``) so the in-pipeline result type is
+    guaranteed regardless of what a producer yielded.
+
+    The wrapping is shallow: keys flow through ``from_kwargs``, so unknown
+    keys land in ``_extras``. The original mapping is not mutated.
+    """
+    if isinstance(res, StatusRecord):
+        return res
+    return StatusRecord.from_kwargs(res)
+
+
 def get_status_dict(
     action: Optional[str] = None,
     ds: Optional[Dataset] = None,
@@ -407,16 +425,24 @@ def results_from_paths(
         )
 
 
-def is_ok_dataset(r: dict) -> bool:
-    """Convenience test for a non-failure dataset-related result dict"""
+def is_ok_dataset(r: Mapping) -> bool:
+    """Convenience test for a non-failure dataset-related result record.
+
+    Accepts both :class:`StatusRecord` and plain ``dict`` (e.g. results
+    yielded from extensions that have not migrated yet).
+    """
     return r.get('status', None) == 'ok' and r.get('type', None) == 'dataset'
 
 
 class ResultXFM:
     """Abstract definition of the result transformer API"""
 
-    def __call__(self, res: dict[str, Any]) -> Any:
-        """This is called with one result dict at a time"""
+    def __call__(self, res: Mapping) -> Any:
+        """This is called with one result record at a time.
+
+        ``res`` is a :class:`Mapping` — ``StatusRecord`` is supported as
+        the typed common case, but plain ``dict`` is also valid.
+        """
         raise NotImplementedError
 
 
@@ -431,7 +457,7 @@ class YieldDatasets(ResultXFM):
     def __init__(self, success_only: bool = False) -> None:
         self.success_only = success_only
 
-    def __call__(self, res: dict[str, Any]) -> Optional[Dataset]:
+    def __call__(self, res: Mapping) -> Optional[Dataset]:
         if res.get('type', None) == 'dataset':
             if not self.success_only or \
                     res.get('status', None) in ('ok', 'notneeded'):
@@ -449,7 +475,7 @@ class YieldRelativePaths(ResultXFM):
     Relative paths are determined from the 'refds' value in the result. If
     no such value is found, `None` is returned.
     """
-    def __call__(self, res: dict[str, Any]) -> Optional[str]:
+    def __call__(self, res: Mapping) -> Optional[str]:
         refpath = res.get('refds', None)
         if refpath:
             return relpath(res['path'], start=refpath)
@@ -468,7 +494,7 @@ class YieldField(ResultXFM):
         """
         self.field = field
 
-    def __call__(self, res: dict[str, Any]) -> Any:
+    def __call__(self, res: Mapping) -> Any:
         if self.field in res:
             return res[self.field]
         else:
@@ -545,13 +571,13 @@ def annexjson2result(d: dict[str, Any], ds: Dataset, **kwargs: Any) -> dict[str,
     return res
 
 
-def count_results(res: Iterable[dict[str, Any]], **kwargs: Any) -> int:
+def count_results(res: Iterable[Mapping], **kwargs: Any) -> int:
     """Return number of results that match all property values in kwargs"""
     return sum(
         all(k in r and r[k] == v for k, v in kwargs.items()) for r in res)
 
 
-def only_matching_paths(res: dict[str, Any], **kwargs: Any) -> bool:
+def only_matching_paths(res: Mapping, **kwargs: Any) -> bool:
     # TODO handle relative paths by using a contained 'refds' value
     paths = ensure_list(kwargs.get('path', []))
     respath = res.get('path', None)
@@ -560,7 +586,7 @@ def only_matching_paths(res: dict[str, Any], **kwargs: Any) -> bool:
 
 # needs decorator, as it will otherwise bind to the command classes that use it
 @staticmethod  # type: ignore[misc]
-def is_result_matching_pathsource_argument(res: dict[str, Any], **kwargs: Any) -> bool:
+def is_result_matching_pathsource_argument(res: Mapping, **kwargs: Any) -> bool:
     # we either have any non-zero number of "paths" (that could be anything), or
     # we have one path and one source
     # we don't do any error checking here, done by the command itself

--- a/datalad/interface/results.py
+++ b/datalad/interface/results.py
@@ -123,8 +123,10 @@ class StatusRecord(MutableMapping):
     # is only "present" once explicitly assigned a non-_UNSET value. The
     # public type of each field is documented in
     # ``docs/source/design/result_records.rst``; the runtime annotations stay
-    # ``Any`` to keep this v1 change minimal-diff and avoid forcing strict
-    # types on existing call sites that pass ``None`` etc.
+    # ``Any`` to keep this minimal-diff and avoid forcing strict types on
+    # existing call sites that pass ``None`` etc.
+    #
+    # Mandatory and common optional fields:
     action: Any = _UNSET
     path: Any = _UNSET
     status: Any = _UNSET
@@ -138,6 +140,13 @@ class StatusRecord(MutableMapping):
     exception: Any = _UNSET
     exception_traceback: Any = _UNSET
     exit_code: Any = _UNSET
+    # Common "in-the-wild" fields promoted from extras in v2.3 because they
+    # are explicitly listed in result_records.rst as observed across
+    # commands. They are not mandatory; producers continue to opt in.
+    bytesize: Any = _UNSET          # entity size in bytes (int)
+    gitshasum: Any = _UNSET         # SHA1 of the entity
+    prev_gitshasum: Any = _UNSET    # SHA1 of a previous state
+    key: Any = _UNSET               # git-annex key (when type == 'file')
 
     # --- escape hatch for arbitrary action-specific keys ---
     _extras: dict = field(default_factory=dict, repr=False)

--- a/datalad/interface/tests/test_status_record.py
+++ b/datalad/interface/tests/test_status_record.py
@@ -25,8 +25,13 @@ import pickle
 import pytest
 
 from datalad.interface.results import (
+    _TRACE_BUCKETS,
     _UNSET,
     StatusRecord,
+    _trace_dump,
+    _trace_enabled,
+    _trace_record_extra,
+    _trace_reset,
     get_status_dict,
 )
 
@@ -574,6 +579,131 @@ def test_strict_mode_status_none_allowed(monkeypatch):
     monkeypatch.setenv('DATALAD_STATUSRECORD_STRICT', '1')
     r = StatusRecord(status=None)        # accepted
     assert r.status is None
+
+
+# ---------------------------------------------------------------------------
+# v2.6: extras-key telemetry
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def trace_off(monkeypatch):
+    monkeypatch.delenv('DATALAD_STATUSRECORD_TRACE', raising=False)
+    _trace_reset()
+    yield
+    _trace_reset()
+
+
+@pytest.fixture
+def trace_on(monkeypatch):
+    monkeypatch.setenv('DATALAD_STATUSRECORD_TRACE', '1')
+    _trace_reset()
+    yield
+    _trace_reset()
+
+
+def test_trace_disabled_by_default(trace_off):
+    """No env var → trace is off → no buckets accumulate."""
+    assert not _trace_enabled()
+    r = StatusRecord.from_kwargs(action='get', custom='v')
+    r['post_extra'] = 1
+    assert dict(_TRACE_BUCKETS) == {}
+
+
+def test_trace_records_extras_at_construction(trace_on):
+    """from_kwargs(extras=...) → __post_init__ records each key."""
+    StatusRecord.from_kwargs(action='get', type='file',
+                             annexkey='ABC123', metadata={'k': 1})
+    keys = sorted(k for (k, _frame) in _TRACE_BUCKETS)
+    assert keys == ['annexkey', 'metadata']
+    # both record the producing action / type
+    for (k, _frame), bucket in _TRACE_BUCKETS.items():
+        assert bucket['count'] == 1
+        assert bucket['actions'] == {'get': 1}
+        assert bucket['types'] == {'file': 1}
+
+
+def test_trace_records_extras_post_construction(trace_on):
+    """r['unknown_key'] = v records via __setitem__ path."""
+    r = StatusRecord(action='configure-sibling', type='sibling')
+    r['name'] = 'origin'
+    r['url'] = 'https://example.com'
+    keys = sorted(k for (k, _frame) in _TRACE_BUCKETS)
+    assert keys == ['name', 'url']
+    for (k, _frame), bucket in _TRACE_BUCKETS.items():
+        assert bucket['actions'] == {'configure-sibling': 1}
+        assert bucket['types'] == {'sibling': 1}
+
+
+def test_trace_does_not_record_declared_field_assignment(trace_on):
+    """Declared-field writes don't go into telemetry — they're typed."""
+    r = StatusRecord(action='get', path='/x', status='ok')
+    r['status'] = 'notneeded'
+    r.path = '/y'
+    assert dict(_TRACE_BUCKETS) == {}
+
+
+def test_trace_aggregates_repeated_writes(trace_on):
+    """Same key from same frame → single bucket with count > 1."""
+    for i in range(5):
+        r = StatusRecord.from_kwargs(action='get', custom_key=i)
+    # all five constructions go through the same call site
+    buckets = list(_TRACE_BUCKETS.values())
+    assert len(buckets) == 1
+    assert buckets[0]['count'] == 5
+    assert buckets[0]['value_types'] == {'int': 5}
+
+
+def test_trace_value_type_diversity(trace_on):
+    """Mixed value types in the same key, from the same call site, get
+    aggregated; ``value_types`` records the diversity. Same call site
+    means same source line — call from a helper to fix the line."""
+    def _emit(v):
+        return StatusRecord.from_kwargs(action='get', custom_key=v)
+    _emit('string')
+    _emit(42)
+    buckets = list(_TRACE_BUCKETS.values())
+    assert len(buckets) == 1                    # same (key, frame)
+    assert buckets[0]['value_types'] == {'str': 1, 'int': 1}
+
+
+def test_trace_distinct_frames_separate_buckets(trace_on):
+    """Same key from different source lines → distinct buckets. This
+    is the property that lets the v2.6 sweep aggregate per-call-site."""
+    StatusRecord.from_kwargs(action='get', custom_key=1)  # call A
+    StatusRecord.from_kwargs(action='get', custom_key=2)  # call B
+    assert len(_TRACE_BUCKETS) == 2
+
+
+def test_trace_examples_truncated_to_three(trace_on):
+    """At most three example values per (key, frame) — bounded memory."""
+    for i in range(10):
+        StatusRecord.from_kwargs(action='get', sample=f'value-{i}')
+    bucket = next(iter(_TRACE_BUCKETS.values()))
+    assert len(bucket['examples']) == 3
+
+
+def test_trace_dump_writes_jsonl(trace_on, tmp_path, monkeypatch):
+    """_trace_dump() serialises buckets to JSONL at the configured path."""
+    out = tmp_path / 'trace.jsonl'
+    monkeypatch.setenv('DATALAD_STATUSRECORD_TRACE_PATH', str(out))
+    StatusRecord.from_kwargs(action='get', custom='v')
+    _trace_dump()
+    assert out.exists()
+    lines = out.read_text().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec['key'] == 'custom'
+    assert rec['count'] == 1
+    assert rec['actions'] == {'get': 1}
+    assert rec['value_types'] == {'str': 1}
+
+
+def test_trace_dump_noop_when_disabled(trace_off, tmp_path, monkeypatch):
+    """No file written when trace is off, even if buckets exist."""
+    out = tmp_path / 'trace.jsonl'
+    monkeypatch.setenv('DATALAD_STATUSRECORD_TRACE_PATH', str(out))
+    _trace_dump()
+    assert not out.exists()
 
 
 def test_in_the_wild_fields_are_typed_attributes():

--- a/datalad/interface/tests/test_status_record.py
+++ b/datalad/interface/tests/test_status_record.py
@@ -706,33 +706,136 @@ def test_trace_dump_noop_when_disabled(trace_off, tmp_path, monkeypatch):
     assert not out.exists()
 
 
-def test_in_the_wild_fields_are_typed_attributes():
-    """v2.3 promotion: fields explicitly listed in
-    ``docs/source/design/result_records.rst`` as commonly-observed across
-    commands are exposed as typed attributes rather than living in
-    ``_extras``. Pin the specific set so a future regression cannot
-    silently demote them.
+def test_v23_v26_base_fields_are_typed():
+    """v2.3 promoted four "in-the-wild" fields to base StatusRecord; v2.6
+    moved the file-specific subset (``bytesize``, ``key``) onto
+    ``FileStatusRecord`` based on the runtime telemetry sweep. The
+    remaining cross-type fields (``gitshasum``, ``prev_gitshasum``)
+    stay on the base.
     """
-    promoted = ('bytesize', 'gitshasum', 'prev_gitshasum', 'key')
-    for name in promoted:
+    on_base = ('gitshasum', 'prev_gitshasum')
+    for name in on_base:
         assert name in StatusRecord._DECLARED_FIELDS_SET, \
-            f'{name!r} should be a declared StatusRecord field (v2.3)'
+            f'{name!r} should still be a declared base field (v2.3)'
 
-    r = StatusRecord(
-        bytesize=1234,
-        gitshasum='deadbeef',
-        prev_gitshasum='cafebabe',
-        key='SHA256E-s12345--abc',
-    )
-    # accessible via both attribute and item style
-    assert r.bytesize == 1234
-    assert r['bytesize'] == 1234
+    moved_to_file = ('bytesize', 'key')
+    for name in moved_to_file:
+        assert name not in StatusRecord._DECLARED_FIELDS_SET, \
+            (f'{name!r} was moved off the base in v2.6 — runtime audit '
+             f'confirmed it is file-specific. Should live on '
+             f'FileStatusRecord.')
+
+    r = StatusRecord(gitshasum='deadbeef', prev_gitshasum='cafebabe')
     assert r.gitshasum == 'deadbeef'
     assert r['gitshasum'] == 'deadbeef'
     assert r.prev_gitshasum == 'cafebabe'
-    assert r.key == 'SHA256E-s12345--abc'
-    # not in _extras
     assert r._extras == {}
+
+
+# ---------------------------------------------------------------------------
+# v2.6: FileStatusRecord and SiblingStatusRecord
+# ---------------------------------------------------------------------------
+
+def test_file_status_record_declares_file_specific_fields():
+    """v2.6: ``FileStatusRecord`` exposes the file-specific cluster as
+    typed attributes."""
+    from datalad.interface.results import FileStatusRecord
+
+    expected = {
+        # moved from base in v2.6
+        'bytesize', 'key',
+        # promoted from extras in v2.6 (each ≥2 frames in the sweep)
+        'annexkey', 'backend', 'has_content', 'hashdirlower',
+        'hashdirmixed', 'humansize', 'keyname', 'mtime', 'objloc',
+    }
+    for name in expected:
+        assert name in FileStatusRecord._DECLARED_FIELDS_SET, \
+            f'{name!r} should be a typed FileStatusRecord field'
+
+    # base-class fields still accessible (subclass inherits)
+    base = {'action', 'path', 'status', 'type', 'message',
+            'gitshasum', 'prev_gitshasum'}
+    for name in base:
+        assert name in FileStatusRecord._DECLARED_FIELDS_SET, \
+            f'{name!r} (base) should be inherited by FileStatusRecord'
+
+
+def test_file_status_record_construction():
+    from datalad.interface.results import FileStatusRecord
+
+    r = FileStatusRecord(
+        action='get', path='/x', status='ok', type='file',
+        bytesize=1234, key='SHA256E-s1234--abc',
+        annexkey='SHA256E-s1234--abc', has_content=True,
+        humansize='1.2 KB',
+    )
+    assert r.bytesize == 1234
+    assert r['bytesize'] == 1234
+    assert r.key == 'SHA256E-s1234--abc'
+    assert r['has_content'] is True
+    # still a StatusRecord and a Mapping
+    assert isinstance(r, StatusRecord)
+    from collections.abc import Mapping as _Mapping
+    assert isinstance(r, _Mapping)
+
+
+def test_file_status_record_from_kwargs():
+    """Permissive ``from_kwargs`` works on the subclass too: declared
+    fields go to attributes, the rest to ``_extras``."""
+    from datalad.interface.results import FileStatusRecord
+
+    r = FileStatusRecord.from_kwargs(
+        action='status', type='file', path='/x',
+        bytesize=99, custom_extra='hi',
+    )
+    assert r.bytesize == 99
+    assert r['custom_extra'] == 'hi'
+    assert 'custom_extra' not in FileStatusRecord._DECLARED_FIELDS_SET
+
+
+def test_sibling_status_record_declares_name():
+    from datalad.interface.results import SiblingStatusRecord
+    assert 'name' in SiblingStatusRecord._DECLARED_FIELDS_SET
+    r = SiblingStatusRecord(
+        action='configure-sibling', type='sibling', name='origin')
+    assert r.name == 'origin'
+    assert r['name'] == 'origin'
+    # url stayed in extras per the v2.6 decision (single call site at
+    # sweep time)
+    r['url'] = 'https://example.com'
+    assert r['url'] == 'https://example.com'
+    assert 'url' not in SiblingStatusRecord._DECLARED_FIELDS_SET
+
+
+def test_subclass_extras_keys_still_work():
+    """Hyphenated keys (``annex-ignore``, ``gitmodule_*``-with-hyphens)
+    must continue to flow through ``_extras`` on the subclasses, since
+    they cannot be Python identifiers."""
+    from datalad.interface.results import (
+        FileStatusRecord,
+        SiblingStatusRecord,
+    )
+
+    s = SiblingStatusRecord(name='origin')
+    s['annex-ignore'] = 'false'
+    s['annex-uuid'] = '00000000-...'
+    assert s['annex-ignore'] == 'false'
+    assert s['annex-uuid'] == '00000000-...'
+
+    f = FileStatusRecord(type='file')
+    f['some-weird-key'] = 1
+    assert f['some-weird-key'] == 1
+
+
+def test_subclass_isinstance_chain():
+    """Existing consumers that test ``isinstance(r, StatusRecord)`` must
+    still match subclass instances."""
+    from datalad.interface.results import (
+        FileStatusRecord,
+        SiblingStatusRecord,
+    )
+    assert isinstance(FileStatusRecord(), StatusRecord)
+    assert isinstance(SiblingStatusRecord(), StatusRecord)
 
 
 def test_unset_sentinel_is_not_visible():

--- a/datalad/interface/tests/test_status_record.py
+++ b/datalad/interface/tests/test_status_record.py
@@ -505,6 +505,77 @@ def test_repr_shows_dict_view():
 # Sentinel hygiene
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# v2.4: opt-in strict-mode validation
+# ---------------------------------------------------------------------------
+
+def test_strict_mode_disabled_by_default(monkeypatch):
+    """Strict mode is opt-in: unset env => no validation, anything goes."""
+    monkeypatch.delenv('DATALAD_STATUSRECORD_STRICT', raising=False)
+    # invalid status accepted via every path
+    r = StatusRecord(status='funky')
+    assert r.status == 'funky'
+    r['status'] = 'wat'
+    assert r.status == 'wat'
+    # unknown extras key accepted silently
+    r['unknown_key'] = 1
+    assert r['unknown_key'] == 1
+
+
+@pytest.mark.parametrize('truthy', ['1', 'true', 'yes', 'TRUE', 'Yes'])
+def test_strict_mode_status_validation_via_init(monkeypatch, truthy):
+    """Strict mode rejects invalid status values at construction time
+    (catches the dataclass __init__ path that __setitem__ does not see)."""
+    monkeypatch.setenv('DATALAD_STATUSRECORD_STRICT', truthy)
+    with pytest.raises(ValueError, match='invalid status value'):
+        StatusRecord(status='funky')
+    # canonical statuses still accepted
+    for s in ('ok', 'notneeded', 'impossible', 'error'):
+        r = StatusRecord(status=s)
+        assert r.status == s
+
+
+def test_strict_mode_status_validation_via_setitem(monkeypatch):
+    monkeypatch.setenv('DATALAD_STATUSRECORD_STRICT', '1')
+    r = StatusRecord(status='ok')
+    with pytest.raises(ValueError, match='invalid status value'):
+        r['status'] = 'broken'
+    # original value preserved
+    assert r.status == 'ok'
+
+
+def test_strict_mode_status_validation_via_attribute_assign(monkeypatch):
+    monkeypatch.setenv('DATALAD_STATUSRECORD_STRICT', '1')
+    r = StatusRecord(status='ok')
+    with pytest.raises(ValueError, match='invalid status value'):
+        r.status = 'oh-no'
+    assert r.status == 'ok'
+
+
+def test_strict_mode_unknown_key_warns(monkeypatch, caplog):
+    """Unknown keys still go to _extras in strict mode, but emit a
+    WARNING so CI / development surfaces typos.
+    """
+    import logging as _log
+    monkeypatch.setenv('DATALAD_STATUSRECORD_STRICT', '1')
+    r = StatusRecord(action='get')
+    with caplog.at_level(_log.WARNING, logger='datalad.interface.results'):
+        r['typo_key'] = 1
+    assert 'typo_key' in r
+    assert any('unknown key' in m.message for m in caplog.records), \
+        f'expected warning, got: {[m.message for m in caplog.records]}'
+
+
+def test_strict_mode_status_none_allowed(monkeypatch):
+    """``None`` is the legacy "absent" marker (e.g. r['status'] = None
+    used to silently drop the key). Strict mode must not treat it as an
+    invalid status value.
+    """
+    monkeypatch.setenv('DATALAD_STATUSRECORD_STRICT', '1')
+    r = StatusRecord(status=None)        # accepted
+    assert r.status is None
+
+
 def test_in_the_wild_fields_are_typed_attributes():
     """v2.3 promotion: fields explicitly listed in
     ``docs/source/design/result_records.rst`` as commonly-observed across

--- a/datalad/interface/tests/test_status_record.py
+++ b/datalad/interface/tests/test_status_record.py
@@ -1,0 +1,518 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Tests for ``StatusRecord`` and its dict-compatibility surface.
+
+The migration from plain ``dict`` to ``StatusRecord`` (see
+``docs/designs/status-record.md``) must preserve every dict-shaped consumer
+pattern in the codebase: subscription, ``.get()`` / ``in`` / iteration,
+mutation, ``.pop()``, dict-spreading, JSON serialization, equality with plain
+dicts, hook-style key matching, and pickling.
+
+These tests pin those invariants so we can refactor producers and central
+consumers in v2 without silent regressions.
+"""
+
+import json
+import logging
+import pickle
+
+import pytest
+
+from datalad.interface.results import (
+    _UNSET,
+    StatusRecord,
+    get_status_dict,
+)
+
+
+# Reference implementation: the old dict-building body of get_status_dict,
+# without the StatusRecord wrapper. Used as the equivalence oracle in tests
+# that must stay byte-identical with the legacy behavior.
+def _legacy_get_status_dict(action=None, ds=None, path=None, type=None,
+                            logger=None, refds=None, status=None,
+                            message=None, error_message=None, **kwargs):
+    d = {}
+    if action is not None:
+        d['action'] = action
+    if ds:
+        d['path'] = ds.path
+        d['type'] = 'dataset'
+    if path is not None:
+        d['path'] = path
+    if type:
+        d['type'] = type
+    if logger:
+        d['logger'] = logger
+    if refds:
+        d['refds'] = refds
+    if status is not None:
+        d['status'] = status
+    if message is not None:
+        d['message'] = message
+    if error_message is not None:
+        d['error_message'] = error_message
+    if kwargs:
+        d.update(kwargs)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# basic construction and Mapping protocol
+# ---------------------------------------------------------------------------
+
+def test_construction_empty():
+    r = StatusRecord()
+    assert len(r) == 0
+    assert list(r) == []
+    assert dict(r) == {}
+
+
+def test_construction_via_kwargs_for_declared_fields():
+    r = StatusRecord(action='get', path='/x', status='ok')
+    assert r['action'] == 'get'
+    assert r['path'] == '/x'
+    assert r['status'] == 'ok'
+    assert r.action == 'get'
+    assert r.path == '/x'
+    assert r.status == 'ok'
+
+
+def test_init_rejects_unknown_kwargs():
+    """Typed ``__init__`` is strict — unknown kwargs raise TypeError.
+    Producers that need permissive behavior must use ``from_kwargs``."""
+    with pytest.raises(TypeError):
+        StatusRecord(action='get', custom='v')   # type: ignore[call-arg]
+
+
+def test_from_kwargs_routes_unknown_to_extras():
+    r = StatusRecord.from_kwargs(action='get', path='/x', status='ok',
+                                 custom='v', another=42)
+    assert r['action'] == 'get'
+    assert r['custom'] == 'v'
+    assert r['another'] == 42
+    assert r.action == 'get'
+    assert sorted(r.keys()) == ['action', 'another', 'custom', 'path', 'status']
+
+
+def test_from_kwargs_preserves_iteration_order_for_extras():
+    """Declared fields come first (in declaration order), extras follow in
+    kwargs order. Pin this so producer-side spreads have stable JSON output.
+    """
+    r = StatusRecord.from_kwargs(
+        action='get', custom='1', another='2', status='ok')
+    assert list(r) == ['action', 'status', 'custom', 'another']
+
+
+def test_from_kwargs_empty_works():
+    r = StatusRecord.from_kwargs()
+    assert len(r) == 0
+    assert dict(r) == {}
+
+
+def test_from_kwargs_positional_mapping_with_overrides():
+    """Mirrors ``dict(mapping, **overrides)``: positional mapping is the
+    base, kwargs override matching keys. This is the call form used by
+    producers that spread an existing res_kwargs dict and need to add or
+    override fields (e.g. ``yield StatusRecord.from_kwargs(res_kwargs,
+    type=c['type'], path=c['path'], action='copy')``).
+    """
+    base = {'action': 'publish', 'type': 'dataset', 'custom': 'v'}
+    r = StatusRecord.from_kwargs(base, type='file', path='/x')
+    assert r['action'] == 'publish'
+    assert r['type'] == 'file'           # overridden
+    assert r['path'] == '/x'             # added
+    assert r['custom'] == 'v'            # extras flow through
+    # source mapping is not mutated
+    assert base == {'action': 'publish', 'type': 'dataset', 'custom': 'v'}
+
+
+def test_from_kwargs_positional_only():
+    """Positional mapping with no override kwargs works as a pure copy."""
+    base = {'action': 'get', 'custom': 'v'}
+    r = StatusRecord.from_kwargs(base)
+    assert dict(r) == base
+
+
+def test_from_kwargs_accepts_status_record_as_base():
+    """A previously-yielded StatusRecord can serve as the base mapping
+    (used by ``status.py`` recursion: ``from_kwargs(r, refds=..., action=...)``).
+    """
+    r1 = StatusRecord.from_kwargs(action='get', path='/x', custom='v')
+    r2 = StatusRecord.from_kwargs(r1, refds='/refds', action='status')
+    assert r2['action'] == 'status'      # overridden
+    assert r2['refds'] == '/refds'
+    assert r2['path'] == '/x'
+    assert r2['custom'] == 'v'
+
+
+def test_unset_field_is_absent():
+    r = StatusRecord(action='get')
+    assert 'path' not in r
+    with pytest.raises(KeyError):
+        r['path']
+    # but .get() with default works as expected
+    assert r.get('path') is None
+    assert r.get('path', 'fallback') == 'fallback'
+
+
+def test_in_operator_only_for_strings():
+    r = StatusRecord(action='get')
+    assert 'action' in r
+    assert 42 not in r            # non-string keys: just absent, no TypeError
+
+
+def test_set_unknown_key_routes_to_extras():
+    r = StatusRecord(action='get')
+    r['custom'] = 1
+    r['annex-ignore'] = 'false'   # hyphenated key, can't be an attribute
+    assert r['custom'] == 1
+    assert r['annex-ignore'] == 'false'
+    assert 'custom' in r
+    assert 'annex-ignore' in r
+
+
+def test_setitem_for_declared_field_updates_attribute():
+    r = StatusRecord()
+    r['status'] = 'ok'
+    assert r.status == 'ok'
+    assert r['status'] == 'ok'
+
+
+def test_delitem_removes_declared_and_extras():
+    r = StatusRecord(action='get')
+    r['custom'] = 1
+    del r['action']
+    assert 'action' not in r
+    del r['custom']
+    assert 'custom' not in r
+    with pytest.raises(KeyError):
+        del r['action']            # already absent
+    with pytest.raises(KeyError):
+        del r['nonexistent']
+
+
+def test_copy_returns_independent_instance():
+    """``StatusRecord.copy()`` mirrors ``dict.copy()`` semantics: a fresh
+    instance, mutations on the copy don't leak back. Backward-compat for
+    test helpers (``_without_command`` in ``test_foreach_dataset.py``)
+    and producer code (``save.py:360``) that treat result records as
+    dicts and call ``.copy()``."""
+    r = StatusRecord(action='get', path='/x', status='ok')
+    r['custom'] = 'v'
+    r2 = r.copy()
+    # equal but not the same object
+    assert r == r2
+    assert r is not r2
+    assert isinstance(r2, StatusRecord)
+    # extras are also shallow-copied — mutating copy doesn't leak
+    r2['extra2'] = 'late'
+    assert 'extra2' not in r
+    r2['status'] = 'error'
+    assert r['status'] == 'ok'
+
+
+def test_copy_preserves_subclass_type():
+    """``copy()`` returns the concrete subclass, not the base."""
+    from datalad.interface.results import (
+        FileStatusRecord,
+        SiblingStatusRecord,
+    )
+    f = FileStatusRecord(action='get', type='file', bytesize=1234)
+    fc = f.copy()
+    assert isinstance(fc, FileStatusRecord)
+    assert fc.bytesize == 1234
+
+    s = SiblingStatusRecord(action='configure-sibling', type='sibling',
+                             name='origin')
+    sc = s.copy()
+    assert isinstance(sc, SiblingStatusRecord)
+    assert sc.name == 'origin'
+
+
+def test_pop_logger_pattern():
+    """The renderer pipeline does ``res.pop('logger', None)`` — verify it
+    returns the logger and afterwards ``'logger' not in r``.
+    """
+    lgr = logging.getLogger('test_pop_logger')
+    r = StatusRecord(action='get', logger=lgr)
+    popped = r.pop('logger', None)
+    assert popped is lgr
+    assert 'logger' not in r
+    # second pop with default returns the default
+    assert r.pop('logger', 'gone') == 'gone'
+
+
+def test_iter_order_is_declared_then_extras():
+    r = StatusRecord(action='a', path='/p', status='ok')
+    r['custom'] = 1
+    r['other'] = 2
+    keys = list(r)
+    # declared fields appear in declaration order, extras follow in
+    # insertion order
+    assert keys[:3] == ['action', 'path', 'status']
+    assert keys[3:] == ['custom', 'other']
+
+
+def test_len_counts_only_set_fields():
+    r = StatusRecord()
+    assert len(r) == 0
+    r['action'] = 'get'
+    assert len(r) == 1
+    r['custom'] = 1
+    assert len(r) == 2
+    del r['custom']
+    assert len(r) == 1
+
+
+# ---------------------------------------------------------------------------
+# equality, dict-spread, items/keys/values
+# ---------------------------------------------------------------------------
+
+def test_equality_with_plain_dict():
+    r = StatusRecord(action='get', path='/x', status='ok')
+    assert r == {'action': 'get', 'path': '/x', 'status': 'ok'}
+    assert {'action': 'get', 'path': '/x', 'status': 'ok'} == dict(r)
+
+
+def test_equality_between_records():
+    r1 = StatusRecord(action='get', path='/x', status='ok')
+    r2 = StatusRecord(action='get', path='/x', status='ok')
+    r3 = StatusRecord(action='get', path='/y', status='ok')
+    assert r1 == r2
+    assert r1 != r3
+
+
+def test_equality_includes_extras():
+    r1 = StatusRecord(action='get')
+    r2 = StatusRecord(action='get')
+    r1['custom'] = 1
+    assert r1 != r2
+    r2['custom'] = 1
+    assert r1 == r2
+
+
+def test_equality_against_non_mapping():
+    r = StatusRecord(action='get')
+    assert r != 42
+    assert r != 'get'
+    assert (r == 'get') is False
+
+
+def test_dict_spread_into_dict():
+    r = StatusRecord(action='get', path='/x', status='ok')
+    spread = dict(r, message='hi')
+    assert spread == {
+        'action': 'get', 'path': '/x', 'status': 'ok', 'message': 'hi',
+    }
+
+
+def test_dict_spread_from_dict():
+    base = {'action': 'get', 'path': '/x'}
+    r = StatusRecord(**base, status='ok')
+    assert r == {'action': 'get', 'path': '/x', 'status': 'ok'}
+
+
+def test_items_keys_values():
+    r = StatusRecord(action='get', status='ok')
+    r['custom'] = 1
+    assert sorted(r.keys()) == ['action', 'custom', 'status']
+    assert sorted(r.values(), key=str) == [1, 'get', 'ok']
+    assert sorted(r.items()) == [
+        ('action', 'get'), ('custom', 1), ('status', 'ok'),
+    ]
+
+
+def test_extras_never_visible_as_a_key():
+    r = StatusRecord(action='get')
+    r['custom'] = 1
+    # the internal _extras dict must not surface as a key in any view
+    assert '_extras' not in r
+    assert '_extras' not in list(r)
+    assert '_extras' not in r.keys()
+    assert '_extras' not in dict(r)
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization byte-equivalence with the legacy dict
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('kw', [
+    dict(),
+    dict(action='get'),
+    dict(action='get', path='/x', status='ok'),
+    dict(action='get', path='/x', status='ok', message='hello'),
+    dict(action='get', path='/x', status='ok', extra_key='extra_value'),
+    dict(action='get', path='/x', status='ok',
+         message=('formatted %s', 'arg')),
+])
+def test_json_serialization_matches_legacy(kw):
+    r = get_status_dict(**kw)
+    legacy = _legacy_get_status_dict(**kw)
+    assert json.dumps(dict(r), sort_keys=True, default=str) == \
+        json.dumps(legacy, sort_keys=True, default=str)
+    # unsorted JSON must also match because iteration order is preserved
+    assert json.dumps(dict(r), default=str) == \
+        json.dumps(legacy, default=str)
+
+
+# ---------------------------------------------------------------------------
+# get_status_dict equivalence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('kw', [
+    dict(action='get'),
+    dict(action='get', path='/x', status='ok'),
+    dict(action='get', path='/x', status='ok', message='hello'),
+    dict(action='get', path='/x', status='ok',
+         message='hello', error_message='boom'),
+    dict(action='get', path='/x', custom='value', another='more'),
+])
+def test_get_status_dict_returns_dict_equivalent(kw):
+    r = get_status_dict(**kw)
+    legacy = _legacy_get_status_dict(**kw)
+    assert isinstance(r, StatusRecord)
+    assert r == legacy
+    assert dict(r) == legacy
+    assert list(r) == list(legacy)
+
+
+def test_get_status_dict_returns_status_record():
+    r = get_status_dict(action='get', status='ok')
+    assert isinstance(r, StatusRecord)
+    # but still a Mapping
+    from collections.abc import Mapping
+    assert isinstance(r, Mapping)
+
+
+# ---------------------------------------------------------------------------
+# Mutation patterns observed in the codebase
+# ---------------------------------------------------------------------------
+
+def test_mutation_of_status_message_path():
+    """update.py / siblings.py / addurls.py mutate these post-construction."""
+    r = get_status_dict(action='update', path='/x', status='impossible')
+    r['status'] = 'notneeded'
+    r['message'] = 'reconsidered'
+    r['path'] = '/y'
+    assert r['status'] == 'notneeded'
+    assert r['message'] == 'reconsidered'
+    assert r['path'] == '/y'
+
+
+def test_mutation_of_extras_key():
+    """create_sibling_gin.py: ``res['annex-ignore'] = 'false'``."""
+    r = get_status_dict(action='configure-sibling', path='/x', status='ok')
+    r['annex-ignore'] = 'false'
+    assert r['annex-ignore'] == 'false'
+    assert 'annex-ignore' in dict(r)
+
+
+# ---------------------------------------------------------------------------
+# Hook-style key match (datalad/core/local/resulthooks.py)
+# ---------------------------------------------------------------------------
+
+def test_jsonhook_match_against_status_record():
+    """The hook system iterates ``match.items()`` and checks
+    ``k in res`` / ``res[k] == val``. Verify the StatusRecord matches the
+    same way as a plain dict.
+    """
+    from datalad.core.local.resulthooks import match_jsonhook2result
+    r = get_status_dict(action='get', path='/x', status='ok', type='file')
+    legacy = _legacy_get_status_dict(
+        action='get', path='/x', status='ok', type='file')
+
+    matches = [
+        # eq operator (default)
+        {'action': 'get'},
+        {'action': 'get', 'status': 'ok'},
+        # in operator
+        {'type': ['in', ['file', 'directory']]},
+        # neq operator
+        {'status': ['neq', 'error']},
+    ]
+    nonmatches = [
+        {'action': 'drop'},
+        {'type': ['in', ['dataset']]},
+        {'status': ['neq', 'ok']},
+    ]
+    for m in matches:
+        assert match_jsonhook2result('h', r, m) == \
+            match_jsonhook2result('h', legacy, m)
+        assert match_jsonhook2result('h', r, m) is True
+    for m in nonmatches:
+        assert match_jsonhook2result('h', r, m) == \
+            match_jsonhook2result('h', legacy, m)
+        assert match_jsonhook2result('h', r, m) is False
+
+
+# ---------------------------------------------------------------------------
+# EnsureKeyChoice constraint (datalad/support/constraints.py)
+# ---------------------------------------------------------------------------
+
+def test_ensure_key_choice_accepts_status_record():
+    from datalad.support.constraints import EnsureKeyChoice
+    constraint = EnsureKeyChoice('action', ('install', 'get'))
+    r = get_status_dict(action='install', path='/x', status='ok')
+    assert constraint(r) is r
+    bad = get_status_dict(action='drop', path='/x', status='ok')
+    with pytest.raises(ValueError):
+        constraint(bad)
+
+
+# ---------------------------------------------------------------------------
+# Pickling
+# ---------------------------------------------------------------------------
+
+def test_pickle_round_trip():
+    r = get_status_dict(action='get', path='/x', status='ok',
+                        message='hi', custom='value')
+    r2 = pickle.loads(pickle.dumps(r))
+    assert isinstance(r2, StatusRecord)
+    assert r == r2
+    assert dict(r) == dict(r2)
+
+
+def test_pickle_round_trip_with_logger_removed():
+    """Logger isn't picklable in general; the pipeline pops it before
+    serialization. Verify the pop+pickle pattern works."""
+    lgr = logging.getLogger('test_pickle')
+    r = get_status_dict(action='get', path='/x', status='ok', logger=lgr)
+    r.pop('logger', None)
+    r2 = pickle.loads(pickle.dumps(r))
+    assert r == r2
+    assert 'logger' not in r2
+
+
+# ---------------------------------------------------------------------------
+# repr / debugging
+# ---------------------------------------------------------------------------
+
+def test_repr_shows_dict_view():
+    r = StatusRecord(action='get', status='ok')
+    s = repr(r)
+    assert 'StatusRecord' in s
+    assert "'action': 'get'" in s
+    assert "'status': 'ok'" in s
+
+
+# ---------------------------------------------------------------------------
+# Sentinel hygiene
+# ---------------------------------------------------------------------------
+
+def test_unset_sentinel_is_not_visible():
+    r = StatusRecord()
+    # _UNSET must never escape to a consumer
+    for k in r:
+        assert r[k] is not _UNSET
+    for v in r.values():
+        assert v is not _UNSET
+    # writing _UNSET deletes the field
+    r['action'] = 'get'
+    r['action'] = _UNSET
+    assert 'action' not in r

--- a/datalad/interface/tests/test_status_record.py
+++ b/datalad/interface/tests/test_status_record.py
@@ -505,6 +505,35 @@ def test_repr_shows_dict_view():
 # Sentinel hygiene
 # ---------------------------------------------------------------------------
 
+def test_in_the_wild_fields_are_typed_attributes():
+    """v2.3 promotion: fields explicitly listed in
+    ``docs/source/design/result_records.rst`` as commonly-observed across
+    commands are exposed as typed attributes rather than living in
+    ``_extras``. Pin the specific set so a future regression cannot
+    silently demote them.
+    """
+    promoted = ('bytesize', 'gitshasum', 'prev_gitshasum', 'key')
+    for name in promoted:
+        assert name in StatusRecord._DECLARED_FIELDS_SET, \
+            f'{name!r} should be a declared StatusRecord field (v2.3)'
+
+    r = StatusRecord(
+        bytesize=1234,
+        gitshasum='deadbeef',
+        prev_gitshasum='cafebabe',
+        key='SHA256E-s12345--abc',
+    )
+    # accessible via both attribute and item style
+    assert r.bytesize == 1234
+    assert r['bytesize'] == 1234
+    assert r.gitshasum == 'deadbeef'
+    assert r['gitshasum'] == 'deadbeef'
+    assert r.prev_gitshasum == 'cafebabe'
+    assert r.key == 'SHA256E-s12345--abc'
+    # not in _extras
+    assert r._extras == {}
+
+
 def test_unset_sentinel_is_not_visible():
     r = StatusRecord()
     # _UNSET must never escape to a consumer

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -15,6 +15,11 @@ __docformat__ = 'restructuredtext'
 import json
 import logging
 import sys
+from collections.abc import (
+    Iterable,
+    Iterator,
+    Mapping,
+)
 from os import listdir
 from os.path import isdir
 from os.path import join as opj
@@ -230,7 +235,7 @@ def eval_results(wrapped):
     return eval_results_moved(wrapped)
 
 
-def generic_result_renderer(res):
+def generic_result_renderer(res: Mapping) -> None:
     # Tolerate plain dicts here: this is a public, extension-callable
     # entry point. Coerce so downstream attribute access is safe.
     res = as_status_record(res)
@@ -297,14 +302,14 @@ def _display_suppressed_message(nsimilar, ndisplayed, last_ts, final=False):
 
 
 def _process_results(
-        results,
+        results: 'Iterable[Mapping]',
         cmd_class,
         on_failure,
         action_summary,
         incomplete_results,
         result_renderer,
         result_log_level,
-        allkwargs):
+        allkwargs) -> 'Iterator[StatusRecord]':
     # private helper pf @eval_results
     # loop over results generated from some source and handle each
     # of them according to the requested behavior (logging, rendering, ...)

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -28,6 +28,10 @@ from typing import TypeVar
 import datalad.support.ansi_colors as ac
 from datalad import cfg as dlcfg
 from datalad.dochelpers import single_or_plural
+from datalad.interface.results import (
+    StatusRecord,
+    as_status_record,
+)
 from datalad.support.exceptions import CapturedException
 from datalad.support.gitrepo import GitRepo
 from datalad.ui import ui
@@ -227,11 +231,14 @@ def eval_results(wrapped):
 
 
 def generic_result_renderer(res):
-    if res.get('status', None) != 'notneeded':
+    # Tolerate plain dicts here: this is a public, extension-callable
+    # entry point. Coerce so downstream attribute access is safe.
+    res = as_status_record(res)
+    if res.status != 'notneeded':
         path = res.get('path', None)
         if path and res.get('refds'):
             try:
-                path = relpath(path, res['refds'])
+                path = relpath(path, res.refds)
             except ValueError:
                 # can happen, e.g., on windows with paths from different
                 # drives. just go with the original path in this case
@@ -243,18 +250,17 @@ def generic_result_renderer(res):
             status=ac.color_status(res.get('status', '<status-unspecified>')),
             path=' {}'.format(path) if path else '',
             type=' ({})'.format(
-                ac.color_word(res['type'], ac.MAGENTA)
+                ac.color_word(res.type, ac.MAGENTA)
             ) if 'type' in res else '',
             msg=' [{}]'.format(
-                res['message'][0] % res['message'][1:]
-                if isinstance(res['message'], tuple) else res[
-                    'message'])
+                res.message[0] % res.message[1:]
+                if isinstance(res.message, tuple) else res.message)
             if res.get('message', None) else '',
             err=ac.color_word(' [{}]'.format(
-                res['error_message'][0] % res['error_message'][1:]
-                if isinstance(res['error_message'], tuple) else res[
-                    'error_message']), ac.RED)
-            if res.get('error_message', None) and res.get('status', None) != 'ok' else ''))
+                res.error_message[0] % res.error_message[1:]
+                if isinstance(res.error_message, tuple)
+                else res.error_message), ac.RED)
+            if res.get('error_message', None) and res.status != 'ok' else ''))
 
 
 # keep for legacy compatibility
@@ -324,10 +330,16 @@ def _process_results(
             lgr.debug('Drop result record without "action": %s', res)
             continue
 
-        actsum = action_summary.get(res['action'], {})
-        if res['status']:
-            actsum[res['status']] = actsum.get(res['status'], 0) + 1
-            action_summary[res['action']] = actsum
+        # coerce-at-boundary: downstream code can rely on attribute access
+        # for typed fields. This also makes plain-dict results from
+        # extension code (or pre-migration call sites) typed as they flow
+        # through the pipeline.
+        res = as_status_record(res)
+
+        actsum = action_summary.get(res.action, {})
+        if res.status:
+            actsum[res.status] = actsum.get(res.status, 0) + 1
+            action_summary[res.action] = actsum
         ## log message, if there is one and a logger was given
         msg = res.get('message', None)
         # remove logger instance from results, as it is no longer useful
@@ -339,22 +351,22 @@ def _process_results(
                 # didn't get a particular log function, go with default
                 res_lgr = getattr(
                     res_lgr,
-                    default_logchannels[res['status']]
+                    default_logchannels[res.status]
                     if result_log_level == 'match-status'
                     else result_log_level)
-            msg = res['message']
+            msg = res.message
             msgargs = None
             if isinstance(msg, tuple):
                 msgargs = msg[1:]
                 msg = msg[0]
             if 'path' in res:
                 # result path could be a path instance
-                path = str(res['path'])
+                path = str(res.path)
                 if msgargs:
                     # we will pass the msg for %-polation, so % should be doubled
                     path = path.replace('%', '%%')
                 msg = '{} [{}({})]'.format(
-                    msg, res['action'], path)
+                    msg, res.action, path)
             if msgargs:
                 # support string expansion of logging to avoid runtime cost
                 try:
@@ -388,7 +400,7 @@ def _process_results(
         # looks for error status, and report at the end via
         # an exception
         if on_failure in ('continue', 'stop') \
-                and res['status'] in ('impossible', 'error'):
+                and res.status in ('impossible', 'error'):
             incomplete_results.append(res)
             if on_failure == 'stop':
                 # first fail -> that's it
@@ -409,7 +421,7 @@ def _render_result_generic(
     repetition_keys = set(('action', 'status', 'type', 'refds'))
 
     trimmed_result = {k: v for k, v in res.items() if k in repetition_keys}
-    if res.get('status', None) != 'notneeded' \
+    if res.status != 'notneeded' \
             and trimmed_result == last_result:
         # this is a similar report, suppress if too many, but count it
         last_result_reps += 1

--- a/datalad/local/add_readme.py
+++ b/datalad/local/add_readme.py
@@ -11,6 +11,7 @@
 __docformat__ = 'restructuredtext'
 
 import logging
+from collections.abc import Mapping
 
 from datalad.interface.base import (
     Interface,
@@ -259,7 +260,7 @@ def _get_dataset_metadata(dataset):
             return_type='item-or-list',
             result_renderer='disabled',
             on_failure='ignore')
-        if not isinstance(dsinfo, dict) or dsinfo.get('status', None) != 'ok':
+        if not isinstance(dsinfo, Mapping) or dsinfo.get('status', None) != 'ok':
             lgr.warning("Could not obtain dataset metadata, proceeding without")
         else:
             # flatten possibly existing multiple metadata sources

--- a/datalad/local/addurls.py
+++ b/datalad/local/addurls.py
@@ -32,6 +32,7 @@ from datalad.interface.common_opts import (
     nosave_opt,
 )
 from datalad.interface.results import (
+    StatusRecord,
     annexjson2result,
     get_status_dict,
 )
@@ -927,10 +928,11 @@ class RegisterUrl(object):
                 ek_info = self.examinekey(parsed_key, filename,
                                           migrate=migrate)
                 if not ek_info:
-                    yield dict(self._err_res,
-                               path=row["filename_abs"],
-                               message=("Failed to get information for %s",
-                                        parsed_key))
+                    yield StatusRecord.from_kwargs(
+                        self._err_res,
+                        path=row["filename_abs"],
+                        message=("Failed to get information for %s",
+                                 parsed_key))
                     return
                 key = ek_info["key"]
             else:
@@ -943,10 +945,11 @@ class RegisterUrl(object):
                 res["message"] = "registered URL"
         except CommandError as exc:
             ce = CapturedException(exc)
-            yield dict(self._err_res,
-                       path=row["filename_abs"],
-                       message=str(ce),
-                       exception=ce)
+            yield StatusRecord.from_kwargs(
+                self._err_res,
+                path=row["filename_abs"],
+                message=str(ce),
+                exception=ce)
         else:
             yield res
 
@@ -1355,7 +1358,8 @@ class Addurls(Interface):
         repo = ds.repo
         st_dict = get_status_dict(action="addurls", ds=ds)
         if repo and not isinstance(repo, AnnexRepo):
-            yield dict(st_dict, status="error", message="not an annex repo")
+            yield StatusRecord.from_kwargs(
+                st_dict, status="error", message="not an annex repo")
             return
 
         if isinstance(url_file, str):
@@ -1388,18 +1392,19 @@ class Addurls(Interface):
                                          missing_value)
             except (ValueError, RequestException) as exc:
                 ce = CapturedException(exc)
-                yield dict(st_dict, status="error", message=str(ce),
-                           exception=ce)
+                yield StatusRecord.from_kwargs(
+                    st_dict, status="error", message=str(ce), exception=ce)
                 return
 
         if not rows:
-            yield dict(st_dict, status="notneeded",
-                       message="No rows to process")
+            yield StatusRecord.from_kwargs(
+                st_dict, status="notneeded", message="No rows to process")
             return
 
         collision_err = _handle_collisions(records, rows, on_collision)
         if collision_err:
-            yield dict(st_dict, status="error", message=collision_err)
+            yield StatusRecord.from_kwargs(
+                st_dict, status="error", message=collision_err)
             return
 
         if dry_run:
@@ -1418,7 +1423,8 @@ class Addurls(Interface):
                     lgr.info("Metadata: %s",
                              sorted(u"{}={}".format(k, v)
                                     for k, v in row["meta_args"].items()))
-            yield dict(st_dict, status="ok", message="dry-run finished")
+            yield StatusRecord.from_kwargs(
+                st_dict, status="ok", message="dry-run finished")
             return
 
         if not repo:

--- a/datalad/local/copy_file.py
+++ b/datalad/local/copy_file.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 import logging
 import os.path as op
 import sys
+from collections.abc import Mapping
 from functools import lru_cache
 from shutil import copyfile
 
@@ -628,7 +629,7 @@ def _copy_file(src, dest, cache):
     # at this point we are copying an annexed file into an annex repo
     res = _place_filekey(
         finfo, str_src, dest, str_dest, dest_repo)
-    if isinstance(res, dict):
+    if isinstance(res, Mapping):
         yield res
         return
     dest_key = res

--- a/datalad/local/run_procedure.py
+++ b/datalad/local/run_procedure.py
@@ -17,7 +17,12 @@ import os.path as op
 import stat
 import sys
 from argparse import REMAINDER
+from collections.abc import Mapping
 from glob import iglob
+from importlib.resources import (
+    as_file,
+    files,
+)
 
 import datalad.support.ansi_colors as ac
 from datalad import cfg
@@ -46,11 +51,6 @@ from datalad.utils import (
     join_cmdline,
     quote_cmdlinearg,
     split_cmdline,
-)
-
-from importlib.resources import (
-    as_file,
-    files,
 )
 
 lgr = logging.getLogger('datalad.local.run_procedures')
@@ -382,9 +382,9 @@ class RunProcedure(Interface):
             return
 
 
-        if isinstance(spec, dict):
+        if isinstance(spec, Mapping):
             # Skip getting procedure implementation if called with a
-            # dictionary (presumably coming from --discover)
+            # mapping (presumably coming from --discover)
             procedure_file = spec['path']
             cmd_name = spec['procedure_name']
             cmd_tmpl = spec['procedure_callfmt']

--- a/datalad/support/due_utils.py
+++ b/datalad/support/due_utils.py
@@ -5,6 +5,7 @@ Support functionality for using DueCredit
 """
 
 import logging
+from collections.abc import Mapping
 
 from datalad.support.exceptions import CapturedException
 
@@ -75,8 +76,8 @@ def duecredit_dataset(dataset):
         )
         return
 
-    if not isinstance(res, dict):
-        lgr.debug("Got record which is not a dict, no duecredit for now")
+    if not isinstance(res, Mapping):
+        lgr.debug("Got record which is not a Mapping, no duecredit for now")
         return
 
     metadata = res.get('metadata', {})

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -75,12 +75,12 @@ from datalad.consts import (
     RESERVED_NAMES_WIN,
 )
 from datalad.core.local.repo import repo_from_path
-from datalad.dochelpers import single_or_plural
 from datalad.dataset.gitrepo import GitRepo as CoreGitRepo
 from datalad.dataset.gitrepo import (
     _get_dot_git,
     path_based_str_repr,
 )
+from datalad.dochelpers import single_or_plural
 from datalad.log import log_progress
 from datalad.support.due import (
     Doi,
@@ -133,6 +133,7 @@ from .path import (
 
 if TYPE_CHECKING:
     from datalad.distribution.dataset import Dataset
+    from datalad.interface.results import StatusRecord
 
 # shortcuts
 _curdirsep = curdir + sep
@@ -3411,7 +3412,7 @@ class GitRepo(CoreGitRepo):
                 careless=True,
             )
 
-    def save(self, message: Optional[str] = None, paths: Optional[list[Path]] = None, _status: Optional[dict[Path, dict[str, str]]] = None, **kwargs: Any) -> list[dict]:
+    def save(self, message: Optional[str] = None, paths: Optional[list[Path]] = None, _status: Optional[dict[Path, dict[str, str]]] = None, **kwargs: Any) -> list['StatusRecord']:
         """Save dataset content.
 
         Parameters
@@ -3450,7 +3451,7 @@ class GitRepo(CoreGitRepo):
             )
         )
 
-    def save_(self, message: Optional[str] = None, paths: Optional[list[Path]] = None, _status: Optional[dict[Path, dict[str, str]]] = None, **kwargs: Any) -> Iterator[dict]:
+    def save_(self, message: Optional[str] = None, paths: Optional[list[Path]] = None, _status: Optional[dict[Path, dict[str, str]]] = None, **kwargs: Any) -> Iterator['StatusRecord']:
         """Like `save()` but working as a generator."""
         from datalad.interface.results import get_status_dict
 
@@ -3808,7 +3809,7 @@ class GitRepo(CoreGitRepo):
             raise ValueError(
                 f"Invalid 'config' value {config!r}")
 
-    def _save_add(self, files: dict[str, Any], git_opts: Optional[list[str]] = None) -> Iterator[dict]:
+    def _save_add(self, files: dict[str, Any], git_opts: Optional[list[str]] = None) -> Iterator['StatusRecord']:
         """Simple helper to add files in save()"""
         from datalad.interface.results import get_status_dict
         try:
@@ -3842,7 +3843,7 @@ class GitRepo(CoreGitRepo):
             lgr.error("add: %s", e)
             raise
 
-    def _save_add_submodules(self, paths: list[Path] | dict[Path, dict]) -> Iterator[dict]:
+    def _save_add_submodules(self, paths: list[Path] | dict[Path, dict]) -> Iterator['StatusRecord']:
         """Add new submodules, or updates records of existing ones
 
         This method does not use `git submodule add`, but aims to be more

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -33,6 +33,7 @@ from collections.abc import (
     Callable,
     Iterable,
     Iterator,
+    Mapping,
     Sequence,
 )
 from contextlib import contextmanager
@@ -800,16 +801,17 @@ def ensure_list(s: Any, copy: bool=False, iterate: bool=True) -> list:
 def ensure_result_list(r: Any) -> list:
     """Return a list of result records
 
-    Largely same as ensure_list, but special casing a single dict being passed
-    in, which a plain `ensure_list` would iterate over. Hence, this deals with
-    the three ways datalad commands return results:
-    - single dict
-    - list of dicts
+    Largely same as ensure_list, but special casing a single Mapping being
+    passed in (a plain ``dict`` or a ``StatusRecord``), which a plain
+    ``ensure_list`` would iterate over (yielding keys). Hence, this deals
+    with the three ways datalad commands return results:
+    - single result record (``dict`` or ``StatusRecord``)
+    - list of result records
     - generator
 
     Used for result assertion helpers.
     """
-    return [r] if isinstance(r, dict) else ensure_list(r)
+    return [r] if isinstance(r, Mapping) else ensure_list(r)
 
 @overload
 def ensure_list_from_str(s: str, sep: str='\n') -> Optional[list[str]]:

--- a/docs/designs/status-record.md
+++ b/docs/designs/status-record.md
@@ -425,6 +425,35 @@ Once v2.1–v2.3 have shaken out the field set, add:
 - Optional `slots=True` if microbenchmarks show measurable overhead
   (Python 3.10+). Only if numbers warrant it.
 
+##### Outcome (v2.4 landed)
+
+The full set is gated behind a single `DATALAD_STATUSRECORD_STRICT` env
+variable (truthy values: `1`, `true`, `yes`); off by default so existing
+producers and extensions are unaffected.
+
+When strict mode is on:
+
+- **Status-value validation** — implemented in `__setattr__` (not
+  `__setitem__`) so it catches all three set paths:
+  `StatusRecord(status=v)` (dataclass `__init__`), `r['status'] = v`
+  (`__setitem__`), and `r.status = v` (direct attribute assignment).
+  Raises `ValueError` for non-canonical values; `None` is still
+  accepted as the legacy "absent" marker.
+- **Unknown-key warning** — `__setitem__` of a key not in the declared
+  set (i.e. routed to `_extras`) logs at WARNING. Does not raise — too
+  disruptive for extension-yielded results that may use ad-hoc keys.
+
+A grep across the codebase before landing v2.4 found every in-tree
+producer uses a canonical status value (`ok` / `error` / `impossible`
+/ `notneeded`); the only non-canonical hits were both in test fixtures
+that explicitly exercise the unknown-status path. So default-off
+strict mode is the right call: production is silent, but anyone
+turning the flag on in a development or CI run gets immediate signal.
+
+`slots=True` deferred — no benchmark data yet showing measurable
+overhead. Can be added cheaply in a future PR if profiling motivates
+it.
+
 Exit criterion: validation either lands cleanly (no producer changes needed)
 or this doc records the offending sites and defers to a v3 cleanup pass.
 

--- a/docs/designs/status-record.md
+++ b/docs/designs/status-record.md
@@ -384,22 +384,33 @@ Inputs from v2.1 + v2.2. Decision rules:
   the subclass to eliminate at least one `cast` / `assert`.
 - Otherwise the field stays in `extras` and the subclass is not created.
 
-Candidate clusters from the audit (subject to v2.1/v2.2 confirmation):
+##### Outcome (v2.3 landed)
 
-| Candidate subclass | Action(s) | Fields under consideration |
+Field promotions to base `StatusRecord`:
+
+| Field | Reason |
+|---|---|
+| `bytesize` | Listed in `docs/source/design/result_records.rst` as common in-the-wild; used across status / addurls / push |
+| `gitshasum` | Same; used in core/local/status, save, run-record |
+| `prev_gitshasum` | Same; pairs with `gitshasum` for diff/save records |
+| `key` | Same; git-annex key, used wherever `type='file'` annexed entities are reported |
+
+Subclasses parked (not introduced in v2.3):
+
+| Candidate | Decision | Reason |
 |---|---|---|
-| `FileStatusRecord` | `status`, `diff`, `save`, `get`, `add` | `state`, `gitshasum`, `prev_gitshasum`, `bytesize`, `key`, `annexkey` |
-| `DatasetStatusRecord` | most dataset-level results | `gitshasum`, `prev_gitshasum`, `branch` |
-| `SiblingStatusRecord` | `siblings`, `create-sibling-*` | `name`, `url`, `ssh_url`, `annex-ignore` (note: hyphen → stays in `extras`) |
-| `AnnexJsonRecord` | results from `annexjson2result` | `annexkey`, `metadata` |
+| `FileStatusRecord` (`state`, `gitshasum`, `prev_gitshasum`, `bytesize`, `key`, `annexkey`) | parked | Five of six fields now live on base; the marginal benefit of a subclass would be exclusively `annexkey` typing — too small to justify the API surface |
+| `DatasetStatusRecord` (`gitshasum`, `prev_gitshasum`, `branch`) | parked | First two now on base; `branch` appears in only one producer (`update.py`) — fails the ≥2-callers rule |
+| `SiblingStatusRecord` (`name`, `url`, `ssh_url`, `annex-ignore`) | parked | Cluster is real but `annex-ignore` *cannot* be a Python identifier (hyphen) and must stay in `_extras`; the typed-access benefit on the remaining three doesn't outweigh adding a class. Revisit if more sibling commands are added |
+| `AnnexJsonRecord` (`annexkey`, `metadata`) | parked | Two fields, single producer (`annexjson2result`); fails the ≥3-fields rule |
 
-Each subclass that survives the decision rule is added in its own sub-PR with
-a single producer migrated to it (e.g. `core/local/status.py` for
-`FileStatusRecord`). If a candidate fails the rule, this doc is updated with
-the reason ("`branch` only used by 1 producer; staying in `extras`") and the
-class is *not* created.
+The "park" decisions can be revisited cheaply later: a subclass is purely
+additive on top of `StatusRecord`. v2.3 deliberately chooses the smaller
+surface; the v2.4/v2.5 work can run with what's already in place.
 
-Exit criterion: subclass set frozen and documented in `docs/source/design/result_records.rst`.
+Exit criterion (met): the four in-the-wild fields are now typed attributes;
+the subclass set is documented as parked with reasons; no new tests
+regressed.
 
 #### v2.4 — opt-in strictness and validation
 

--- a/docs/designs/status-record.md
+++ b/docs/designs/status-record.md
@@ -1,0 +1,492 @@
+# Status Record migration plan
+
+Branch: `enh-statusrec-class`
+
+Goal: replace the ad-hoc `dict` produced by `datalad.interface.results.get_status_dict`
+with a typed dataclass-style class, **without breaking** any of the dict-shaped
+consumers (in-tree code, JSON output, user hooks, third-party renderers), and
+**with the smallest possible diff** so the change can be reviewed by a human in one
+sitting.
+
+## Guiding principle: small, reviewable v1 — but v2 is where the design is validated
+
+A v1 PR should add the new class, route `get_status_dict` through it, and ship.
+That PR alone is review-friendly: one new class + tests, no churn elsewhere.
+But v1 in isolation is not *useful* — it does not yet exercise the design
+choices (which fields are typed, which clusters deserve subclasses, whether
+`extras` is comfortable, whether validation can be turned on). Those answers
+come from v2, which is **planned and committed-to up front**, not deferred
+indefinitely.
+
+The four items below are **explicit non-goals for v1 and explicit goals for
+v2**. They are the most interesting part of the migration because they are
+how we discover the variability the v1 class must accommodate:
+
+- Rewriting manual `dict(res_kwargs, status=..., ...)` spread sites.
+- Converting `res['k']` / `res.get('k')` to attribute access in central
+  consumers.
+- Introducing action-specific subclasses where (and only where) the data
+  warrants them.
+- Adding validation, deprecation warnings, or strict modes.
+
+v1 also does not retype existing function signatures or rename
+`get_status_dict`; those are follow-ups (v2.5 / Phase 3).
+
+What changes externally in v1 is approximately one line: `get_status_dict`
+now returns a `StatusRecord` instead of a `dict`. Everything else that the
+result moves through must be unchanged or test-equivalent. v2 then probes
+the rest of the codebase to assess and shape the typed surface.
+
+## 1. What we are migrating
+
+The "result record" is the unit of data flow in DataLad. Every interface function
+yields a stream of these. Today they are plain `dict`s, conventionally produced by
+`get_status_dict` (`datalad/interface/results.py:61`).
+
+Documented schema: `docs/source/design/result_records.rst` — defines mandatory
+keys (`action`, `path`, `status`) and optional ones (`type`, `message`, `logger`,
+`refds`, `parentds`, `state`, `error_message`, `exception`, `exception_traceback`,
+`bytesize`, `gitshasum`, `prev_gitshasum`, `key`).
+
+Surface area (from audit):
+
+- **~140 call sites** of `get_status_dict` across **29 files** (mostly under
+  `datalad/core/`, `datalad/distribution/`, `datalad/distributed/`,
+  `datalad/local/`).
+- **Manual dict-spread construction** that bypasses the helper:
+  - `datalad/core/local/status.py:188-194,420-424`
+  - `datalad/core/distributed/push.py:216-224`
+  - `datalad/distribution/siblings.py:599-603,770-773`
+  - `datalad/core/local/save.py:374-380`
+  - `datalad/local/addurls.py:930-951`
+- **Post-construction mutation** is widespread: `res['status'] = ...`,
+  `res['message'] = ...`, `res['error_message'] = ...`, `res['path'] = ...`,
+  `res['annex-ignore'] = 'false'` (`create_sibling_gin.py:172`), etc. The class
+  must support `__setitem__`.
+- `annexjson2result` (`datalad/interface/results.py:257`) builds a record then
+  rewrites status, path, action, annexkey, metadata, error_message, message in
+  place.
+
+## 2. Backward-compat surface — non-negotiable
+
+These usage patterns must keep working **unchanged**:
+
+| Pattern | Where | Notes |
+|---|---|---|
+| `res['key']`, `res.get('key', dflt)` | everywhere | dict-style access |
+| `'key' in res` | everywhere | membership |
+| `res['key'] = v` | mutation sites listed above | post-construction edits |
+| `res.pop('logger', None)` | `interface/utils.py:336` | strips logger before render/JSON |
+| `dict(other_kwargs, status=..., ...)` spread | siblings.py, push.py, save.py, addurls.py | left as-is in v1 |
+| `{k: v for k, v in res.items() if k in {...}}` | `interface/utils.py:411`, `_render_result_json` | iteration + items() |
+| `json.dumps(...)` | `_render_result_json:432` | byte-for-byte equivalence required |
+| `res == other_dict` | repetition detection | equality with plain dicts |
+| `EnsureKeyChoice('action', ...)(res)` | `cli/exec.py`, `core/distributed/clone.py:140`, `core/local/create.py:104`, `distribution/install.py:111` | `__contains__` + `__getitem__` |
+| `match_jsonhook2result(res, match)` | `core/local/resulthooks.py:79` | user-defined match dicts; arbitrary keys |
+| `result_filter=lambda x: x.get('type') in (...)` | `core/local/run.py:549` | user-supplied callables |
+| `res['message'][0] % res['message'][1:]` | `interface/utils.py:249` | message tuple shape preserved |
+| arbitrary user `result_renderer` callables | extension API | treats `res` as dict — must remain dict-like |
+| pickling across multiprocessing | `runnerthreads`, parallel get/clone | dataclass needs to be picklable |
+
+`docs/source/design/result_records.rst` explicitly warns that **changing field
+names breaks user hooks**. Therefore: same key names, same value shapes, same
+JSON output, byte-for-byte where possible.
+
+## 3. Design — `StatusRecord`
+
+A `@dataclass`-based class that **also implements `MutableMapping`**, so every
+existing consumer keeps working through dict semantics while new code can
+opt-in to typed attribute access **in follow-up PRs**.
+
+```python
+# datalad/interface/results.py — added near get_status_dict
+
+from collections.abc import MutableMapping
+from dataclasses import dataclass, field, fields
+from typing import Any, Optional, Union
+import logging
+
+from datalad.support.exceptions import CapturedException
+
+MessageT = Union[str, tuple, None]
+
+
+@dataclass
+class StatusRecord(MutableMapping):
+    """Typed result record yielded by DataLad interface functions.
+
+    Behaves as both a dataclass (typed attribute access) and a
+    MutableMapping (dict-style access for backward compatibility).
+    Unknown / domain-specific keys are stored in ``extras``.
+    """
+
+    # mandatory per docs/source/design/result_records.rst
+    # (kept Optional because get_status_dict allows None today)
+    action: Optional[str] = None
+    path:   Optional[str] = None
+    status: Optional[str] = None
+
+    # common optional
+    type:                Optional[str] = None
+    message:             MessageT = None
+    logger:              Optional[logging.Logger] = None
+    refds:               Optional[str] = None
+    parentds:            Optional[str] = None
+    state:               Optional[str] = None
+    error_message:       MessageT = None
+    exception:           Optional[Union[Exception, CapturedException]] = None
+    exception_traceback: Optional[str] = None
+    exit_code:           Optional[int] = None
+
+    # escape hatch for action-specific keys
+    extras: dict = field(default_factory=dict)
+
+    # MutableMapping protocol — see implementation sketch in §3.2
+    ...
+```
+
+### 3.1 Key design decisions
+
+1. **All currently-documented fields are `Optional` and default to `None`.**
+   Today `get_status_dict` only adds keys when given a non-None value. The
+   Mapping protocol mirrors that: `__contains__` returns False for keys whose
+   attribute is still `None`, `__iter__` skips them, `len()` counts only set
+   keys. The *visible* dict contents are unchanged.
+2. **`extras: dict`** captures the long tail of action-specific keys
+   (`name`, `url`, `ssh_url`, `annex-ignore`, `bytesize`, `gitshasum`,
+   `prev_gitshasum`, `key`, `annexkey`, `metadata`, `hints`, `stdout`, `stderr`,
+   `stdout_json`, `branch`, `source_url`, `git`, `request_data`, `clone_url`,
+   `destination`, `contains`, ...). These are *not* promoted to typed fields in
+   v1 — there are too many, most are used by exactly one command, and adding
+   them inflates the diff.
+3. **No validation, no warnings, no deprecations in v1.** Schema today is
+   "anything goes"; introducing strict checks alongside a class swap doubles
+   migration risk.
+4. **`get_status_dict()` keeps its signature.** Only its return type changes
+   from `dict[str, Any]` to `StatusRecord`. All ~140 callers are untouched.
+5. **No subclasses in v1.** `FileStatusRecord` / `DatasetStatusRecord` /
+   `SiblingStatusRecord` are explicitly deferred — they are an optimization
+   for typed call sites, and v1 has zero typed call sites.
+6. **`extras` must NOT appear as a key in iteration / serialization.** It is
+   spliced into iteration; from the outside the record looks flat.
+
+### 3.2 MutableMapping implementation (sketch)
+
+```python
+def __post_init__(self):
+    object.__setattr__(self, '_DECLARED',
+                       frozenset(f.name for f in fields(self)
+                                 if f.name not in ('extras',)))
+
+def __getitem__(self, key):
+    if key in self._DECLARED:
+        v = getattr(self, key)
+        if v is None:
+            raise KeyError(key)
+        return v
+    return self.extras[key]
+
+def __setitem__(self, key, value):
+    if key in self._DECLARED:
+        setattr(self, key, value)
+    else:
+        self.extras[key] = value
+
+def __delitem__(self, key):
+    if key in self._DECLARED:
+        if getattr(self, key) is None:
+            raise KeyError(key)
+        setattr(self, key, None)
+    else:
+        del self.extras[key]
+
+def __iter__(self):
+    for name in self._DECLARED:
+        if getattr(self, name) is not None:
+            yield name
+    yield from self.extras
+
+def __len__(self):
+    return sum(1 for _ in self)
+
+def __contains__(self, key):
+    if key in self._DECLARED:
+        return getattr(self, key) is not None
+    return key in self.extras
+
+def __eq__(self, other):
+    if isinstance(other, (StatusRecord, dict)):
+        return dict(self) == dict(other)
+    return NotImplemented
+```
+
+`@dataclass(eq=False)` is used so the dataclass's default `__eq__` (which would
+compare across declared fields only and not consider Mapping equivalence) does
+not collide with the explicit Mapping-style `__eq__` above.
+
+### 3.3 Construction ergonomics
+
+`get_status_dict` accepts `**kwargs` for arbitrary keys. The class needs the
+same. Strategy: `get_status_dict` partitions kwargs into declared-fields and
+extras and passes them to the constructor:
+
+```python
+def get_status_dict(action=None, ds=None, ..., **kwargs):
+    # ...existing body, but build a StatusRecord at the end:
+    declared = StatusRecord._declared_field_names()  # cached
+    declared_kw = {k: v for k, v in d.items() if k in declared}
+    extras = {k: v for k, v in d.items() if k not in declared}
+    return StatusRecord(**declared_kw, extras=extras)
+```
+
+This is the only line of "real" logic the migration adds outside the class.
+
+The manual `dict(res_kwargs, status='ok', ...)` spread sites are **not** rewritten
+in v1. They keep producing plain dicts. Consumers handle both.
+
+### 3.4 JSON serialization
+
+`_render_result_json` (`interface/utils.py:432`) currently does
+`json.dumps({k: v for k, v in res.items() if k != 'logger'}, default=str)`. With
+`MutableMapping` this keeps working unmodified, *provided* the iteration order
+and key set match the current dict shape. **This is the single most important
+backward-compat invariant** — it is what users programmatically consume. Add a
+golden-record test that captures the current JSON output for a representative
+result and asserts the dataclass produces identical bytes.
+
+### 3.5 Pickling
+
+`MutableMapping` + `@dataclass` is picklable by default. The only weird field
+is `logger`, which is already popped before the record crosses the parallel
+boundary in `_process_results`. Add an explicit `pickle.dumps`/`pickle.loads`
+round-trip test.
+
+## 4. Phased rollout
+
+### Phase 1 — single PR, minimal diff (this branch)
+
+**Files touched:**
+
+- `datalad/interface/results.py` — add `StatusRecord` class, route
+  `get_status_dict`'s final `return d` through `StatusRecord(...)`. ~150 lines
+  added, ~5 lines changed.
+- `datalad/interface/tests/test_results.py` (or a new
+  `test_status_record.py`) — add the test suite below. New file.
+- `docs/designs/status-record.md` — this document.
+
+**Tests:**
+
+- Dict semantics: `r['x']`, `r.get('x')`, `'x' in r`, `r.pop('x')`,
+  `r['x'] = 1`, `dict(r)`, `r.items()`, `r.keys()`, `r.values()`, `len(r)`,
+  iteration order matches `get_status_dict` plain-dict baseline.
+- Equality: `StatusRecord(...)` == `get_status_dict_old(...)` for a battery
+  of representative inputs.
+- JSON serialization: `json.dumps(StatusRecord(...))` is byte-identical to
+  `json.dumps(dict_baseline)` for the same inputs (sorted keys).
+- Spread: `dict(other, **r)` and `dict(r, **other)` produce the same dicts
+  as before.
+- Constraint: `EnsureKeyChoice('action', ('install',))(StatusRecord(action='install'))`
+  succeeds.
+- Hooks: `match_jsonhook2result(hook, StatusRecord(...), match)` returns the
+  same boolean as against the equivalent dict.
+- Pickling: `pickle.loads(pickle.dumps(r))` round-trips and equals `r`.
+- `extras` is not visible: `'extras' not in r`, `'extras' not in r.keys()`,
+  `'extras' not in json.loads(json.dumps(dict(r)))`.
+- Mutation: arbitrary `r['some_new_key'] = 1` lands in `extras` and shows up
+  in iteration.
+
+**Acceptance:**
+
+- Full test suite passes.
+- `datalad ... -f json` output is byte-identical for representative commands
+  (`status`, `save`, `clone`, `get`, `siblings`, `push`) against a recorded
+  baseline.
+- Diff is small enough to review in one pass: roughly one new class + tests +
+  this doc, no edits to other files.
+
+### Phase 2 — design validation via end-to-end migration (staged immediately after v1)
+
+v1 alone proves the class works as a dict. **v2 is where the design is actually
+exercised** — only by converting producers and consumers across the codebase do
+we learn:
+
+- Whether the chosen typed fields are the right ones.
+- Whether the action-specific clusters (file / dataset / sibling / annex-json)
+  are *real* — i.e. consistent enough to deserve subclasses, or mushy enough
+  that a single flat class with `extras` is the right answer.
+- Whether `extras` is comfortable as the escape hatch, or routinely painful.
+- Which consumer patterns survive attribute-access conversion and which do
+  not (e.g. dynamic key names, dict-spread, `.pop`).
+- Whether validation can be turned on without breaking any in-tree producer.
+
+v2 is therefore framed as a **probe**, not a checklist. Each sub-PR's job is
+both to convert code *and* to surface concrete feedback that may force changes
+to the v1 class shape (extra fields, removed fields, renamed `extras`, slot
+optimization, subclass set, etc.). The plan deliberately does *not* commit to
+the final subclass set up front — that is decided by the data v2 produces.
+
+v2 is split into reviewable sub-PRs, each independently revertable:
+
+#### v2.1 — convert manual-dict construction sites
+
+Targets:
+
+- `datalad/core/local/status.py:188-194,420-424`
+- `datalad/core/distributed/push.py:216-224`
+- `datalad/distribution/siblings.py:599-603,770-773`
+- `datalad/core/local/save.py:374-380`
+- `datalad/local/addurls.py:930-951`
+
+For each: replace `dict(res_kwargs, status='ok', ...)` with
+`StatusRecord(**res_kwargs, status='ok', ...)`. Audit `res_kwargs` at each
+call: which keys flow in? Are any of them ones that should be promoted from
+`extras` to typed fields? Record findings in this doc as a table.
+
+Exit criterion: all five sites converted; JSON byte-identity tests still
+green; **list of any `extras` keys that appear in ≥2 of the five sites
+recorded as candidates for promotion to typed fields in v2.3**.
+
+#### v2.2 — convert dict-style read access in central consumers
+
+Targets (the consumers that read every result, not the producers):
+
+- `datalad/interface/utils.py` — `_process_results`, `generic_result_renderer`,
+  `_render_result_generic`, `_render_result_json`, `keep_result`.
+- `datalad/interface/base.py` — `eval_results` decorator's result loop.
+- `datalad/interface/results.py` — `ResultXFM` subclasses (`YieldDatasets`,
+  `YieldRelativePaths`, `YieldField`), `is_ok_dataset`, `count_results`,
+  `only_matching_paths`, `is_result_matching_pathsource_argument`.
+
+For each: convert `res.get('status')` → `res.status`,
+`res.get('path')` → `res.path`, etc., where the key is a typed field. Leave
+`res.get(dynamic_key)` and `res[<extras-key>]` as dict access. The aim is
+*partial* attribute adoption — wherever the type checker can help.
+
+`_render_result_json` keeps its `dict(res)` snapshot; it must produce identical
+JSON. `match_jsonhook2result` keeps full dict semantics — user matches name
+arbitrary keys.
+
+Exit criterion: full test suite + JSON byte-identity tests green; mypy/pyright
+run on the touched files reports zero net new errors; **list of read-paths
+that fell back to dict access (dynamic key, `extras`, `.pop`) recorded as
+input to v2.4**.
+
+#### v2.3 — promote-or-park decision; introduce subclasses *iff justified*
+
+Inputs from v2.1 + v2.2. Decision rules:
+
+- A field graduates from `extras` to a typed attribute on `StatusRecord` iff
+  it appears in ≥3 producer sites or ≥1 consumer site outside its origin
+  command.
+- A subclass (`FileStatusRecord`, `DatasetStatusRecord`,
+  `SiblingStatusRecord`, `AnnexJsonRecord`) is introduced iff ≥3 fields
+  cluster consistently across ≥2 callers *and* a typed call site can use
+  the subclass to eliminate at least one `cast` / `assert`.
+- Otherwise the field stays in `extras` and the subclass is not created.
+
+Candidate clusters from the audit (subject to v2.1/v2.2 confirmation):
+
+| Candidate subclass | Action(s) | Fields under consideration |
+|---|---|---|
+| `FileStatusRecord` | `status`, `diff`, `save`, `get`, `add` | `state`, `gitshasum`, `prev_gitshasum`, `bytesize`, `key`, `annexkey` |
+| `DatasetStatusRecord` | most dataset-level results | `gitshasum`, `prev_gitshasum`, `branch` |
+| `SiblingStatusRecord` | `siblings`, `create-sibling-*` | `name`, `url`, `ssh_url`, `annex-ignore` (note: hyphen → stays in `extras`) |
+| `AnnexJsonRecord` | results from `annexjson2result` | `annexkey`, `metadata` |
+
+Each subclass that survives the decision rule is added in its own sub-PR with
+a single producer migrated to it (e.g. `core/local/status.py` for
+`FileStatusRecord`). If a candidate fails the rule, this doc is updated with
+the reason ("`branch` only used by 1 producer; staying in `extras`") and the
+class is *not* created.
+
+Exit criterion: subclass set frozen and documented in `docs/source/design/result_records.rst`.
+
+#### v2.4 — opt-in strictness and validation
+
+Once v2.1–v2.3 have shaken out the field set, add:
+
+- Status-value validation: `__setitem__('status', v)` raises if `v` not in
+  `{'ok', 'notneeded', 'impossible', 'error'}`. Only added if v2.1/v2.2
+  produced no offenders; otherwise this is documented as a future step.
+- Optional warning on `__setitem__` of an unknown key, gated by
+  `DATALAD_STATUSRECORD_STRICT=1`, off by default. The warning's value is in
+  CI / development; production stays silent.
+- Optional `slots=True` if microbenchmarks show measurable overhead
+  (Python 3.10+). Only if numbers warrant it.
+
+Exit criterion: validation either lands cleanly (no producer changes needed)
+or this doc records the offending sites and defers to a v3 cleanup pass.
+
+#### v2.5 — annotate hot-path return types
+
+Now that consumers read typed attributes, annotate the return types of
+`get_status_dict`, `annexjson2result`, `results_from_paths`,
+`results_from_annex_noinfo`, and the `eval_results` decorator's yielded type.
+This is pure annotation — no behavior change. Smallest possible diff.
+
+Exit criterion: annotations land; mypy/pyright run is clean for
+`datalad/interface/`.
+
+### Phase 3 — opportunistic, no fixed timeline
+
+These are opt-in cleanups that do not affect the design and can land
+piecemeal as the codebase is touched for other reasons. Listed here so they
+do not get re-discovered as "what's next" after v2:
+
+- Annotate yielded types on individual command implementations
+  (`Iterator[StatusRecord]`).
+- Migrate remaining `res.get('k')` → `res.k` in non-central consumers.
+- Convert third-party / extension-facing helpers (`is_ok_dataset` etc.) to
+  accept either `StatusRecord` or a plain dict (already true; just document).
+- Pydantic / msgspec model for the external `-f json` schema, with a `$schema`
+  URL. This is a *new* API surface, not a migration step.
+
+### Exit criteria for the migration as a whole
+
+The migration is "done" when:
+
+1. `get_status_dict` returns a `StatusRecord`.
+2. All in-tree producers either go through `get_status_dict` or directly
+   construct a `StatusRecord` / subclass.
+3. Central consumers (`eval_results`, renderers, `ResultXFM`) read typed
+   attributes for the standard fields.
+4. The subclass set is frozen and documented.
+5. `docs/source/design/result_records.rst` is updated to describe the typed
+   class; the dict shape becomes a *protocol* the class implements, not the
+   primary representation.
+6. `-f json` output remains byte-identical to the pre-migration baseline.
+
+Until #6 is at risk, the migration is reversible.
+
+## 5. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **User hooks break** because key set or iteration changes | Golden-record JSON tests; keep all current keys; do not rename |
+| **Performance regression** in tight result loops | Microbenchmark `get_status_dict` before/after; if needed, `@dataclass(slots=True)` (Python 3.10+) |
+| **Pickle breakage** across multiprocessing boundaries | Explicit pickle round-trip test |
+| **`extras` accidentally surfaces in iteration / JSON** | Test asserts `'extras'` is never in `keys()`, `items()`, JSON output |
+| **`__eq__` collides between dataclass and Mapping** | `@dataclass(eq=False)` and explicit Mapping-style `__eq__` |
+| **`logger.pop` semantics change** | Test `r.pop('logger', None)` returns the logger and afterwards `'logger' not in r` |
+| **`annex-ignore` (hyphenated) is invalid as identifier** | Stays in `extras` — that is exactly its purpose |
+| **Diff bloat from incidental annotation churn** | Hard rule: v1 PR touches `interface/results.py` + tests + this doc only |
+
+## 6. Open questions for discussion
+
+These do not block v1 — flagging for the follow-up phases.
+
+1. **Should `get_status_dict` be renamed?** It now returns a `StatusRecord`,
+   not a dict. Renaming aids discoverability but is wider churn. Suggest:
+   keep it (it's the public extension API), add `StatusRecord(...)` as the
+   typed entry point for new code.
+2. **`exception` typing**: today the field can hold either a raw `Exception`
+   or a `CapturedException`. Keep the union, or coerce to `CapturedException`
+   in `__post_init__`? Coercing is cleaner but changes observable behavior
+   for user hooks. Suggest: keep the union.
+3. **Strictness of `extras`**: should `__setitem__` of an unknown key warn?
+   Suggest: not in v1; later, opt-in via env var.
+4. **Subclass `action` as `Literal`?** Pro: types catch bugs. Con: every new
+   action becomes a code change. Suggest: leave as `str`.
+5. **Module placement**: `datalad/interface/results.py` is the obvious home
+   for v1 (where `get_status_dict` lives). Splitting into
+   `datalad/interface/status_record.py` is cosmetic; defer.

--- a/docs/designs/status-record.md
+++ b/docs/designs/status-record.md
@@ -412,6 +412,14 @@ Exit criterion (met): the four in-the-wild fields are now typed attributes;
 the subclass set is documented as parked with reasons; no new tests
 regressed.
 
+> **Caveat — these decisions were taken on a static grep audit.** A
+> static survey misses dynamic key construction (`addurls` building
+> keys from CSV columns, helpers spreading `**res_kwargs` from
+> closures, results yielded from extensions, etc.). The base-class
+> field set above and the subclass-park decisions should be treated
+> as a *working hypothesis*. The honest version of v2.3 needs runtime
+> evidence — see **v2.6** below.
+
 #### v2.4 — opt-in strictness and validation
 
 Once v2.1–v2.3 have shaken out the field set, add:
@@ -487,6 +495,133 @@ annotation passes (Phase 3 in this doc) build on.
 
 Exit criterion: annotations land; mypy/pyright run is clean for
 `datalad/interface/`.
+
+#### v2.6 — runtime extras-key telemetry; redo v2.3 with real data
+
+The v1 base-class field set (`bytesize`, `gitshasum`, `prev_gitshasum`,
+`key`) and the v2.3 subclass-park decisions were taken on the basis of
+a static grep over `res[k] = v`, `dict(res_kwargs, k=v, ...)`, and
+explicit `get_status_dict(..., k=v, ...)` call sites. **A static survey
+is structurally incomplete** — it misses dynamic key construction
+(`addurls` building keys from CSV column names, helpers that spread
+`**res_kwargs` originally constructed in callers up the stack, results
+yielded from extensions, results converted by `annexjson2result` whose
+field set varies with the upstream `git annex` JSON shape, etc.).
+
+The result-record contract is genuinely dynamic; the actual field
+shape can only be observed at runtime by exercising the codepaths.
+
+##### Mechanism
+
+Add a debug-only trace mode to `StatusRecord`, gated by
+`DATALAD_STATUSRECORD_TRACE=1` (independent of `_STRICT`). When on,
+every write to `_extras` (i.e. every `__setitem__` / `__init__` of a
+key not in `_DECLARED_FIELDS_SET`) records:
+
+- the key name,
+- the producer's stack frame, truncated to the topmost in-tree call
+  site (skip `get_status_dict` / `from_kwargs` / pytest frames),
+- the producing `action` and `type` if known on the record at that
+  point (so we can correlate `key` with `type='file'`, etc.),
+- the value's Python type (so e.g. `bytesize: int` vs `bytesize: str`
+  divergence is visible).
+
+Records accumulate in a module-global structure. On process exit (via
+`atexit`) or on explicit `dump_extras_telemetry(path)`, the structure
+serializes to a JSONL report — one line per `(key, frame)` cluster
+with counts and a few representative values.
+
+The collector is intentionally cheap when off (the env-var read can be
+cached at module import) and best-effort when on; it does not need to
+be thread-safe or production-grade. Its only job is to feed an
+offline analysis.
+
+##### Sweep procedure
+
+1. `DATALAD_STATUSRECORD_TRACE=1 pytest datalad/` — full local suite.
+2. Optionally also run integration / network tests (un-set
+   `DATALAD_TESTS_NONETWORK`) and the long-running parallel
+   `get` / `clone` paths to exercise multiprocessing-yielded results.
+3. Aggregate the JSONL by key. For each key bucket by:
+   - **frequency** — how many distinct call sites emit it;
+   - **co-occurrence** — which other extras-keys appear in the same
+     record;
+   - **action / type distribution** — does the key concentrate around
+     one action or entity type, or does it span?
+   - **value-type stability** — is it always `int`, or sometimes
+     `str`?
+
+Output the aggregated report as part of the v2.6 PR so reviewers can
+see the data.
+
+##### How the analysis drives decisions
+
+A key earns a typed slot somewhere — base or subclass — when:
+
+- it appears at ≥2 distinct in-tree call sites, *and*
+- its co-occurrence pattern is stable (same companion keys appear
+  together with high frequency), *and*
+- it can be expressed as a Python identifier (otherwise it must stay
+  in `_extras`; e.g. `annex-ignore`, `error-messages`).
+
+Where the slot lives is decided by the action / type distribution:
+
+- spans many actions and both `type='dataset'` and `type='file'` →
+  base class;
+- concentrated on one entity type (e.g. `key` only ever fires when
+  `type='file'`) → subclass for that entity type;
+- concentrated on one command (e.g. `run_info` only fires for
+  `run`/`rerun`) → either a small subclass for that command, or stays
+  in `_extras` if the cluster is too small to justify a class.
+
+##### Re-examining the v1 / v2.3 base-class fields
+
+The v1+v2.3 promotions to base — `bytesize`, `gitshasum`,
+`prev_gitshasum`, `key` — are all file-specific *in practice*
+(`type='file'` or `type='symlink'`). They were placed on the base on
+the strength of `result_records.rst` listing them as commonly-observed
+in-the-wild fields. A runtime audit is likely to show they cluster
+tightly with `state` and `parentds` for file results and never appear
+on dataset / sibling records.
+
+If that hypothesis holds, v2.6 should:
+
+- introduce `FileStatusRecord(StatusRecord)` and *move*
+  `bytesize`, `gitshasum`, `prev_gitshasum`, `key` (and possibly
+  `state`, `annexkey`) from the base onto it;
+- introduce `DatasetStatusRecord(StatusRecord)` for any
+  dataset-specific cluster (e.g. `gitshasum` for the dataset's commit
+  hexsha if that is observed cross-command — could overlap with
+  `FileStatusRecord` if the *name* is reused);
+- introduce `SiblingStatusRecord(StatusRecord)` for `name`/`url`/
+  `ssh_url` if the cluster shows ≥2 callers (likely true);
+- introduce a `RunStatusRecord` or similar for `run_info` /
+  `run_message` / `rerun_*` / `diff` / `author` / `date` if those
+  cluster as the static grep suggests.
+
+Moving fields *off* the base is mildly disruptive — code paths that
+expect them on the base would need to be re-typed — but it is a
+better long-term shape. The cost is bounded because v1+v2.3 only
+landed four fields and they are not yet relied on by any consumer
+that accesses them via attribute (they remain accessible via the
+Mapping API in any case).
+
+##### Status
+
+Not yet executed. v2.6 is the next planned phase, consuming the work
+already in v1–v2.5. Until v2.6 lands, the v1+v2.3 base-class field
+set should be treated as a working hypothesis, not the final shape.
+
+##### Exit criterion
+
+- Telemetry instrumentation lands behind the env var (no behavior
+  change when off).
+- The JSONL output of a full test sweep is included in the PR for
+  reviewer scrutiny.
+- The aggregate analysis is summarized in this design doc.
+- Subclasses are introduced (or definitively parked) per the data —
+  not the grep — and any base-class fields that fail the data test
+  are moved onto the appropriate subclass.
 
 ### Phase 3 — opportunistic, no fixed timeline
 

--- a/docs/designs/status-record.md
+++ b/docs/designs/status-record.md
@@ -623,6 +623,63 @@ set should be treated as a working hypothesis, not the final shape.
   not the grep — and any base-class fields that fail the data test
   are moved onto the appropriate subclass.
 
+##### Outcome (v2.6 landed in two sub-PRs)
+
+v2.6a — telemetry instrumentation: `StatusRecord` records every
+`_extras` write at construction (`__post_init__`) and post-construction
+(`__setitem__`) when `DATALAD_STATUSRECORD_TRACE=1` is set, dumping
+JSONL on process exit. Off by default; one cached-bool check on the
+hot path when off.
+
+v2.6b — sweep + decision. A 213-test sweep produced 1747 extras-key
+writes across 64 distinct keys. The aggregated report
+(`.git-meta/v26_report.md`) drove the field set as follows:
+
+**Field moves (off base):**
+
+| Field | Decision | Reason |
+|---|---|---|
+| `bytesize` | moved off base → `FileStatusRecord` | Runtime data + grep confirm strictly file-scoped |
+| `key` | moved off base → `FileStatusRecord` | Same |
+| `gitshasum` | **stays on base** | `gitrepo.py:2490` emits it for `type='dataset'` records too — cross-type |
+| `prev_gitshasum` | stays on base | Pairs with `gitshasum` |
+
+**Subclass introductions:**
+
+- `FileStatusRecord(StatusRecord)` — adds `bytesize`, `key` (moved
+  from base) plus the file-specific cluster from the sweep:
+  `annexkey` (9 frames, 213 occ), `backend`, `has_content`,
+  `hashdirlower`, `hashdirmixed`, `humansize`, `keyname`, `mtime`,
+  `objloc` (each 2 frames, ~4–22 occ).
+- `SiblingStatusRecord(StatusRecord)` — adds `name` (8 frames,
+  120 occ). `url` would be the natural pair but at sweep time has
+  only 1 producer call site; promote in a future PR if a second
+  producer adds it.
+
+**Subclasses parked again:**
+
+- `DatasetStatusRecord` — no field cluster meets the rule.
+  `contains` (5 frames, 44 occ) and `target` (5 frames, 141 occ)
+  are the only multi-frame dataset-typed extras, and they don't
+  cluster: `contains` is `subdataset`-only, `target` is
+  `publish`/`copy`. Each can be promoted individually if a future
+  data set shows broader use — keeping them in `_extras` for now
+  matches the rule.
+- `RunStatusRecord` — `run_info`, `msg_path`, `version_tag` are all
+  single-call-site (the static grep was wrong about a cluster).
+
+**Producer migration is out of scope for v2.6.** The subclasses
+exist and are tested; producers can opt in incrementally in v2.7+
+(or as side-effects of other refactors). Existing producers continue
+to work — they emit `StatusRecord` instances whose extras-keys still
+flow through `_extras`. Backward compat: `isinstance(r,
+StatusRecord)` is True for any subclass, so the central pipeline,
+hooks, JSON renderer, and Mapping consumers all behave identically.
+
+The sweep report at `.git-meta/v26_report.md` is preserved alongside
+the analyser script `.git-meta/analyze_v26_trace.py` so the
+methodology is reproducible.
+
 ### Phase 3 — opportunistic, no fixed timeline
 
 These are opt-in cleanups that do not affect the design and can land

--- a/docs/designs/status-record.md
+++ b/docs/designs/status-record.md
@@ -464,6 +464,27 @@ Now that consumers read typed attributes, annotate the return types of
 `results_from_annex_noinfo`, and the `eval_results` decorator's yielded type.
 This is pure annotation — no behavior change. Smallest possible diff.
 
+##### Outcome (v2.5 landed)
+
+- `get_status_dict(...)` — return type already migrated in v1 from
+  `dict[str, Any]` to `StatusRecord`.
+- `results_from_paths(...)` — return `Iterator[StatusRecord]`.
+- `annexjson2result(...)` — return `StatusRecord`.
+- `results_from_annex_noinfo(...)` — return `Iterator[StatusRecord]`.
+- `as_status_record(res)` — parameter tightened from `Any` to `Mapping`.
+- `interface/utils.py` `_process_results` — `results: Iterable[Mapping]
+  -> Iterator[StatusRecord]`.
+- `interface/utils.py` `generic_result_renderer` — `res: Mapping -> None`.
+- `interface/base.py` `eval_results` — docstring updated to point at
+  `StatusRecord`; the decorator itself is generic and intentionally not
+  signature-typed (would require `ParamSpec`/`TypeVar` machinery beyond
+  the v2.5 minimal-diff scope).
+
+These are pure annotations / docstring changes; runtime behavior is
+unchanged. mypy clean-run on `datalad/interface/` is the long-term
+target — v2.5 is the prerequisite typing scaffold that follow-on
+annotation passes (Phase 3 in this doc) build on.
+
 Exit criterion: annotations land; mypy/pyright run is clean for
 `datalad/interface/`.
 


### PR DESCRIPTION
## Summary

Introduce a typed `StatusRecord` (`@dataclass` + `MutableMapping`) to replace
the ad-hoc dict that interface functions historically yielded — without
breaking any of the dict-shaped consumers (in-tree code, JSON output,
user hooks, third-party renderers). The migration plan, decisions, and
empirical data driving them are documented in
[`docs/designs/status-record.md`](../blob/enh-statusrec-class/docs/designs/status-record.md).

The PR lands as a sequence of small, reviewable commits per the plan's
phases — each builds on the previous and could in principle be split
into separate PRs if reviewers prefer.

## Why

Today every command yields plain `dict`s with no schema enforcement; the
"contract" is documented prose at `docs/source/design/result_records.rst`.
That makes wrong-key typos silent and prevents IDE / mypy from helping.
But the dict shape is also load-bearing for user hooks and the `-f json`
renderer — so the migration has to be *seamless*: the new type must be a
drop-in replacement.

<details>
<summary>What etc</summary>
## What

- A `StatusRecord` dataclass that also implements `MutableMapping`.
  Declared fields are typed attributes; unknown / domain-specific keys
  (and hyphenated git-config-style keys like `annex-ignore`) flow into
  an internal `_extras` mapping and are spliced into the Mapping view
  transparently.
- `get_status_dict()` returns a `StatusRecord` (the only externally
  visible change); all existing dict-style accesses — subscription,
  `.get()`, `in`, iteration, mutation, `.pop()`, dict-spread, JSON
  serialization, equality with plain dicts, hook-style key matching,
  pickling, `.copy()` — keep working unchanged.
- Two specialised subclasses (`FileStatusRecord`,
  `SiblingStatusRecord`) for the field clusters that earned their
  place via runtime evidence (see v2.6 below).
- Opt-in strict mode (`DATALAD_STATUSRECORD_STRICT=1`) validates
  `status` values and warns on unknown-key writes.
- Opt-in telemetry (`DATALAD_STATUSRECORD_TRACE=1`) records every
  `_extras` write with producer call site to JSONL for offline
  analysis.

## Commit-by-commit

| Phase | Commit | What |
|---|---|---|
| design | `df74a5f` | Plan in `docs/designs/status-record.md` |
| v1 | `76d5aca` | `StatusRecord` class + `get_status_dict` routes through it. Includes drop-in fixes for `isinstance(x, dict)` checks on result records (`due_utils.py`, `copy_file.py`, `run_procedure.py`, `add_readme.py`, `utils.py::ensure_result_list`); adds `.copy()` |
| v2.1 | `22263fc` | Convert manual `dict(res_kwargs, ...)` producers (status, push, siblings, save, addurls) to `StatusRecord.from_kwargs` |
| v2.2 | `e1ec16b` | Typed attribute access in the central pipeline (`_process_results`, renderer). Coerce-at-boundary so plain-dict producers (e.g. extension code) flow through typed pipeline |
| v2.3 | `d362b19` | Promote `bytesize`, `gitshasum`, `prev_gitshasum`, `key` from extras to base — **on a static-grep basis**, marked as a working hypothesis |
| v2.4 | `9d623d4` | Opt-in strict-mode (`DATALAD_STATUSRECORD_STRICT=1`): canonical-status validation + unknown-key warnings |
| v2.5 | `42c0e17` | Annotate hot-path return types (`Iterator[StatusRecord]`, `Mapping`, …) |
| v2.6 plan | `f9e6ce7` | Add v2.6 telemetry phase to the design doc (admit the static grep is incomplete) |
| v2.6a | `bbb7927` | Runtime extras-key telemetry instrumentation behind `DATALAD_STATUSRECORD_TRACE=1`; one cached-bool check on the hot path when off |
| v2.6b | `e931321` | **Data-driven redo of v2.3**: move `bytesize`, `key` off base onto new `FileStatusRecord`; promote runtime-confirmed file cluster (`annexkey`, `backend`, `has_content`, `hashdirlower`/`hashdirmixed`, `humansize`, `keyname`, `mtime`, `objloc`); add `SiblingStatusRecord` for `name`; keep `gitshasum`/`prev_gitshasum` on base (`gitrepo.py:2490` emits them on `type='dataset'` too) |

## Backward compatibility

- `isinstance(r, StatusRecord)` is True for any subclass, so the central
  pipeline, hooks, JSON renderer, and Mapping consumers all behave
  identically.
- JSON output (`datalad ... -f json`) is byte-identical to the legacy
  dict baseline — pinned by tests in `test_status_record.py`.
- All existing dict-style consumer patterns are pinned by tests
  (subscription, `.get()`, `in`, iteration, `.pop()`, dict-spread,
  equality with plain dict, `.copy()`, `EnsureKeyChoice`,
  `match_jsonhook2result`, pickle round-trip).
- Producers can opt into typed subclasses incrementally; no producer
  migration is required for this PR.

## v2.6 data-driven decisions

The v2.3 promote-or-park decisions were taken from a static grep — which
structurally misses dynamic key construction (`addurls` building keys
from CSV column names, helpers spreading `**res_kwargs` from closures,
extension-yielded results). The v2.6 telemetry sweep ran the test suite
with `DATALAD_STATUSRECORD_TRACE=1` (213 tests, 1747 `_extras` writes,
64 distinct keys), aggregated by `(key, call site, action, type,
value-type)`, and drove the subclass / field set via objective rules
(≥2 distinct call sites, valid Python identifier, type-distribution
informs location). Report at `.git-meta/v26_report.md` is reproducible
via `.git-meta/analyze_v26_trace.py`. Full outcome summary in the
design doc.

## Notes for reviewers

- The design doc (`docs/designs/status-record.md`) is the source of
  truth for the migration rationale; each phase's "Outcome" section
  documents what landed.
- The single most important backward-compat invariant is JSON
  byte-equivalence (because user code consumes that). It is pinned by
  parametrised tests against an in-test legacy oracle.
- v2.3 base-class field set is intentionally narrower in v2.6b than
  in v2.3 itself — `bytesize` and `key` moved to `FileStatusRecord`.
  This is a deliberate "data over grep" correction; the design doc has
  the full justification.

</details>

## Test plan

- [ ] CI green on `tox -e py3`, `lint`, `typing` (mypy)
- [ ] JSON output of `datalad status`, `datalad save`, `datalad clone`,
      `datalad get`, `datalad siblings`, `datalad push` is byte-identical
      to a `maint` baseline for a representative dataset
- [ ] User hook configurations against canonical fields
      (`action`, `status`, `type`, `path`) continue to fire as before
- [ ] `DATALAD_STATUSRECORD_STRICT=1 pytest datalad/` passes (no
      in-tree producer uses a non-canonical status value)
- [ ] `DATALAD_STATUSRECORD_TRACE=1 pytest datalad/` produces JSONL
      sweep at `/tmp/datalad_statusrecord_trace.jsonl` for follow-up
      audits

### Related

- https://github.com/datalad/datalad-next/tree/main/datalad_next/iter_collections