### PR TITLE
BF: terminate child before closing stdout/stderr on process timeout

### DIFF
--- a/changelog.d/pr-7866.md
+++ b/changelog.d/pr-7866.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: terminate child before closing stdout/stderr on process timeout.  [PR #7866](https://github.com/datalad/datalad/pull/7866) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/runner/nonasyncrunner.py
+++ b/datalad/runner/nonasyncrunner.py
@@ -544,9 +544,23 @@ class ThreadedRunner:
 
     def _handle_process_timeout(self):
         if self.protocol.timeout(None) is True:
-            self.ensure_stdin_stdout_stderr_closed()
+            # Close our end of the child's stdin first to signal EOF -- a
+            # well-behaved child may wind down cleanly on that alone.  We
+            # MUST NOT close stdout/stderr yet: the child (or anything
+            # sharing its stdout fd, e.g. a `tar`/`curl` helper that git-
+            # annex spawned) would then be killed by SIGPIPE on its next
+            # write, surfacing as exitcode 141 to the runner's caller.
+            self.close_stdin()
             self.process.terminate()
-            self.process.wait()
+            try:
+                self.process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait()
+            # Child is now reaped; safe to close our end of stdout/stderr.
+            self._ensure_closed(
+                (self.process.stdout, self.process.stderr)
+            )
             self.remove_process()
 
     def _handle_source_timeout(self, source):

--- a/datalad/runner/tests/test_sigpipe_on_timeout.py
+++ b/datalad/runner/tests/test_sigpipe_on_timeout.py
@@ -72,6 +72,7 @@ def test_process_timeout_does_not_sigpipe_child() -> None:
         timeout=0.1,
         exception_on_error=False,
     )
+    assert isinstance(result, dict)
     rc = result["code"]
     # Anything is fine *except* SIGPIPE.  After the fix we expect SIGKILL
     # (rc == -9) since the child traps SIGTERM; on a non-trapping child

--- a/datalad/runner/tests/test_sigpipe_on_timeout.py
+++ b/datalad/runner/tests/test_sigpipe_on_timeout.py
@@ -1,0 +1,85 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Regression: process-timeout teardown must terminate the child *before*
+closing its stdout/stderr pipes -- otherwise the child (or anything
+sharing its stdout fd) gets SIGPIPE on its next write, surfacing as
+``exitcode 141`` (= 128+13) to the caller.
+
+AppVeyor observed this on a ``git annex get ... --json-progress`` call in
+build https://ci.appveyor.com/project/mih/datalad/builds/54014269 (test
+``test_add_archive_content``).  git-annex itself catches SIGPIPE, but the
+``tar`` helper it spawns to extract the archive does not, and its 141
+propagates back.
+"""
+
+from __future__ import annotations
+
+import shutil
+import signal
+import sys
+from typing import Optional
+
+import pytest
+
+from datalad.runner.coreprotocols import StdOutErrCapture
+from datalad.runner.nonasyncrunner import run_command
+
+# bash script: trap SIGTERM so the runner's terminate() does not kill us
+# during the close/terminate race; then sleep briefly (long enough for
+# the runner's 0.1s timeout to fire), then exec a python emitter that
+# leaves SIGPIPE at SIG_DFL.  If the runner closes our stdout *before*
+# we resume writing, python is SIGPIPE'd on its first write -> rc = -13
+# (Python form) / 141 (shell form).
+_CHILD = r"""
+trap '' TERM
+sleep 0.5
+exec python3 -u -c "
+import signal, sys
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+for i in range(1000):
+    sys.stdout.write('p %d\n' % i)
+    sys.stdout.flush()
+"
+"""
+
+
+class _TerminateOnTimeoutProtocol(StdOutErrCapture):
+    """Return ``True`` for the process-runtime timeout so the runner's
+    ``_handle_process_timeout`` is invoked, exercising the
+    close-before-terminate race we're guarding against.
+    """
+
+    def timeout(self, fd: Optional[int]) -> bool:
+        return fd is None
+
+
+@pytest.mark.ai_generated
+@pytest.mark.skipif(
+    sys.platform != "linux" or shutil.which("bash") is None,
+    reason="SIGPIPE-driven exit 141 reproducer is Linux+bash specific.",
+)
+def test_process_timeout_does_not_sigpipe_child() -> None:
+    result = run_command(
+        ["bash", "-c", _CHILD],
+        stdin=None,
+        protocol=_TerminateOnTimeoutProtocol,
+        timeout=0.1,
+        exception_on_error=False,
+    )
+    rc = result["code"]
+    # Anything is fine *except* SIGPIPE.  After the fix we expect SIGKILL
+    # (rc == -9) since the child traps SIGTERM; on a non-trapping child
+    # SIGTERM (rc == -15) is the expected outcome.  The bug surfaces as
+    # rc == -signal.SIGPIPE (Python's representation) or 141 (shell-style
+    # propagation through an intermediate exit-code translator).
+    assert rc not in (141, -signal.SIGPIPE), (
+        f"runner closed child stdout before terminating it; child was "
+        f"killed by SIGPIPE (rc={rc!r}).  Expected rc -9 (SIGKILL) or "
+        f"-15 (SIGTERM) depending on whether the child traps SIGTERM."
+    )


### PR DESCRIPTION
`ThreadedRunner._handle_process_timeout` previously closed our end of the child's stdin/stdout/stderr *before* calling `process.terminate()`. Between the close and the SIGTERM landing, the child (or anything that shares its stdout fd -- e.g. a `tar`/`curl` helper that git-annex spawned) gets SIGPIPE on its next write and dies with signal 13.  Shell- style propagation through an intermediate exit-code translator surfaces this as `exitcode 141` to the runner's caller.

Observed in the wild on AppVeyor build 54014269 (test `test_add_archive_content`):

  CommandError: 'git ... annex get ... --json-progress -- '1/1 f.txt''
  failed with exitcode 141

git-annex itself catches SIGPIPE (Haskell GHC default), but its `tar` helper does not.  When the runner closes git-annex's stdout, the kernel delivers SIGPIPE to tar, and git-annex propagates tar's 141.

Reorder the teardown so the child is terminated (with a 1s SIGKILL escalation) *before* its stdout/stderr fds are closed.  stdin still closes first so a well-behaved child can wind down on EOF without needing SIGTERM at all.

Add a Linux+bash regression test in `test_sigpipe_on_timeout.py`: a SIGTERM-trapping bash child execs a SIGPIPE=SIG_DFL python emitter; the runner's teardown fires during the bash sleep window.  With the bug the emitter is killed by SIGPIPE (rc=-13); with the fix the runner escalates to SIGKILL (rc=-9) after the trap blocks SIGTERM.  Verified:

  - reverting the fix       -> test FAILS, rc=-13
  - with the fix in place   -> test PASSES, rc=-9
  - whole datalad/runner/   -> 71 passed in 36s