### PR TITLE
NF: add -J cpus option for explicit CPU-based parallelism

### DIFF
--- a/changelog.d/pr-7871.md
+++ b/changelog.d/pr-7871.md
@@ -1,0 +1,12 @@
+### 🚀 Enhancements and New Features
+
+- Add `cpus` as a new value for the `-J`/`--jobs` option, resolving to the
+  number of CPUs available to the process (via `os.sched_getaffinity` on
+  Linux, so CPU-affinity and cpuset limits are respected).  Unlike `auto`,
+  `cpus`
+  is not bounded by `datalad.runtime.max-annex-jobs`, providing an explicit
+  opt-in to CPU-count-based parallelism.  The `auto` path is now also
+  affinity-aware (no change in behavior under the default
+  `max-annex-jobs=1`).
+  [PR #7871](https://github.com/datalad/datalad/pull/7871)
+  (by [@just-meng](https://github.com/just-meng))

--- a/datalad/interface/common_opts.py
+++ b/datalad/interface/common_opts.py
@@ -207,10 +207,13 @@ jobs_opt = Parameter(
     args=("-J", "--jobs"),
     metavar="NJOBS",
     default='auto',
-    constraints=EnsureInt() | EnsureNone() | EnsureChoice('auto'),
+    constraints=EnsureInt() | EnsureNone() | EnsureChoice('auto', 'cpus'),
     doc="""how many parallel jobs (where possible) to use. "auto" corresponds
     to the number defined by 'datalad.runtime.max-annex-jobs' configuration
-    item""")
+    item. "cpus" sets the number of jobs to the number of available CPUs.
+    Note that, unlike "auto", "cpus" is NOT bounded by
+    'datalad.runtime.max-annex-jobs' and can therefore be resource-intensive
+    on machines with many cores""")
 
 verbose = Parameter(
     args=("-v", "--verbose",),

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -19,7 +19,6 @@ import re
 import time
 import warnings
 from itertools import chain
-from multiprocessing import cpu_count
 from os import linesep
 from os.path import (
     curdir,
@@ -70,6 +69,7 @@ from datalad.utils import (
     Path,
     PurePosixPath,
     auto_repr,
+    available_cpu_count,
     bytes2human,
     ensure_list,
     on_windows,
@@ -957,13 +957,19 @@ class AnnexRepo(GitRepo, RepoInterface):
         if self._annex_common_options:
             cmd += self._annex_common_options
 
-        if jobs == 'auto':
+        if jobs == 'cpus':
+            jobs = available_cpu_count()
+            if jobs == 1:
+                lgr.warning(
+                    "'-J cpus' resolved to a single CPU available to this "
+                    "process; proceeding without parallelism")
+        elif jobs == 'auto':
             # Limit to # of CPUs (but at least 3 to start with)
             # and also an additional config constraint (by default 1
             # due to https://github.com/datalad/datalad/issues/4404)
             jobs = self._n_auto_jobs or min(
                 self.config.obtain('datalad.runtime.max-annex-jobs'),
-                max(3, cpu_count()))
+                max(3, available_cpu_count()))
             # cache result to avoid repeated calls to cpu_count()
             self._n_auto_jobs = jobs
         if jobs and jobs != 1:

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -959,10 +959,6 @@ class AnnexRepo(GitRepo, RepoInterface):
 
         if jobs == 'cpus':
             jobs = available_cpu_count()
-            if jobs == 1:
-                lgr.warning(
-                    "'-J cpus' resolved to a single CPU available to this "
-                    "process; proceeding without parallelism")
         elif jobs == 'auto':
             # Limit to # of CPUs (but at least 3 to start with)
             # and also an additional config constraint (by default 1

--- a/datalad/support/parallel.py
+++ b/datalad/support/parallel.py
@@ -28,7 +28,10 @@ from threading import Thread
 from datalad.support.exceptions import CapturedException
 
 from ..log import log_progress
-from ..utils import path_is_subpath
+from ..utils import (
+    available_cpu_count,
+    path_is_subpath,
+)
 from . import ansi_colors as colors
 
 lgr = logging.getLogger('datalad.parallel')
@@ -248,7 +251,13 @@ class ProducerConsumer:
         It will account for configuration variable ('datalad.runtime.max-jobs') and possible
         other requirements (such as version of Python).
         """
-        if jobs in (None, "auto"):
+        if jobs == "cpus":
+            jobs = available_cpu_count()
+            if jobs == 1:
+                lgr.warning(
+                    "'-J cpus' resolved to a single CPU available to this "
+                    "process; proceeding without parallelism")
+        elif jobs in (None, "auto"):
             from datalad import cfg
 
             # ATM there is no "auto" for this operation, so in both auto and None

--- a/datalad/support/parallel.py
+++ b/datalad/support/parallel.py
@@ -253,10 +253,6 @@ class ProducerConsumer:
         """
         if jobs == "cpus":
             jobs = available_cpu_count()
-            if jobs == 1:
-                lgr.warning(
-                    "'-J cpus' resolved to a single CPU available to this "
-                    "process; proceeding without parallelism")
         elif jobs in (None, "auto"):
             from datalad import cfg
 

--- a/datalad/tests/test_jobs.py
+++ b/datalad/tests/test_jobs.py
@@ -118,12 +118,13 @@ def test_call_annex_resolves_cpus(path=None):
 
 
 @pytest.mark.ai_generated
-def test_jobs_cpus_warns_when_single_cpu():
-    """'cpus' resolving to a single CPU warns about lack of parallelism"""
-    with patch('datalad.support.parallel.available_cpu_count',
-               return_value=1), \
-            swallow_logs(new_level=logging.WARNING) as cml:
-        jobs = ProducerConsumer.get_effective_jobs('cpus')
-        assert jobs == 1
-        cml.assert_logged("'-J cpus' resolved to a single CPU",
-                          level='WARNING', regex=False)
+def test_available_cpu_count_warns_when_undetermined():
+    """available_cpu_count warns and returns 1 when the OS cannot report a count"""
+    import datalad.utils as du
+    with patch.object(du, '_n_available_cpus', None), \
+         patch('os.sched_getaffinity', side_effect=AttributeError, create=True), \
+         patch('os.cpu_count', return_value=None), \
+         swallow_logs(new_level=logging.WARNING) as cml:
+        n = available_cpu_count()
+    assert n == 1
+    cml.assert_logged("Could not determine", level='WARNING', regex=False)

--- a/datalad/tests/test_jobs.py
+++ b/datalad/tests/test_jobs.py
@@ -1,0 +1,129 @@
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test -J/--jobs value resolution (follow-up to gh-7867)"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from datalad.api import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.parallel import ProducerConsumer
+from datalad.tests.utils_pytest import (
+    assert_in_results,
+    assert_status,
+    skip_if_adjusted_branch,
+    with_tempfile,
+)
+from datalad.utils import (
+    available_cpu_count,
+    swallow_logs,
+)
+
+
+@pytest.mark.ai_generated
+@with_tempfile(mkdir=True)
+def test_jobs_cpus_get(path=None):
+    """'cpus' is accepted and resolves for get"""
+    ds = Dataset(path).create()
+    (ds.pathobj / 'file.txt').write_text('content')
+    ds.save(message='add file')
+
+    res = ds.get('file.txt', jobs='cpus')
+    assert_status(['ok', 'notneeded'], res)
+
+
+@pytest.mark.ai_generated
+@skip_if_adjusted_branch  # push->copy semantics differ on Windows adjusted branches
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_jobs_cpus_push(srcpath=None, dstpath=None):
+    """'cpus' is accepted and resolves for push"""
+    src = Dataset(srcpath).create()
+    (src.pathobj / 'file.txt').write_text('content')
+    src.save(message='add file')
+
+    target = AnnexRepo(dstpath, init=True, create=True)
+    target.config.set(
+        'receive.denyCurrentBranch', 'updateInstead', scope='local')
+    src.siblings('add', name='target', url=dstpath,
+                 result_renderer='disabled')
+
+    res = src.push(to='target', jobs='cpus')
+    assert_in_results(res, action='copy', status='ok',
+                      path=str(src.pathobj / 'file.txt'))
+
+
+@pytest.mark.ai_generated
+@skip_if_adjusted_branch  # drop content semantics differ on Windows adjusted branches
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_jobs_cpus_drop(srcpath=None, dstpath=None):
+    """'cpus' is accepted and resolves for drop"""
+    src = Dataset(srcpath).create()
+    (src.pathobj / 'file.txt').write_text('content')
+    src.save(message='add file')
+
+    target = AnnexRepo(dstpath, init=True, create=True)
+    target.config.set(
+        'receive.denyCurrentBranch', 'updateInstead', scope='local')
+    src.siblings('add', name='target', url=dstpath,
+                 result_renderer='disabled')
+    src.push(to='target')
+
+    assert src.repo.file_has_content('file.txt')
+    res = src.drop(jobs='cpus')
+    assert_in_results(res, action='drop', status='ok',
+                      path=str(src.pathobj / 'file.txt'))
+    assert not src.repo.file_has_content('file.txt')
+
+
+@pytest.mark.ai_generated
+def test_jobs_cpus_resolves_to_cpu_count():
+    """'cpus' resolves to available_cpu_count() in ProducerConsumer path"""
+    expected = available_cpu_count()
+    assert ProducerConsumer.get_effective_jobs('cpus') == expected
+
+
+@pytest.mark.ai_generated
+def test_available_cpu_count():
+    """available_cpu_count returns a positive integer"""
+    n = available_cpu_count()
+    assert isinstance(n, int)
+    assert n >= 1
+
+
+@pytest.mark.ai_generated
+@with_tempfile(mkdir=True)
+def test_call_annex_resolves_cpus(path=None):
+    """_call_annex resolves jobs='cpus' to available_cpu_count() in -J flag
+
+    Unlike 'auto', 'cpus' is not bounded by datalad.runtime.max-annex-jobs,
+    so the resolved value is passed straight through as -J<n>.
+    """
+    repo = AnnexRepo(path, create=True)
+    # use a distinctive (>1, so -J is emitted) value to avoid coincidences
+    with patch('datalad.support.annexrepo.available_cpu_count',
+               return_value=7), \
+            patch.object(repo, '_git_runner') as runner:
+        repo._call_annex(['find'], jobs='cpus')
+    cmd = runner.run.call_args[0][0]
+    assert '-J7' in cmd
+
+
+@pytest.mark.ai_generated
+def test_jobs_cpus_warns_when_single_cpu():
+    """'cpus' resolving to a single CPU warns about lack of parallelism"""
+    with patch('datalad.support.parallel.available_cpu_count',
+               return_value=1), \
+            swallow_logs(new_level=logging.WARNING) as cml:
+        jobs = ProducerConsumer.get_effective_jobs('cpus')
+        assert jobs == 1
+        cml.assert_logged("'-J cpus' resolved to a single CPU",
+                          level='WARNING', regex=False)

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2872,9 +2872,9 @@ def available_cpu_count():
     job schedulers).  Note that this does not account for cgroup CPU
     *quota* limits (e.g. Docker ``--cpus``), which throttle CPU time
     rather than restrict which cores are available.  On macOS/Windows,
-    falls back to ``os.cpu_count``.  Returns 1 if the count cannot be
-    determined.  The result is computed once and cached for the lifetime
-    of the process.
+    falls back to ``os.cpu_count``.  Emits a warning and returns 1 if the
+    count cannot be determined.  The result is computed once and cached for
+    the lifetime of the process.
     """
     global _n_available_cpus
     if _n_available_cpus is None:
@@ -2883,8 +2883,10 @@ def available_cpu_count():
         except (AttributeError, NotImplementedError):
             # no sched_getaffinity (macOS/Windows or exotic platforms):
             # fall back to the total CPU count, or 1 if undeterminable
-            _n_available_cpus = os.cpu_count() or 1
-            lgr.debug(
-                "os.sched_getaffinity unavailable; falling back to "
-                "os.cpu_count() = %d available CPU(s)", _n_available_cpus)
+            if not (cpu_count := os.cpu_count()):
+                lgr.warning(
+                    "Could not determine the number of CPUs available to "
+                    "this process; defaulting to 1")
+                cpu_count = 1
+            _n_available_cpus = cpu_count
     return _n_available_cpus

--- a/datalad/utils.py
+++ b/datalad/utils.py
@@ -2858,3 +2858,33 @@ def ensure_write_permission(path: Path) -> Iterator[None]:
                 # nothing to do. Don't test exists(), though - asking for
                 # forgiveness to save a call.
                 pass
+
+
+_n_available_cpus = None
+
+
+def available_cpu_count():
+    """Return the number of CPUs available to this process.
+
+    On Linux, uses ``os.sched_getaffinity`` to count only the CPUs this
+    process is actually allowed to run on, respecting CPU affinity and
+    cpuset restrictions (e.g. ``taskset``, ``--cpuset-cpus``, and many HPC
+    job schedulers).  Note that this does not account for cgroup CPU
+    *quota* limits (e.g. Docker ``--cpus``), which throttle CPU time
+    rather than restrict which cores are available.  On macOS/Windows,
+    falls back to ``os.cpu_count``.  Returns 1 if the count cannot be
+    determined.  The result is computed once and cached for the lifetime
+    of the process.
+    """
+    global _n_available_cpus
+    if _n_available_cpus is None:
+        try:
+            _n_available_cpus = len(os.sched_getaffinity(0))
+        except (AttributeError, NotImplementedError):
+            # no sched_getaffinity (macOS/Windows or exotic platforms):
+            # fall back to the total CPU count, or 1 if undeterminable
+            _n_available_cpus = os.cpu_count() or 1
+            lgr.debug(
+                "os.sched_getaffinity unavailable; falling back to "
+                "os.cpu_count() = %d available CPU(s)", _n_available_cpus)
+    return _n_available_cpus


### PR DESCRIPTION
## Summary

Following #7868 (which fixed `-J auto` crashing push/drop), this adds `cpus` as a new `-J`/`--jobs` value that resolves to the number of CPUs available to the process.

**Motivation:** `-J auto` is intentionally conservative — it's capped by `datalad.runtime.max-annex-jobs`, which defaults to `1` (see #4404, where unbounded CPU-count parallelism caused crashes). With the default config `auto` therefore resolves to `1` (effectively serial). Users who *want* CPU-based parallelism currently have no way to request it without knowing their CPU count and passing a literal number.

`-J cpus` fills this gap: an explicit opt-in to CPU-count-based parallelism, without changing the safe `auto` default.

**Safety note:** unlike `auto`, `cpus` is deliberately *not* bounded by `datalad.runtime.max-annex-jobs`. On many-core machines this can be resource-intensive and, for git-annex operations, can reach the regime that #4404 guarded against. This trade-off is documented in the `-J` help text so inexperienced users are warned.

**Related future work (not in this PR):** arguably `-J auto` should itself resolve to something `> 1` but below a sensible cap, instead of the current default of `1`. That is a larger change to the default-parallelism policy and is left to the maintainers; `cpus` gives the explicit "use all available CPUs" knob in the meantime.

## Changes

| File | Change |
|------|--------|
| `utils.py` | Add `available_cpu_count()`: uses `os.sched_getaffinity()` on Linux (respects cgroups/containers), falls back to `os.cpu_count()` on macOS/Windows, `1` if undeterminable |
| `common_opts.py` | Add `'cpus'` to `EnsureChoice` for `jobs_opt`; document it and warn that it is not bounded by `max-annex-jobs` |
| `annexrepo.py` | Handle `'cpus'` → `available_cpu_count()` in `_call_annex()`; also switch the existing `auto` path from `multiprocessing.cpu_count()` to `available_cpu_count()` (no behavior change under the default `max-annex-jobs=1`) |
| `parallel.py` | Handle `'cpus'` in `ProducerConsumer.get_effective_jobs()` |
| `tests/test_jobs.py` | Tests for get/push/drop with `jobs='cpus'`, plus unit tests for resolution and `available_cpu_count()` |
| `changelog.d/` | scriv fragment under "🚀 Enhancements and New Features" |

## Test plan

- [x] `test_jobs_cpus_get` — get with `jobs='cpus'` is accepted and runs
- [x] `test_jobs_cpus_push` — push with `jobs='cpus'` works
- [x] `test_jobs_cpus_drop` — drop with `jobs='cpus'` works
- [x] `test_jobs_cpus_resolves_to_cpu_count` — resolves to `available_cpu_count()` in the `ProducerConsumer` path
- [x] `test_available_cpu_count` — returns a positive integer
- [x] Existing push and drop tests pass without regressions

### Manual end-to-end verification

Tested in a real dataset (16 available CPUs) — `-J cpus` resolves to `-J16` and is passed through to git-annex, completing successfully:

```
$ datalad -l debug get . -J cpus 2>&1 | grep -E -- "-J[0-9]+"
[DEBUG] Run ['git', ..., 'annex', 'get', ..., '-J16', '--', '.'] (protocol_class=AnnexJsonProtocol) (cwd=.../figures)
[DEBUG] Finished ['git', ..., 'annex', 'get', ..., '-J16', '--', '.'] with status 0
```

Ref: #7867

🤖 Generated with [Claude Code](https://claude.com/claude-code)
