### PR TITLE
BF: resolve the update target's corresponding branch on adjusted branches

### DIFF
--- a/changelog.d/adjusted_update_target.md
+++ b/changelog.d/adjusted_update_target.md
@@ -1,0 +1,9 @@
+### 🐛 Bug Fixes
+
+- `update --how=reset` (and `--how=merge`) now resolves the corresponding branch
+  when determining the update target on adjusted branches (Windows / crippled
+  filesystems). Previously the adjusted branch name was used to build a
+  nonexistent `<remote>/adjusted/...` ref, so the update aborted with
+  "Could not determine update target".
+  Fixes [#7873](https://github.com/datalad/datalad/issues/7873).
+  (by [@just-meng](https://github.com/just-meng))

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -41,10 +41,12 @@ from datalad.tests.utils_pytest import (
     assert_repo_status,
     assert_result_count,
     assert_status,
+    corresponding_hexsha,
     create_tree,
     eq_,
     known_failure_windows,
     maybe_adjust_repo,
+    maybe_unadjust_repo,
     neq_,
     ok_,
     ok_file_has_content,
@@ -1039,6 +1041,65 @@ def test_update_reset_dirty(path=None):
     assert_repo_status(ds_clone.path,
                        modified=[ds_clone_s1.repo.path,
                                  ds_clone_s2.repo.path])
+
+
+@slow  # ~10s
+@pytest.mark.parametrize("divergence", ["local_discard", "remote_discard"])
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted(path=None, *, divergence):
+    """`update --how=reset` must actually run on an adjusted branch following a sibling.
+
+    Two ways the corresponding branch can differ from the sibling:
+    ``local_discard`` (clone has an extra local commit) and ``remote_discard``
+    (the sibling moved back without the clone, e.g. via --force push).
+    Either way, target determination and the reset itself must work on the adjusted branch.
+
+    Regression: target determination used the *adjusted* branch name (e.g.
+    ``adjusted/master(unlocked)``) and built a nonexistent
+    ``<remote>/adjusted/master(unlocked)`` ref, so the command aborted with
+    "Could not determine update target".  It must instead resolve the
+    corresponding branch and reset to ``<remote>/<corresponding>``.
+    """
+    path = Path(path)
+
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "remote.txt").write_text("base commit")
+    ds_src.save()
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+
+    if divergence == 'local_discard':
+        (ds_clone.pathobj / "local.txt").write_text("local only, discard me by reset")
+        ds_clone.save()
+    elif divergence == 'remote_discard':
+        # A raw git reset --hard must move the sibling's corresponding branch
+        # -- the one rewrite that needs an unadjust here (see maybe_unadjust_repo).
+        maybe_unadjust_repo(ds_src.repo)
+        ds_src.repo.call_git(["reset", "--hard", "HEAD~"])
+
+    # Read both real tips with corresponding_hexsha (corr-aware)
+    target_hexsha = corresponding_hexsha(ds_src.repo)
+    pre_update_hexsha = corresponding_hexsha(ds_clone.repo)
+    neq_(pre_update_hexsha, target_hexsha)  # the local clone has diverged
+
+    # reset local clone to sibling (previously raised "Could not determine update target")
+    assert_in_results(
+        ds_clone.update(follow="sibling", how="reset"),
+        action="update.reset", status="ok")
+
+    # The corresponding branch matches the sibling again (local commit gone)...
+    post_update_hexsha = corresponding_hexsha(ds_clone.repo)
+    eq_(post_update_hexsha, target_hexsha)
+    # ... the adjusted view's anchor (basis) was re-anchored to the target too,
+    # otherwise the next git annex adjust would rebuild the view from the wrong basis
+    adjusted = ds_clone.repo.get_active_branch()
+    eq_(ds_clone.repo.get_hexsha(f"refs/basis/{adjusted}"), target_hexsha)
+    # ... and we are still on the adjusted branch.
+    ok_(ds_clone.repo.is_managed_branch())
 
 
 def test_process_how_args():

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -485,6 +485,12 @@ def _choose_update_target(repo, branch, remote, cfg_remote):
              f"{repo.get_corresponding_branch(branch) or ''}" "@{upstream}"],
             read_only=True)
     elif branch:
+        # On an adjusted branch the active branch (e.g.
+        # 'adjusted/master(unlocked)') has no remote counterpart; the sibling
+        # tracks the corresponding branch ('master'). Resolve it so the target
+        # becomes e.g. 'origin/master' instead of the nonexistent
+        # 'origin/adjusted/master(unlocked)'.
+        branch = repo.get_corresponding_branch(branch) or branch
         remote_branch = "{}/{}".format(remote, branch)
         if repo.commit_exists(remote_branch):
             target = remote_branch

--- a/datalad/tests/test_tests_utils_pytest.py
+++ b/datalad/tests/test_tests_utils_pytest.py
@@ -42,6 +42,7 @@ from _pytest.outcomes import (
 )
 
 from datalad import cfg as dl_cfg
+from datalad.distribution.dataset import Dataset
 from datalad.support import path as op
 from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils_pytest import (
@@ -56,6 +57,7 @@ from datalad.tests.utils_pytest import (
     assert_re_in,
     assert_str_equal,
     assert_true,
+    corresponding_hexsha,
     eq_,
     fs_supports_filename,
     get_most_obscure_supported_name,
@@ -63,6 +65,9 @@ from datalad.tests.utils_pytest import (
     known_failure_githubci_win,
     known_failure_windows,
     local_testrepo_flavors,
+    maybe_adjust_repo,
+    maybe_unadjust_repo,
+    neq_,
     nok_startswith,
     ok_,
     ok_broken_symlink,
@@ -82,6 +87,7 @@ from datalad.tests.utils_pytest import (
     serve_path_via_http,
     signal_timeout,
     skip_if,
+    skip_if_adjusted_branch,
     skip_if_no_module,
     skip_if_no_network,
     skip_if_on_windows,
@@ -771,3 +777,66 @@ def test_signal_timeout_noop_without_sigalrm(monkeypatch):
     # but with SIGALRM removed it must be a pure no-op.
     with signal_timeout(0.001):
         time.sleep(0.05)
+
+
+#
+# Test the adjusted-branch helpers
+#
+
+@with_tempfile(mkdir=True)
+def test_corresponding_hexsha(path=None):
+    ds = Dataset(path).create()
+    maybe_adjust_repo(ds.repo)
+    corr = ds.repo.get_corresponding_branch()
+    old = ds.repo.get_hexsha(corr)
+
+    (ds.pathobj / "new.txt").write_text("NEW")
+    ds.save()
+    new = ds.repo.get_hexsha(corr)
+
+    neq_(old, new)
+    neq_(ds.repo.get_hexsha("HEAD"), new)
+
+    # valid non-HEAD refs that contain "HEAD" in the string
+    ds.repo.call_git(["branch", "myHEAD", new])
+    ds.repo.call_git(["update-ref", "ORIG_HEAD", new])
+
+    eq_(corresponding_hexsha(ds.repo), new)
+    eq_(corresponding_hexsha(ds.repo, corr), new)
+    eq_(corresponding_hexsha(ds.repo, old), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD~"), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD^"), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD@{0}"), new)
+    eq_(corresponding_hexsha(ds.repo, "myHEAD"), new)
+    eq_(corresponding_hexsha(ds.repo, "ORIG_HEAD"), new)
+
+    for bogus in ("bogus", "bogusHEAD", "HEAD~99"):
+        assert_raises(ValueError, corresponding_hexsha, ds.repo, bogus)
+
+
+@skip_if_adjusted_branch
+@with_tempfile(mkdir=True)
+def test_maybe_unadjust_repo_noop(path=None):
+    repo = Dataset(path).create().repo
+    branch, hexsha = repo.get_active_branch(), repo.get_hexsha("HEAD")
+    maybe_unadjust_repo(repo)
+    eq_(repo.get_active_branch(), branch)
+    eq_(repo.get_hexsha("HEAD"), hexsha)
+
+
+@with_tempfile(mkdir=True)
+def test_maybe_unadjust_repo(path=None):
+    ds = Dataset(path).create()
+    maybe_adjust_repo(ds.repo)
+    corr = ds.repo.get_corresponding_branch()
+    corr_hexsha = ds.repo.get_hexsha(corr)
+
+    maybe_unadjust_repo(ds.repo)
+    assert_false(ds.repo.is_managed_branch())
+    eq_(ds.repo.get_active_branch(), corr)
+    eq_(ds.repo.get_hexsha("HEAD"), corr_hexsha)
+
+    # idempotent: a second call is the no-op case
+    maybe_unadjust_repo(ds.repo)
+    eq_(ds.repo.get_active_branch(), corr)
+    eq_(ds.repo.get_hexsha("HEAD"), corr_hexsha)

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1952,6 +1952,47 @@ def maybe_adjust_repo(repo):
         repo.adjust()
 
 
+def maybe_unadjust_repo(repo):
+    """Check out `repo`'s *corresponding* branch (the real history beneath
+    the adjusting commit), the inverse of `maybe_adjust_repo`.
+
+    Call this function before you need to modify the commit history of a source/
+    sibling repo that has been created on a crippled FS (e.g. Windows CI).
+    A crippled FS forces every repo onto the adjusted branch. A plain
+    ``git reset --hard`` must land on the corresponding branch (not the adjusted
+    view). On a repo that is not adjusted it is a no-op.
+
+    Caveats:
+
+    - only faithful for asserting SHA-identity after a history-rewrite. If you
+      try to assert content-identity, you'll need to materialize the content first
+      via e.g. ``git checkout -- .``.
+
+    - only plain ``git`` keeps the repo unadjusted. DataLad's ``save``, ``update``
+      and ``push`` run ``git annex sync`` internally, which re-adjusts the branch
+      on a crippled filesystem.
+    """
+    if repo.is_managed_branch():
+        corr_branch = repo.get_corresponding_branch()
+        adjusted = repo.get_active_branch()
+        repo.call_git(["checkout", corr_branch])
+        repo.call_git(["branch", "-D", adjusted])
+
+
+def corresponding_hexsha(repo, ref="HEAD"):
+    """Hexsha of ``ref``, read from the corresponding branch when adjusted.
+
+    A plain ``get_hexsha(HEAD)`` on an adjusted repo returns the SHA of the git-annex
+    "adjusting" commit which is just the view. To read the SHA of the real history,
+    HEAD-relative refs need to be resolved against the corresponding branch instead.
+    On a normal branch it is a plain ``get_hexsha(ref)``.
+    """
+    if (corr := repo.get_corresponding_branch()) and (
+            ref == "HEAD" or ref.startswith(("HEAD~", "HEAD^", "HEAD@"))):
+        ref = corr + ref[len("HEAD"):]
+    return repo.get_hexsha(ref)
+
+
 @lru_cache()
 @with_tempfile
 @with_tempfile


### PR DESCRIPTION
Closes #7873.

On an adjusted branch (Windows / crippled filesystem) the active branch is e.g. `adjusted/master(unlocked)`, which has no remote counterpart. `_choose_update_target` built the update target from the adjusted name (`<remote>/adjusted/master(unlocked)`, a nonexistent ref), so `datalad update --how=reset` (and `--how=merge`) aborted with "Could not determine update target".

**Fix:** resolve the corresponding branch when building the target, so it becomes `<remote>/master`. A one-liner.

**Test:** 
- `test_update_reset_adjusted`: the update runs and lands both the corresponding branch and the adjusted view at the sibling.
- helper `corresponding_hexsha`: reads the hexsha NOT from the view, but from the corresponding branch below the view, so corr-aware.
- helper `maybe_unadjust_repo`: checks out the corresponding branch of the source data (while the clone, the dataset under control, stays adjusted) to enable "normal-enough" branch behaviour on a crippled FS -- the reverse of the existing `maybe_adjust_repo`.

Note, `test_update_reset_adjusted` deliberately tests beyond the observed bug and carries a generic name for `datalad update --how=reset` on adjusted branch, because no test exits in the test suite that asserts the basic behaviour of this command.
