### PR TITLE
BF: resolve -J auto for push/drop/remove instead of passing 'auto' to git-annex

### DIFF
--- a/changelog.d/pr-7868.md
+++ b/changelog.d/pr-7868.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Resolve `--jobs auto` for `push`, `drop`, and `remove` so the literal string `auto` is no longer passed through to `git annex`.  Previously `push --jobs=auto` crashed with `option --jobs: cannot parse value 'auto'`, while `drop --jobs=auto` (and `remove --jobs=auto`, which delegates to drop) swallowed the same `CommandError` and silently left content in place.  Fixes [#7867](https://github.com/datalad/datalad/issues/7867).  [PR #7868](https://github.com/datalad/datalad/pull/7868) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -859,9 +859,6 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
 
     cmd = ['copy', '--batch', '-z', '--to', target]
 
-    if jobs:
-        cmd.extend(['--jobs', str(jobs)])
-
     # Since we got here - we already have some  data != "nothing"
     if (data == 'auto') or \
         (
@@ -908,6 +905,7 @@ def _push_data(ds, target, content, data, force, jobs, res_kwargs,
     # and go
     res = ds_repo._call_annex_records(
         cmd,
+        jobs=jobs,
         git_options=[
             "-c",
             "annex.retry={}".format(

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -240,7 +240,11 @@ def check_push(annex, src_path, dst_path):
     # we could say since='HEAD~2' to make things fast, or we are lazy
     # and say since='^' to indicate the state of the tracking remote
     # which is the same, because we made to commits since the last push.
-    res = src.push(to='target', since="^", jobs=2)
+    # Use jobs='auto' to exercise the auto-resolution code path -- this
+    # is a regression test for gh-7867 where push was passing the
+    # literal string 'auto' through to git-annex copy, which fails with
+    # "option --jobs: cannot parse value `auto'".
+    res = src.push(to='target', since="^", jobs='auto')
     assert_in_results(
         res,
         action='publish', status='ok', target='target',

--- a/datalad/distributed/drop.py
+++ b/datalad/distributed/drop.py
@@ -757,11 +757,9 @@ def _drop_allkeys(ds, repo, force=False, jobs=None):
     cmd = ['drop', '--all']
     if force:
         cmd.append('--force')
-    if jobs:
-        cmd.extend(['--jobs', str(jobs)])
 
     try:
-        yield from repo._call_annex_records_items_(cmd)
+        yield from repo._call_annex_records_items_(cmd, jobs=jobs)
     except CommandError as e:
         # pick up the results captured so far and yield them
         # the error will be amongst them
@@ -789,14 +787,12 @@ def _drop_files(ds, repo, paths, force=False, jobs=None):
     cmd = ['drop']
     if force:
         cmd.append('--force')
-    if jobs:
-        cmd.extend(['--jobs', str(jobs)])
 
     respath_by_status = {}
     try:
         yield from (
             _postproc_annexdrop_result(res, respath_by_status, ds)
-            for res in repo._call_annex_records_items_(cmd, files=paths)
+            for res in repo._call_annex_records_items_(cmd, files=paths, jobs=jobs)
         )
     except CommandError as e:
         # pick up the results captured so far and yield them

--- a/datalad/distributed/tests/test_drop.py
+++ b/datalad/distributed/tests/test_drop.py
@@ -87,12 +87,16 @@ def test_drop_file_content(path=None, outside_path=None):
             refds=ds.path,
         )
 
-    # drop multiple files from different datasets
+    # drop multiple files from different datasets.
+    # Use jobs='auto' to also exercise the auto-resolution code path
+    # (regression test for gh-7867: 'auto' must not be passed verbatim
+    # to git-annex, which would silently swallow the resulting
+    # CommandError and leave content undropped).
     ok_(ds.repo.file_has_content(axfile_rootds))
     res = ds.drop(
         [axfile_rootds, axfile_subds],
         reckless='availability',
-        jobs=2,
+        jobs='auto',
         on_failure='ignore')
     nok_(ds.repo.file_has_content(axfile_rootds))
     assert_result_count(res, 2)
@@ -203,8 +207,9 @@ def test_drop_allkeys(origpath=None, clonepath=None):
     eq_(1, repo.call_annex_records(['info'])[0]['local annex keys'])
 
     # and now drop all keys from the clone, one is redundant and can be
-    # dropped, the other is not and must fail
-    res = dsclone.drop(what='allkeys', jobs=2, on_failure='ignore')
+    # dropped, the other is not and must fail. Use jobs='auto' for the
+    # same regression coverage as in test_drop above (gh-7867).
+    res = dsclone.drop(what='allkeys', jobs='auto', on_failure='ignore')
     # confirm one key gone, one left
     eq_(1, dsclone.repo.call_annex_records(['info'])[0]['local annex keys'])
     assert_result_count(res, 1, action='drop', status='error', type='key')


### PR DESCRIPTION
## Summary

`push --jobs=auto` crashed with `option --jobs: cannot parse value 'auto'`, and `drop --jobs=auto` (plus `remove --jobs=auto`, which delegates to drop) silently swallowed the same `CommandError` and left content untouched.

Root cause: `_push_data`, `_drop_allkeys`, and `_drop_files` each appended `--jobs <jobs>` to the git-annex command manually before calling `_call_annex_records[_items_]` **without** `jobs=`, bypassing the `'auto'`-to-integer resolution that already lives in `AnnexRepo._call_annex` (annexrepo.py:958-968).

Fix: drop the three manual `cmd.extend(['--jobs', str(jobs)])` blocks; forward `jobs=jobs` to the `_call_annex_records*` calls so resolution happens uniformly in one place.

Refs #7867. **This PR only addresses the literal-`'auto'`-passed-verbatim half of the issue.** The other half — that `'auto'` resolves to `1` by default because `datalad.runtime.max-annex-jobs` / `datalad.runtime.max-jobs` default to `1`, making `-J auto` indistinguishable from omitting `-J` — is left for a follow-up.

## Commits

- 88e0c7665 `BF: resolve -J auto for push/drop/remove instead of passing 'auto' to git-annex`

<details><summary>Per-commit details</summary>

### 88e0c7665 `BF: resolve -J auto for push/drop/remove`

Three call sites built the git-annex command line themselves:

- `datalad/core/distributed/push.py:_push_data` — `cmd.extend(['--jobs', str(jobs)])` then `_call_annex_records(cmd)` with no `jobs=`. Crashed with a visible `CommandError`.
- `datalad/distributed/drop.py:_drop_allkeys` and `_drop_files` — same pattern, but each is wrapped in `except CommandError` that pulls captured results from `e.kwargs.get('stdout_json', [])`. With `'auto'` git-annex never produces any JSON before erroring, so the exception is caught and `drop` returns no results. `remove` inherits the bug via `Drop.__call__(jobs=jobs)`.

The fix is to delete the manual `cmd.extend` and pass `jobs=jobs` to `_call_annex_records` / `_call_annex_records_items_`. The existing logic at `annexrepo.py:958-968` resolves `'auto'` → `min(datalad.runtime.max-annex-jobs, max(3, cpu_count()))` and emits `-J<int>` only when the result is > 1.

Tests: tuned the existing `test_push.check_push`, `test_drop.test_drop_file_content`, and `test_drop.test_drop_allkeys` calls from `jobs=2` to `jobs='auto'`. Verified that with the manual handling restored, `test_push[True]` raises `CommandError` and `test_drop_allkeys` fails its post-drop key-count check, so the change provides regression coverage for both the crash and the silent-failure paths.

</details>

<details><summary>Manual reproduction (before vs after)</summary>

```text
$ datalad push --to=target --jobs=auto         # before
CommandError: 'git ... annex copy --batch -z --to target --jobs auto ...'
  failed with exitcode 1
option --jobs: cannot parse value `auto'

$ datalad drop --jobs=auto .                    # before
(no output, exit 0, files NOT dropped)
```

After:

```text
$ datalad push --to=target --jobs=auto
copy(ok): a_1.bin (file) [to target...]
copy(ok): a_2.bin (file) [to target...]
...
$ datalad drop --jobs=auto .
drop(ok): a_1.bin (file)
drop(ok): a_2.bin (file)
...
```

</details>

## Test plan

- [x] `pytest datalad/core/distributed/tests/test_push.py` — 19 passed, 1 skipped
- [x] `pytest datalad/distributed/tests/test_drop.py` — 16 passed
- [x] `pytest datalad/local/tests/test_remove.py` — 9 passed
- [x] Reverified with the patch stashed: `test_push[True]` raises `CommandError`, `test_drop_allkeys` fails its key-count assertion → modified tests do provide regression coverage.
- [ ] Follow-up PR for the `max-annex-jobs` / `max-jobs` default-of-1 half of #7867.
