### PR TITLE
BF: clean up synced/ so discarded commits stay dead on adjusted branches

### DIFF
--- a/changelog.d/adjusted_merge_synced.md
+++ b/changelog.d/adjusted_merge_synced.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- `update --how=merge` on an adjusted branch now removes the `synced/<branch>`
+  ref it creates (matching `AnnexRepo.localsync`), so a later `git annex sync`
+  cannot merge the zombie back and resurrect discarded commits.
+  Re [#7772](https://github.com/datalad/datalad/issues/7772).
+  (by [@just-meng](https://github.com/just-meng))

--- a/changelog.d/adjusted_reset_synced.md
+++ b/changelog.d/adjusted_reset_synced.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- `update --how=reset` on an adjusted branch now reconciles git-annex's
+  `synced/<branch>` ref, so a discarded commit is not resurrected by the next
+  `git annex sync` (run internally by `save`/`push`).
+  Re [#7772](https://github.com/datalad/datalad/issues/7772).
+  (by [@just-meng](https://github.com/just-meng))

--- a/changelog.d/adjusted_update_target.md
+++ b/changelog.d/adjusted_update_target.md
@@ -1,0 +1,9 @@
+### 🐛 Bug Fixes
+
+- `update --how=reset` (and `--how=merge`) now resolves the corresponding branch
+  when determining the update target on adjusted branches (Windows / crippled
+  filesystems). Previously the adjusted branch name was used to build a
+  nonexistent `<remote>/adjusted/...` ref, so the update aborted with
+  "Could not determine update target".
+  Fixes [#7873](https://github.com/datalad/datalad/issues/7873).
+  (by [@just-meng](https://github.com/just-meng))

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -1002,9 +1002,9 @@ def test_update_how_subds_different(path=None, *, follow, action):
 
 
 @slow  # ~15s
-@skip_if_adjusted_branch
+@pytest.mark.parametrize("on_adjusted", [False, True])
 @with_tempfile(mkdir=True)
-def test_update_reset_dirty(path=None):
+def test_update_reset_dirty(path=None, *, on_adjusted):
     path = Path(path)
     ds_src = Dataset(path / "source").create()
     ds_src_s1 = ds_src.create("s1")
@@ -1013,30 +1013,51 @@ def test_update_reset_dirty(path=None):
 
     ds_clone = install(source=ds_src.path, path=path / "clone",
                        recursive=True, result_xfm="datasets")
+    ds_clone_s1 = Dataset(ds_clone.pathobj / "s1")
+    ds_clone_s2 = Dataset(ds_clone.pathobj / "s2")
+
+    if on_adjusted:
+        # Exercise the adjusted-branch reset path (_annex_reset_target) for both
+        # the parent and the subdatasets. Adjust subdatasets before the parent
+        # to dodge the git-annex submodule/adjust crash fixed in 7.20191024.
+        for d in (ds_clone_s1, ds_clone_s2, ds_clone):
+            maybe_adjust_repo(d.repo)
+        if not ds_clone.repo.is_managed_branch():
+            pytest.skip("test requires adjusted branch support")
+    elif ds_clone.repo.is_managed_branch():
+        # A crippled filesystem forces adjusted branches, so the non-adjusted
+        # leg is impossible here; the adjusted leg still runs natively. (Skip
+        # per-leg rather than the whole function with @skip_if_adjusted_branch,
+        # so this adjusted-branch fix is also exercised on crippled-fs CI.)
+        pytest.skip("filesystem forces adjusted branches; non-adjusted leg N/A")
 
     (ds_src_s1.pathobj / "foo").write_text("foo")
     (ds_src_s2.pathobj / "bar").write_text("bar")
     ds_src.save(recursive=True)
 
-    ds_clone_s1 = Dataset(ds_clone.pathobj / "s1")
-    ds_clone_s2 = Dataset(ds_clone.pathobj / "s2")
     (ds_clone_s1.pathobj / "dirt").write_text("")
 
     res = ds_clone.update(follow="sibling", how="reset", recursive=True,
                           on_failure="ignore")
 
     assert_result_count(res, 1, path=ds_clone.path,
-                        action=f"update.reset", status="error")
+                        action="update.reset", status="error")
     assert_result_count(res, 1, path=ds_clone_s1.path,
-                        action=f"update.reset", status="error")
+                        action="update.reset", status="error")
     assert_result_count(res, 1, path=ds_clone_s2.path,
-                        action=f"update.reset", status="ok")
+                        action="update.reset", status="ok")
 
-    # s2 was reset...
-    eq_(ds_src_s2.repo.get_hexsha(), ds_clone_s2.repo.get_hexsha())
+    # Compare real histories with corresponding_hexsha: it reads each repo's
+    # corresponding branch when adjusted, so neither the (adjusted) clone nor
+    # the (crippled-fs) sibling needs unadjusting just to be observed.
+    # s2 was reset to the sibling ...
+    eq_(corresponding_hexsha(ds_src_s2.repo),
+        corresponding_hexsha(ds_clone_s2.repo))
     # ... but s1 and the top-level dataset stayed behind due to the dirty tree.
-    eq_(ds_src.repo.get_hexsha("HEAD~"), ds_clone.repo.get_hexsha())
-    eq_(ds_src_s1.repo.get_hexsha("HEAD~"), ds_clone_s1.repo.get_hexsha())
+    eq_(corresponding_hexsha(ds_src.repo, "HEAD~"),
+        corresponding_hexsha(ds_clone.repo))
+    eq_(corresponding_hexsha(ds_src_s1.repo, "HEAD~"),
+        corresponding_hexsha(ds_clone_s1.repo))
 
     assert_repo_status(ds_clone.path,
                        modified=[ds_clone_s1.repo.path,
@@ -1320,7 +1341,7 @@ def test_update_merge_adjusted_no_leftover_synced(path=None):
     if synced_branch in ds_clone.repo.get_branches():
         ds_clone.repo.call_git(["branch", "-D", synced_branch])
 
-    # Advance the sibling so the merge has something to pull. 
+    # Advance the sibling so the merge has something to pull.
     (ds_src.pathobj / "new.txt").write_text("new")
     ds_src.save(message="new commit")
 

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -41,10 +41,12 @@ from datalad.tests.utils_pytest import (
     assert_repo_status,
     assert_result_count,
     assert_status,
+    corresponding_hexsha,
     create_tree,
     eq_,
     known_failure_windows,
     maybe_adjust_repo,
+    maybe_unadjust_repo,
     neq_,
     ok_,
     ok_file_has_content,
@@ -1039,6 +1041,65 @@ def test_update_reset_dirty(path=None):
     assert_repo_status(ds_clone.path,
                        modified=[ds_clone_s1.repo.path,
                                  ds_clone_s2.repo.path])
+
+
+@slow  # ~10s
+@pytest.mark.parametrize("divergence", ["local_discard", "remote_discard"])
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted(path=None, *, divergence):
+    """`update --how=reset` must actually run on an adjusted branch following a sibling.
+
+    Two ways the corresponding branch can differ from the sibling:
+    ``local_discard`` (clone has an extra local commit) and ``remote_discard``
+    (the sibling moved back without the clone, e.g. via --force push).
+    Either way, target determination and the reset itself must work on the adjusted branch.
+
+    Regression: target determination used the *adjusted* branch name (e.g.
+    ``adjusted/master(unlocked)``) and built a nonexistent
+    ``<remote>/adjusted/master(unlocked)`` ref, so the command aborted with
+    "Could not determine update target".  It must instead resolve the
+    corresponding branch and reset to ``<remote>/<corresponding>``.
+    """
+    path = Path(path)
+
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "remote.txt").write_text("base commit")
+    ds_src.save()
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+
+    if divergence == 'local_discard':
+        (ds_clone.pathobj / "local.txt").write_text("local only, discard me by reset")
+        ds_clone.save()
+    elif divergence == 'remote_discard':
+        # A raw git reset --hard must move the sibling's corresponding branch
+        # -- the one rewrite that needs an unadjust here (see maybe_unadjust_repo).
+        maybe_unadjust_repo(ds_src.repo)
+        ds_src.repo.call_git(["reset", "--hard", "HEAD~"])
+
+    # Read both real tips with corresponding_hexsha (corr-aware)
+    target_hexsha = corresponding_hexsha(ds_src.repo)
+    pre_update_hexsha = corresponding_hexsha(ds_clone.repo)
+    neq_(pre_update_hexsha, target_hexsha)  # the local clone has diverged
+
+    # reset local clone to sibling (previously raised "Could not determine update target")
+    assert_in_results(
+        ds_clone.update(follow="sibling", how="reset"),
+        action="update.reset", status="ok")
+
+    # The corresponding branch matches the sibling again (local commit gone)...
+    post_update_hexsha = corresponding_hexsha(ds_clone.repo)
+    eq_(post_update_hexsha, target_hexsha)
+    # ... the adjusted view's anchor (basis) was re-anchored to the target too,
+    # otherwise the next git annex adjust would rebuild the view from the wrong basis
+    adjusted = ds_clone.repo.get_active_branch()
+    eq_(ds_clone.repo.get_hexsha(f"refs/basis/{adjusted}"), target_hexsha)
+    # ... and we are still on the adjusted branch.
+    ok_(ds_clone.repo.is_managed_branch())
 
 
 def test_process_how_args():

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -1292,6 +1292,44 @@ def test_update_reset_adjusted_no_resurrection_on_push(path=None):
     eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
 
 
+@slow  # ~10s
+@with_tempfile(mkdir=True)
+def test_update_merge_adjusted_no_leftover_synced(path=None):
+    """`update --how=merge` on an adjusted branch must not leave a zombie synced/.
+
+    On adjusted branches `update --how=merge` runs `git annex sync`, which
+    creates a `synced/<branch>` ref. Left behind, that ref is a "zombie": a
+    later sync (run internally by save/push) can merge it back and resurrect
+    discarded commits (gh-7772). Mirror `AnnexRepo.localsync`'s delete-if-created
+    hygiene -- if this sync created `synced/<branch>`, remove it again.
+    """
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "base.txt").write_text("base")
+    ds_src.save()
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+    corr_branch = ds_clone.repo.get_corresponding_branch()
+    synced_branch = f"synced/{corr_branch}"
+
+    # Start from a clean slate so we only judge the synced/ this merge creates.
+    if synced_branch in ds_clone.repo.get_branches():
+        ds_clone.repo.call_git(["branch", "-D", synced_branch])
+
+    # Advance the sibling so the merge has something to pull. 
+    (ds_src.pathobj / "new.txt").write_text("new")
+    ds_src.save(message="new commit")
+
+    # The merge runs git-annex-sync, which creates synced/<branch> ...
+    ds_clone.update(how="merge")
+    # ... and must clean up the synced/ it created (delete-if-created).
+    assert_not_in(synced_branch, ds_clone.repo.get_branches())
+
+
 def test_process_how_args():
     # --merge maps onto --how values. It has no equivalent of --how-subds,
     # --which just gets set to --how's value when unspecified.

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -1102,6 +1102,196 @@ def test_update_reset_adjusted(path=None, *, divergence):
     ok_(ds_clone.repo.is_managed_branch())
 
 
+@slow  # ~12s
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted_resets_synced(path=None):
+    """Reset on an adjusted branch must STICK across a later git-annex-sync.
+
+    On crippled filesystems (Windows), DataLad uses adjusted branches, and
+    git-annex keeps ``synced/<branch>`` refs tracking the corresponding branch.
+    If ``_annex_reset_target`` reset the corresponding branch but left
+    ``synced/<branch>`` at the old (newer) state, the next ``git annex sync``
+    would merge it back in, resurrecting the intentionally-discarded commits.
+
+    We check both halves: right after the reset *and* after a real sync, BOTH
+    the corresponding branch and ``synced/<branch>`` sit at the target -- so the
+    discard holds, and the following sync stays safe too.
+    See https://github.com/datalad/datalad/issues/7772
+    """
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "file1.txt").write_text("initial")
+    ds_src.save()
+
+    ds_clone = install(
+        source=ds_src.path, path=path / "clone",
+        result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+
+    corr_branch = ds_clone.repo.get_corresponding_branch()
+    target_hexsha = corresponding_hexsha(ds_clone.repo)
+
+    # Advance source.
+    (ds_src.pathobj / "file2.txt").write_text("new")
+    ds_src.save()
+
+    # Merge into the adjusted clone, advancing the corresponding branch.
+    ds_clone.update(sibling=DEFAULT_REMOTE, how="merge")
+    post_update_hexsha = corresponding_hexsha(ds_clone.repo)
+    neq_(post_update_hexsha, target_hexsha)
+
+    # Simulate a synced/ branch left behind by git-annex (as happens on
+    # Windows) by creating synced/<branch> at the post-merge state.
+    synced_branch = f"synced/{corr_branch}"
+    ds_clone.repo.call_git(
+        ["branch", "-f", synced_branch, post_update_hexsha])
+    ok_(synced_branch in ds_clone.repo.get_branches())
+
+    # Reset to the old state via _annex_reset_target.
+    from datalad.distribution.update import _annex_reset_target
+    for r in _annex_reset_target(ds_clone.repo, None, target_hexsha):
+        eq_(r["status"], "ok")
+
+    # PRE-SYNC: _annex_reset_target's direct contract -- BOTH the corresponding
+    # branch AND synced/<branch> must now sit at the reset target.
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+    eq_(ds_clone.repo.get_hexsha(synced_branch), target_hexsha)
+
+    # ACID + DURABILITY: a real git-annex-sync must NOT resurrect the discarded
+    # commit, AND must leave BOTH refs at the target -- so the *next* sync is
+    # safe too (no re-armed synced/ left to merge back in).
+    ds_clone.repo.call_annex(
+        ["sync", "--no-push", "--no-pull", "--no-commit",
+         "--no-content", "--no-resolvemerge"])
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+    eq_(ds_clone.repo.get_hexsha(synced_branch), target_hexsha)
+
+
+@slow  # ~15s
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted_no_resurrection_on_save(path=None):
+    """local_discard: a `save` after reset must not resurrect a discarded commit.
+
+    Realistic adjusted-branch flow (public API only, no raw git-annex commands):
+    ``update --how=merge`` leaves a local ``synced/<branch>`` behind; a later
+    ``update --how=reset`` discards a local commit; if ``synced/<branch>`` is
+    not reconciled, the next ``save`` (which runs git-annex-sync internally)
+    merges it back, resurrecting the discarded commit.  Requires BOTH fixes:
+    target determination on adjusted branches (so reset runs at all) and the
+    synced/ reset inside ``_annex_reset_target``.
+    """
+    path = Path(path)
+
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "base.txt").write_text("base commit")
+    ds_src.save(message="add a base commit")
+
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+    corr_branch = ds_clone.repo.get_corresponding_branch()
+
+    # `update --how merge` to create the underlying `synced/<branch>`
+    ds_clone.update(how="merge")
+
+    # Store sibling's state as the reset target -- a corr-aware read, so the
+    # sibling can stay adjusted (we never rewrite it); no unadjust needed.
+    target_hexsha = corresponding_hexsha(ds_src.repo)
+
+    # A local commit that the reset will discard.
+    (ds_clone.pathobj / "local.txt").write_text("discard me")
+    ds_clone.save(message="local commit to be discarded")
+    discard = ds_clone.repo.get_hexsha(corr_branch)
+    neq_(discard, target_hexsha)
+
+    # Reset to the sibling, discarding the local commit.
+    assert_in_results(ds_clone.update(how="reset"),
+                      action="update.reset", status="ok")
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+
+    # The reckoning: a normal save must NOT resurrect the discarded commit,
+    # and must NOT lose the fresh work added on top. `save` runs git-annex-sync
+    # internally, which is where a zombie synced/<branch> would merge the
+    # discarded commit back in.
+    (ds_clone.pathobj / "fresh.txt").write_text("fresh work")
+    ds_clone.save(message="fresh work after reset")
+    # the discarded commit did not come back ...
+    assert_false(ds_clone.repo.is_ancestor(discard, corr_branch))
+    ok_(not (ds_clone.pathobj / "local.txt").exists())
+    # ... and the fresh work survived.
+    ok_((ds_clone.pathobj / "fresh.txt").exists())
+
+
+@slow  # ~15s
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted_no_resurrection_on_push(path=None):
+    """remote_discard: a `push` after reset must not resurrect a discarded commit.
+
+    The sibling grows a commit, the clone pulls it via ``update --how=merge``
+    (seeding the zombie ``synced/<branch>``), then the sibling rewinds it (as a
+    history rewrite / --force push would).  The clone resets to match the
+    rewound sibling, discarding the commit -- but if ``synced/<branch>`` is not
+    reconciled, the next ``push`` (which runs the same git-annex-sync via
+    ``push``'s internal ``localsync``) merges it back and resurrects the
+    discarded commit *on the sibling*.
+    """
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "base.txt").write_text("base commit")
+    ds_src.save()
+
+    # allow pushing back into the (non-bare) source's checked-out branch
+    ds_src.repo.config.set("receive.denyCurrentBranch", "updateInstead",
+                           scope="local")
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+    corr_branch = ds_clone.repo.get_corresponding_branch()
+    src_branch = ds_src.repo.get_corresponding_branch() or DEFAULT_BRANCH
+
+    (ds_src.pathobj / "bad.txt").write_text("bad upstream commit")
+    ds_src.save(message="bad commit")
+
+    ds_clone.update(how="merge")
+    discard = ds_clone.repo.get_hexsha(corr_branch)
+    ok_((ds_clone.pathobj / "bad.txt").exists())
+
+    # Upstream rewinds the bad commit (history rewrite / --force push). A raw
+    # `git reset --hard` must move the sibling's corresponding branch, not its
+    # adjusted view. See maybe_unadjust_repo.
+    maybe_unadjust_repo(ds_src.repo)
+    ds_src.repo.call_git(["reset", "--hard", "HEAD~"])
+    target_hexsha = corresponding_hexsha(ds_src.repo)
+    neq_(discard, target_hexsha)
+
+    # The clone resets to match the rewound sibling, discarding the bad commit.
+    assert_in_results(ds_clone.update(how="reset"),
+                      action="update.reset", status="ok")
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+
+    # The reckoning: pushing back must NOT resurrect the bad commit. We push
+    # directly after the reset (no intervening local save) so that push's own
+    # internal localsync -- not a save -- is what would merge a zombie
+    # synced/<branch> back in.
+    ds_clone.push(to=DEFAULT_REMOTE)
+    # the discarded commit did not come back, on either side ...
+    assert_false(ds_src.repo.is_ancestor(discard, src_branch))
+    assert_false(ds_clone.repo.is_ancestor(discard, corr_branch))
+    # ... and both sides agree at the rewound target (good state preserved,
+    # nothing extra resurrected).
+    eq_(ds_src.repo.get_hexsha(src_branch), target_hexsha)
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+
+
 def test_process_how_args():
     # --merge maps onto --how values. It has no equivalent of --how-subds,
     # --which just gets set to --how's value when unspecified.

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -578,10 +578,27 @@ def _annex_plain_merge(repo, _, target, opts=None):
 
 
 def _annex_sync(repo, remote, _target, opts=None):
-    yield _try_command(
+    # git-annex-sync creates a synced/<branch> ref. Mirror
+    # AnnexRepo.localsync's delete-if-created hygiene: if this sync created it,
+    # remove it again, so a later git-annex-sync (run internally by save/push)
+    # cannot merge the zombie back and resurrect discarded commits (gh-7772).
+    branch = repo.get_active_branch()
+    branch = repo.get_corresponding_branch(branch) or branch
+    synced_branch = 'synced/{}'.format(branch)
+    had_synced_branch = synced_branch in repo.get_branches()
+    res = _try_command(
         {"action": "update.annex_sync", "message": "Ran git-annex-sync"},
         repo.call_annex,
         ['sync', '--no-push', '--pull', '--no-commit', '--no-content', remote])
+    yield res
+    # Use -D (force): after a --pull sync, synced/<branch> may hold commits not
+    # reachable from the *adjusted* HEAD (they live on the corresponding branch
+    # and remote-tracking ref), so -d would refuse. Force-deleting the ref we
+    # just created loses nothing.
+    if res.get("status") != "error" \
+            and not had_synced_branch \
+            and synced_branch in repo.get_branches():
+        repo.call_git(['branch', '-D', synced_branch])
 
 
 def _annex_merge_target(repo, _remote, target, opts=None):

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -622,8 +622,10 @@ def _annex_reset_target(repo, _remote, target, opts=None):
     """Reset an adjusted branch to a specific target revision.
 
     This performs a hard reset on the corresponding branch, then re-adjusts
-    the branch to maintain the adjusted state. This is useful for
-    `how_subds='reset'` on adjusted branches.
+    the branch to maintain the adjusted state. It also resets any
+    ``synced/<branch>`` ref so that a subsequent ``git annex sync`` does not
+    merge the old (pre-reset) state back in — which is the root cause of
+    "zombie commits" on Windows / crippled filesystems (see #7772).
     """
     if repo.dirty:
         yield {"action": "update.reset",
@@ -641,6 +643,11 @@ def _annex_reset_target(repo, _remote, target, opts=None):
         try:
             # Reset to target
             repo.call_git(['reset', '--hard', target])
+            # Also reset synced/<branch> so git-annex-sync won't
+            # resurrect the discarded commits (#7772).
+            synced_branch = 'synced/{}'.format(corr_branch)
+            if synced_branch in repo.get_branches():
+                repo.call_git(['branch', '-f', synced_branch, corr_branch])
             # Re-adjust with --force to overwrite existing adjusted branch
             repo.call_annex(['adjust', adjust_mode, '--force'])
         except Exception:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -485,6 +485,12 @@ def _choose_update_target(repo, branch, remote, cfg_remote):
              f"{repo.get_corresponding_branch(branch) or ''}" "@{upstream}"],
             read_only=True)
     elif branch:
+        # On an adjusted branch the active branch (e.g.
+        # 'adjusted/master(unlocked)') has no remote counterpart; the sibling
+        # tracks the corresponding branch ('master'). Resolve it so the target
+        # becomes e.g. 'origin/master' instead of the nonexistent
+        # 'origin/adjusted/master(unlocked)'.
+        branch = repo.get_corresponding_branch(branch) or branch
         remote_branch = "{}/{}".format(remote, branch)
         if repo.commit_exists(remote_branch):
             target = remote_branch

--- a/datalad/tests/test_tests_utils_pytest.py
+++ b/datalad/tests/test_tests_utils_pytest.py
@@ -42,6 +42,7 @@ from _pytest.outcomes import (
 )
 
 from datalad import cfg as dl_cfg
+from datalad.distribution.dataset import Dataset
 from datalad.support import path as op
 from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils_pytest import (
@@ -56,6 +57,7 @@ from datalad.tests.utils_pytest import (
     assert_re_in,
     assert_str_equal,
     assert_true,
+    corresponding_hexsha,
     eq_,
     fs_supports_filename,
     get_most_obscure_supported_name,
@@ -63,6 +65,9 @@ from datalad.tests.utils_pytest import (
     known_failure_githubci_win,
     known_failure_windows,
     local_testrepo_flavors,
+    maybe_adjust_repo,
+    maybe_unadjust_repo,
+    neq_,
     nok_startswith,
     ok_,
     ok_broken_symlink,
@@ -82,6 +87,7 @@ from datalad.tests.utils_pytest import (
     serve_path_via_http,
     signal_timeout,
     skip_if,
+    skip_if_adjusted_branch,
     skip_if_no_module,
     skip_if_no_network,
     skip_if_on_windows,
@@ -771,3 +777,66 @@ def test_signal_timeout_noop_without_sigalrm(monkeypatch):
     # but with SIGALRM removed it must be a pure no-op.
     with signal_timeout(0.001):
         time.sleep(0.05)
+
+
+#
+# Test the adjusted-branch helpers
+#
+
+@with_tempfile(mkdir=True)
+def test_corresponding_hexsha(path=None):
+    ds = Dataset(path).create()
+    maybe_adjust_repo(ds.repo)
+    corr = ds.repo.get_corresponding_branch()
+    old = ds.repo.get_hexsha(corr)
+
+    (ds.pathobj / "new.txt").write_text("NEW")
+    ds.save()
+    new = ds.repo.get_hexsha(corr)
+
+    neq_(old, new)
+    neq_(ds.repo.get_hexsha("HEAD"), new)
+
+    # valid non-HEAD refs that contain "HEAD" in the string
+    ds.repo.call_git(["branch", "myHEAD", new])
+    ds.repo.call_git(["update-ref", "ORIG_HEAD", new])
+
+    eq_(corresponding_hexsha(ds.repo), new)
+    eq_(corresponding_hexsha(ds.repo, corr), new)
+    eq_(corresponding_hexsha(ds.repo, old), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD~"), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD^"), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD@{0}"), new)
+    eq_(corresponding_hexsha(ds.repo, "myHEAD"), new)
+    eq_(corresponding_hexsha(ds.repo, "ORIG_HEAD"), new)
+
+    for bogus in ("bogus", "bogusHEAD", "HEAD~99"):
+        assert_raises(ValueError, corresponding_hexsha, ds.repo, bogus)
+
+
+@skip_if_adjusted_branch
+@with_tempfile(mkdir=True)
+def test_maybe_unadjust_repo_noop(path=None):
+    repo = Dataset(path).create().repo
+    branch, hexsha = repo.get_active_branch(), repo.get_hexsha("HEAD")
+    maybe_unadjust_repo(repo)
+    eq_(repo.get_active_branch(), branch)
+    eq_(repo.get_hexsha("HEAD"), hexsha)
+
+
+@with_tempfile(mkdir=True)
+def test_maybe_unadjust_repo(path=None):
+    ds = Dataset(path).create()
+    maybe_adjust_repo(ds.repo)
+    corr = ds.repo.get_corresponding_branch()
+    corr_hexsha = ds.repo.get_hexsha(corr)
+
+    maybe_unadjust_repo(ds.repo)
+    assert_false(ds.repo.is_managed_branch())
+    eq_(ds.repo.get_active_branch(), corr)
+    eq_(ds.repo.get_hexsha("HEAD"), corr_hexsha)
+
+    # idempotent: a second call is the no-op case
+    maybe_unadjust_repo(ds.repo)
+    eq_(ds.repo.get_active_branch(), corr)
+    eq_(ds.repo.get_hexsha("HEAD"), corr_hexsha)

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1952,6 +1952,47 @@ def maybe_adjust_repo(repo):
         repo.adjust()
 
 
+def maybe_unadjust_repo(repo):
+    """Check out `repo`'s *corresponding* branch (the real history beneath
+    the adjusting commit), the inverse of `maybe_adjust_repo`.
+
+    Call this function before you need to modify the commit history of a source/
+    sibling repo that has been created on a crippled FS (e.g. Windows CI).
+    A crippled FS forces every repo onto the adjusted branch. A plain
+    ``git reset --hard`` must land on the corresponding branch (not the adjusted
+    view). On a repo that is not adjusted it is a no-op.
+
+    Caveats:
+
+    - only faithful for asserting SHA-identity after a history-rewrite. If you
+      try to assert content-identity, you'll need to materialize the content first
+      via e.g. ``git checkout -- .``.
+
+    - only plain ``git`` keeps the repo unadjusted. DataLad's ``save``, ``update``
+      and ``push`` run ``git annex sync`` internally, which re-adjusts the branch
+      on a crippled filesystem.
+    """
+    if repo.is_managed_branch():
+        corr_branch = repo.get_corresponding_branch()
+        adjusted = repo.get_active_branch()
+        repo.call_git(["checkout", corr_branch])
+        repo.call_git(["branch", "-D", adjusted])
+
+
+def corresponding_hexsha(repo, ref="HEAD"):
+    """Hexsha of ``ref``, read from the corresponding branch when adjusted.
+
+    A plain ``get_hexsha(HEAD)`` on an adjusted repo returns the SHA of the git-annex
+    "adjusting" commit which is just the view. To read the SHA of the real history,
+    HEAD-relative refs need to be resolved against the corresponding branch instead.
+    On a normal branch it is a plain ``get_hexsha(ref)``.
+    """
+    if (corr := repo.get_corresponding_branch()) and (
+            ref == "HEAD" or ref.startswith(("HEAD~", "HEAD^", "HEAD@"))):
+        ref = corr + ref[len("HEAD"):]
+    return repo.get_hexsha(ref)
+
+
 @lru_cache()
 @with_tempfile
 @with_tempfile


### PR DESCRIPTION
Closes #7772. Stacked on #7880 — please review/merge that one first; its commits show in this PR until it lands.

On an adjusted branch (Windows / crippled filesystem) a stale or leftover `synced/<branch>` ref is merged back by the next `git annex sync` (run internally by `save`/`push`), resurrecting commits the user intentionally discarded ("zombie commits"). Two code paths leave one behind:

- `update --how=reset` reset the corresponding branch but left `synced/<branch>` at the pre-reset tip.
- `update --how=merge` created a `synced/<branch>` and never removed it.

**Fix:**

- `_annex_reset_target`: force-point `synced/<branch>` at the reset target.
- `_annex_sync`: delete the `synced/<branch>` it created, matching `AnnexRepo.localsync`'s hygiene.

**Tests:** `test_update_reset_adjusted_resets_synced` (plus no-resurrection across `save` and `push`), `test_update_merge_adjusted_no_leftover_synced`, and `test_update_reset_dirty` un-skipped on adjusted branches.
