### PR TITLE
NF: new reset command for correct reset on adjusted branches and reset across a dataset hierarchy

### DIFF
--- a/changelog.d/20260630_reset_command.md
+++ b/changelog.d/20260630_reset_command.md
@@ -1,0 +1,13 @@
+### 🚀 Enhancements and New Features
+
+- New command `datalad reset`: discard local divergence and set a dataset
+  (optionally a whole hierarchy) to a target revision, like `git reset --hard`
+  but correct on git-annex *adjusted* branches (the default on Windows /
+  crippled filesystems). A plain `git reset` there operates on the disposable
+  adjusted *view* and leaves the real history untouched, so discarded commits
+  can be resurrected by the next sync; `datalad reset` instead resets the
+  corresponding branch, reconciles git-annex's `synced/<branch>` ref, and
+  regenerates the adjusted view. Supports `--recursive` (each dataset resolves
+  the target locally) and `--follow parentds` (subdatasets reset to the
+  revisions the superdataset records). Addresses part of
+  [#7872](https://github.com/datalad/datalad/issues/7872).

--- a/changelog.d/adjusted_merge_synced.md
+++ b/changelog.d/adjusted_merge_synced.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- `update --how=merge` on an adjusted branch now removes the `synced/<branch>`
+  ref it creates (matching `AnnexRepo.localsync`), so a later `git annex sync`
+  cannot merge the zombie back and resurrect discarded commits.
+  Re [#7772](https://github.com/datalad/datalad/issues/7772).
+  (by [@just-meng](https://github.com/just-meng))

--- a/changelog.d/adjusted_reset_synced.md
+++ b/changelog.d/adjusted_reset_synced.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- `update --how=reset` on an adjusted branch now reconciles git-annex's
+  `synced/<branch>` ref, so a discarded commit is not resurrected by the next
+  `git annex sync` (run internally by `save`/`push`).
+  Re [#7772](https://github.com/datalad/datalad/issues/7772).
+  (by [@just-meng](https://github.com/just-meng))

--- a/changelog.d/adjusted_update_target.md
+++ b/changelog.d/adjusted_update_target.md
@@ -1,0 +1,9 @@
+### 🐛 Bug Fixes
+
+- `update --how=reset` (and `--how=merge`) now resolves the corresponding branch
+  when determining the update target on adjusted branches (Windows / crippled
+  filesystems). Previously the adjusted branch name was used to build a
+  nonexistent `<remote>/adjusted/...` ref, so the update aborted with
+  "Could not determine update target".
+  Fixes [#7873](https://github.com/datalad/datalad/issues/7873).
+  (by [@just-meng](https://github.com/just-meng))

--- a/datalad/distribution/reset.py
+++ b/datalad/distribution/reset.py
@@ -1,0 +1,96 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""High-level interface for resetting a dataset to a revision."""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+
+from datalad.consts import ADJUSTED_BRANCH_EXPR
+from datalad.distribution.utils import _try_command
+
+lgr = logging.getLogger('datalad.distribution.reset')
+
+
+def _get_adjust_mode(branch_name):
+    """Extract the adjustment mode from an adjusted branch name.
+
+    E.g., 'adjusted/master(unlocked)' -> '--unlock'
+    """
+    match = ADJUSTED_BRANCH_EXPR.match(branch_name or '')
+    if not match:
+        # Default to unlocked mode as it is the most common adjustment,
+        # especially on crippled filesystems where unlocked behavior is expected.
+        return '--unlock'
+    mode = match.group('mode')
+    mode_to_option = {
+        'unlocked': '--unlock',
+        'locked': '--lock',
+        'fix': '--fix',
+        'fixed': '--fix',
+        'hidemissing': '--hide-missing',
+    }
+    return mode_to_option.get(mode, '--unlock')
+
+
+def _annex_reset_target(repo, _remote, target, opts=None):
+    """Reset an adjusted branch to a specific target revision.
+
+    Performs a hard reset on the corresponding branch, reconciles git-annex's
+    ``synced/<branch>`` ref, and re-adjusts the branch to maintain the adjusted
+    state.
+
+    This is a *pure* reset helper: it always discards (like ``git reset
+    --hard``) and does not inspect the working tree, so ``datalad
+    reset`` can reuse it.  Its only caller here, ``update --how=reset``,
+    enforces its stricter refuse-if-dirty contract before delegating.
+    """
+    active_branch = repo.get_active_branch()
+    corr_branch = repo.get_corresponding_branch(active_branch)
+    adjust_mode = _get_adjust_mode(active_branch)
+
+    def do_reset():
+        # Checkout the corresponding branch, force-discarding any dirty tree
+        # (git-parity for `datalad reset`; a no-op for `update`, which refuses
+        # a dirty tree before reaching here).
+        repo.call_git(['checkout', '--force', corr_branch])
+        try:
+            # Reset to target
+            repo.call_git(['reset', '--hard', target])
+            # Also reset synced/<branch> so git-annex-sync won't
+            # resurrect the discarded commits (#7772).
+            synced_branch = 'synced/{}'.format(corr_branch)
+            if synced_branch in repo.get_branches():
+                repo.call_git(['branch', '-f', synced_branch, corr_branch])
+            # Re-adjust with --force to overwrite existing adjusted branch
+            repo.call_annex(['adjust', adjust_mode, '--force'])
+        except Exception:
+            # Try to restore the adjusted branch so the repo isn't stranded
+            # on the corresponding branch
+            try:
+                repo.call_annex(['adjust', adjust_mode, '--force'])
+            except Exception:
+                lgr.debug(
+                    "Failed to restore adjusted branch %s after "
+                    "failed reset", active_branch, exc_info=True)
+            raise
+
+    yield _try_command(
+        {"action": "update.reset", "message": ("Reset to %s", target)},
+        do_reset)
+
+
+def _reset_hard(repo, _, target, opts=None):
+    """Pure hard-reset helper (see `_annex_reset_target` for the dirty-tree
+    contract).  Called by ``update --how=reset``; pure so ``datalad reset`` can
+    reuse it."""
+    yield _try_command(
+        {"action": "update.reset", "message": ("Reset to %s", target)},
+        repo.call_git,
+        ["reset", "--hard", target])

--- a/datalad/distribution/reset.py
+++ b/datalad/distribution/reset.py
@@ -13,7 +13,35 @@ __docformat__ = 'restructuredtext'
 import logging
 
 from datalad.consts import ADJUSTED_BRANCH_EXPR
-from datalad.distribution.utils import _try_command
+from datalad.distribution.utils import (
+    _try_command,
+    corresponding_hexsha,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
+from datalad.interface.common_opts import (
+    recursion_flag,
+    recursion_limit,
+)
+from datalad.interface.results import get_status_dict
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.constraints import (
+    EnsureChoice,
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.exceptions import CommandError
+from datalad.support.param import Parameter
+
+from .dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
 
 lgr = logging.getLogger('datalad.distribution.reset')
 
@@ -40,50 +68,100 @@ def _get_adjust_mode(branch_name):
 
 
 def _annex_reset_target(repo, _remote, target, opts=None):
-    """Reset an adjusted branch to a specific target revision.
+    """Hard-reset an adjusted branch to TARGET (pure: always discards).
 
-    Performs a hard reset on the corresponding branch, reconciles git-annex's
-    ``synced/<branch>`` ref, and re-adjusts the branch to maintain the adjusted
-    state.
+    Dispatches on whether TARGET moves history:
 
-    This is a *pure* reset helper: it always discards (like ``git reset
-    --hard``) and does not inspect the working tree, so ``datalad
-    reset`` can reuse it.  Its only caller here, ``update --how=reset``,
-    enforces its stricter refuse-if-dirty contract before delegating.
+    - it does not (e.g. plain ``HEAD``): reset the adjusted *view* only -- the
+      corresponding branch and ``synced/`` are left untouched
+      (`_reset_adjusted_view`).
+    - it does (a SHA, ``HEAD~N``, a sibling ref): reset the *corresponding*
+      branch, reconcile git-annex's ``synced/<branch>`` ref, and regenerate the
+      adjusted view (`_reset_corresponding_branch`).
     """
+    strategy = (_reset_adjusted_view if _is_current_head(repo, target)
+                else _reset_corresponding_branch)
+    yield _try_command(
+        {"action": "update.reset", "message": ("Reset to %s", target)},
+        strategy, repo, target)
+
+
+def _is_current_head(repo, target):
+    """Whether TARGET denotes the current real-history HEAD -- so resetting to
+    it moves no real history and can take the cheap `_reset_adjusted_view` path.
+
+    Compared *corr-aware*: on an adjusted branch the literal HEAD is the
+    adjusting commit, one above the real-history tip (the corresponding-branch
+    tip). A user typically means that real tip -- via plain ``HEAD``, the SHA
+    read from ``git log`` (= corr-tip), or a sibling ref already at it -- and
+    all of those should reset the view in place. The literal-HEAD check also
+    accepts the adjusting commit's own SHA (the top of ``git log`` on the
+    adjusted branch), so pasting it does not fall through to the
+    corresponding-branch reset (which would stamp it onto real history).
+    Relative refs (``HEAD~N`` -> a real move) and a diverged sibling resolve
+    off the tip, so they return False.
+    """
+    try:
+        # literal adjusted HEAD (covers `target` == the adjusting-commit SHA)
+        if repo.get_hexsha(target) == repo.get_hexsha("HEAD"):
+            return True
+        # corr-aware: does TARGET resolve to the corresponding-branch tip?
+        return corresponding_hexsha(repo, target) == corresponding_hexsha(repo)
+    except ValueError:
+        return False
+
+
+def _reset_adjusted_view(repo, target):
+    """Hard-reset the adjusted view in place -- TARGET moves no real history.
+
+    Resets to the adjusted HEAD (the adjusting commit), NOT to ``target``:
+    ``target`` may be the corresponding-branch tip or a sibling SHA, and a bare
+    ``git reset --hard <corr-tip>`` on the adjusted branch would strand the view
+    on a non-adjusted commit. The view stays put; we only discard the working
+    tree and re-materialise.
+
+    A bare reset writes back pointer files but does not smudge content into
+    the worktree, leaving unlocked files unmaterialised (content present, but
+    the file holds the pointer). Re-checkout re-runs the smudge filter to
+    materialise them -- crucially without a re-adjust, so it works even under
+    the crippled-fs *simulation*, where `git annex fix`/`adjust` leave the
+    pointer in place (or abort on retained content).
+    """
+    repo.call_git(["reset", "--hard", "HEAD"])
+    repo.call_git(["checkout", "--", "."])
+
+
+def _reset_corresponding_branch(repo, target):
+    """Hard-reset the corresponding branch to TARGET, reconcile ``synced/`` and
+    regenerate the adjusted view -- TARGET moves history."""
     active_branch = repo.get_active_branch()
     corr_branch = repo.get_corresponding_branch(active_branch)
     adjust_mode = _get_adjust_mode(active_branch)
+    synced_branch = "synced/{}".format(corr_branch)
 
-    def do_reset():
-        # Checkout the corresponding branch, force-discarding any dirty tree
-        # (git-parity for `datalad reset`; a no-op for `update`, which refuses
-        # a dirty tree before reaching here).
-        repo.call_git(['checkout', '--force', corr_branch])
+    # Check out the corresponding branch, force-discarding any dirty tree
+    # (git-parity for ``datalad reset``; a no-op for ``update``, which refuses a
+    # dirty tree before reaching here).
+    repo.call_git(["checkout", "--force", corr_branch])
+    try:
+        repo.call_git(["reset", "--hard", target])
+        # Reconcile synced/<corr> so a discarded commit cannot be resurrected by
+        # the next sync/save (gh-7772): it records the last-synced state, and
+        # left at the old tip the next sync would merge it back in.
+        if synced_branch in repo.get_branches():
+            repo.call_git(["branch", "-f", synced_branch, corr_branch])
+        # regenerate the adjusted view on top of the reset corresponding branch
+        repo.call_annex(["adjust", adjust_mode, "--force"])
+    except Exception:
+        # never strand the repo on the corresponding branch: restore the
+        # adjusted view (best effort -- don't let a rescue failure mask the
+        # original error)
         try:
-            # Reset to target
-            repo.call_git(['reset', '--hard', target])
-            # Also reset synced/<branch> so git-annex-sync won't
-            # resurrect the discarded commits (#7772).
-            synced_branch = 'synced/{}'.format(corr_branch)
-            if synced_branch in repo.get_branches():
-                repo.call_git(['branch', '-f', synced_branch, corr_branch])
-            # Re-adjust with --force to overwrite existing adjusted branch
-            repo.call_annex(['adjust', adjust_mode, '--force'])
+            repo.call_annex(["adjust", adjust_mode, "--force"])
         except Exception:
-            # Try to restore the adjusted branch so the repo isn't stranded
-            # on the corresponding branch
-            try:
-                repo.call_annex(['adjust', adjust_mode, '--force'])
-            except Exception:
-                lgr.debug(
-                    "Failed to restore adjusted branch %s after "
-                    "failed reset", active_branch, exc_info=True)
-            raise
-
-    yield _try_command(
-        {"action": "update.reset", "message": ("Reset to %s", target)},
-        do_reset)
+            lgr.debug("Failed to restore adjusted branch %s after failed reset",
+                      active_branch, exc_info=True)
+        raise
 
 
 def _reset_hard(repo, _, target, opts=None):
@@ -94,3 +172,203 @@ def _reset_hard(repo, _, target, opts=None):
         {"action": "update.reset", "message": ("Reset to %s", target)},
         repo.call_git,
         ["reset", "--hard", target])
+
+
+def _is_history_coordinate(repo, target):
+    """Whether TARGET is a parent-history coordinate.
+
+    A raw commit SHA or a relative ref (``HEAD~N``, ``...^``) is a coordinate in
+    the parent's history with no per-subdataset meaning; a symbolic ref
+    (branch / tag / remote-tracking ref) resolves locally in every dataset.
+    Plain ``HEAD`` (no offset) is exempt.
+    """
+    if target in (None, "HEAD"):
+        return False
+    if "~" in target or "^" in target:
+        return True
+    # "SHA-like" := resolves to a commit but has no symbolic-full-name. A
+    # branch/tag/remote-tracking ref has one; a raw SHA does not. Robust against
+    # a branch literally named like a hex string.
+    try:
+        sym = repo.call_git(
+            ["rev-parse", "--symbolic-full-name", target],
+            read_only=True).strip()
+    except CommandError:
+        # Not resolvable as a ref expression -- not this guard's concern; the
+        # engine reports the error per dataset.
+        return False
+    return not sym
+
+
+def _reset_ds(ds, target):
+    """Reset a single dataset to TARGET, dispatching on branch type.
+
+    Yields the raw engine records (with ``status``/``message``). The shared
+    engine is pure -- it always discards like ``git reset --hard`` (discard
+    tracked, keep untracked); reset never refuses a dirty tree.
+    """
+    repo = ds.repo
+    adjusted = isinstance(repo, AnnexRepo) and repo.is_managed_branch()
+    reset_fn = _annex_reset_target if adjusted else _reset_hard
+    yield from reset_fn(repo, None, target)
+
+
+@build_doc
+class Reset(Interface):
+    """Reset a dataset to a target revision, discarding local divergence.
+
+    Like ``git reset --hard``, but correct on git-annex *adjusted* branches (the
+    default on Windows / crippled filesystems).  A plain ``git reset`` there
+    operates on the disposable adjusted *view* rather than the corresponding
+    branch, so the real history is left untouched and the discarded commits can
+    be resurrected by the next `git annex sync`. This command instead resets the
+    corresponding branch, reconciles git-annex's ``synced/<branch>`` ref, and
+    regenerates the adjusted view.
+
+    On a normal branch this runs ``git reset --hard <target>``.
+
+    A dirty working tree is handled like ``git reset --hard``: tracked
+    modifications are discarded, untracked files are kept (this is not
+    ``git clean``).
+
+    Annexed content is not deleted: ``git reset`` never touches the annex object
+    store, so content stays recoverable until ``git annex unused``/gc.
+
+    With ``--recursive``, every dataset in the hierarchy is reset.  By default
+    each dataset resets to ``TARGET`` resolved in its own repository (a local
+    operation).  With ``--follow=parentds`` the superdataset is reset to
+    ``TARGET`` and each subdataset is reset to the revision the (reset)
+    superdataset records for it, reconciling the hierarchy to the super's pins.
+    """
+
+    _examples_ = [
+        dict(text="Reset the current branch to its HEAD, discarding "
+                  "modifications of tracked files",
+             code_py="reset()",
+             code_cmd="datalad reset"),
+        dict(text="Reset the current branch to a sibling's state, discarding "
+                  "local commits",
+             code_py="reset(target='sibling/branch')",
+             code_cmd="datalad reset <sibling/branch>"),
+        dict(text="Reset the current branch to a specific commit",
+             code_py="reset(target='commit')",
+             code_cmd="datalad reset <commit>"),
+        dict(text="Reset a whole hierarchy to the revisions the superdataset "
+                  "records",
+             code_py="reset(recursive=True, follow='parentds')",
+             code_cmd="datalad reset -r --follow parentds"),
+    ]
+
+    _params_ = dict(
+        target=Parameter(
+            args=("target",),
+            metavar="COMMIT",
+            nargs="?",
+            doc="""revision to reset to: a commit-ish such as a branch, tag,
+            SHA, or a remote-tracking ref like 'origin/main'. Defaults to HEAD.
+            On an adjusted branch the reset is applied to the corresponding
+            branch. A relative ref such as 'HEAD~1' discards exactly that many
+            real commits (also on adjusted branches), but is only supported
+            without recursion (or with [CMD: --follow parentds CMD][PY:
+            follow='parentds' PY]).""",
+            constraints=EnsureStr() | EnsureNone()),
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to reset. If no dataset is given, an
+            attempt is made to identify it based on the current working
+            directory.""",
+            constraints=EnsureDataset() | EnsureNone()),
+        follow=Parameter(
+            args=("--follow",),
+            constraints=EnsureChoice("parentds") | EnsureNone(),
+            doc="""how to interpret TARGET for subdatasets (only meaningful with
+            [CMD: --recursive CMD][PY: recursive=True PY]). By default every
+            dataset resets to TARGET resolved in its own repository. With
+            'parentds' the superdataset is reset to TARGET and each subdataset
+            is reset to the revision the (reset) superdataset records for it."""),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+    )
+
+    @staticmethod
+    @datasetmethod(name='reset')
+    @eval_results
+    def __call__(
+            target=None,
+            *,
+            dataset=None,
+            follow=None,
+            recursive=False,
+            recursion_limit=None,
+    ):
+        # The classic Interface only enforces constraints via the command line;
+        # validate explicitly so the Python API rejects bad values too.
+        if follow not in (None, "parentds"):
+            raise ValueError(
+                "follow={!r} is not valid; only 'parentds' is supported "
+                "(reset is a local operation -- there is no 'sibling')".format(
+                    follow))
+
+        refds = require_dataset(dataset, check_installed=True, purpose='reset')
+        res = dict(action="reset", refds=refds.path, logger=lgr)
+        target = target or "HEAD"
+
+        def emit(ds, rec):
+            return get_status_dict(
+                ds=ds, status=rec.get("status"),
+                message=rec.get("message"), **res)
+
+        # NOTE/open-question: the shared `_try_command` contract stringifies a
+        # CommandError into `message` and does not set `exception`, so error
+        # records read as a nested "CommandError(CommandError: ...)". Worth
+        # upgrading that shared contract (benefits `update` too) rather than
+        # papering over it here.
+
+        if not recursive:
+            for rec in _reset_ds(refds, target):
+                yield emit(refds, rec)
+            return
+
+        # --- recursive ---
+        # A parent-history coordinate (raw SHA or relative ref) has no
+        # per-subdataset meaning under the default each-dataset-resolves-locally
+        # mode; require an explicit --follow=parentds.
+        if follow != "parentds" and _is_history_coordinate(refds.repo, target):
+            yield get_status_dict(
+                ds=refds, status="impossible",
+                message=(
+                    "%r is a parent-history coordinate with no per-subdataset "
+                    "meaning; pass --follow=parentds to reset subdatasets to "
+                    "the revisions the superdataset records", target),
+                **res)
+            return
+
+        if follow == "parentds":
+            # super first, then descend resetting each subds to the revision
+            # its (reset) parent records.
+            yield from Reset._reset_tree(
+                refds, target, recursion_limit, emit)
+        else:
+            # default or `--follow=None`: every dataset resets to TARGET resolved in its own repo.
+            datasets = [refds] + refds.subdatasets(
+                recursive=True, recursion_limit=recursion_limit,
+                state='present', result_xfm='datasets',
+                result_renderer='disabled')
+            for ds in datasets:
+                for rec in _reset_ds(ds, target):
+                    yield emit(ds, rec)
+
+    @staticmethod
+    def _reset_tree(ds, target, recursion_limit, emit):
+        """Recursively reset DS to TARGET, then each subdataset to the revision
+        DS records for it (--follow=parentds). Parent before children."""
+        for rec in _reset_ds(ds, target):
+            yield emit(ds, rec)
+        if recursion_limit is not None and recursion_limit <= 0:
+            return
+        sub_limit = (recursion_limit - 1) \
+            if isinstance(recursion_limit, int) else None
+        for sub in ds.subdatasets(recursive=False, state='present',
+                                  result_renderer='disabled'):
+            yield from Reset._reset_tree(
+                Dataset(sub['path']), sub['gitshasum'], sub_limit, emit)

--- a/datalad/distribution/tests/test_reset.py
+++ b/datalad/distribution/tests/test_reset.py
@@ -1,0 +1,851 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+"""Tests for `datalad reset` (adjusted-branch-safe hard reset).
+
+Behavior is parametrized over the ``fs_mode`` fixture, which runs every test
+across the three natural (filesystem, branch) modes -- ``normal``, ``adjusted``
+and ``crippled`` (see the fixture's docstring). The ``crippled`` mode is
+*simulated* on a normal filesystem, so a single Linux run exercises the
+adjusted-branch-on-crippled-fs code path rather than leaving it to Windows CI
+alone. The only per-leg skip is the genuinely impossible combination -- a normal
+branch on a crippled filesystem (see `_skip_normal_leg_on_crippled`).
+
+Histories are read with ``corresponding_hexsha`` (corr-aware) and compared
+relationally, never against a hardcoded value.
+
+The command's design and intended behavior are documented in
+``docs/source/design/reset.rst``.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from datalad.api import install
+from datalad.distribution.dataset import Dataset
+from datalad.distribution.reset import _is_current_head
+from datalad.distribution.utils import corresponding_hexsha
+from datalad.tests.utils_pytest import (
+    assert_false,
+    assert_in_results,
+    assert_result_count,
+    eq_,
+    has_symlink_capability,
+    maybe_adjust_repo,
+    maybe_unadjust_repo,
+    neq_,
+    ok_,
+    skip_if_adjusted_branch,
+    slow,
+    with_tempfile,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers: adjusted branch
+# ---------------------------------------------------------------------------
+FS_MODES = ("normal", "adjusted", "crippled")
+
+
+@pytest.fixture(params=FS_MODES)
+def fs_mode(request, monkeypatch):
+    """Parametrize a test over three (filesystem, branch) modes: ``normal``,
+    ``adjusted`` and ``crippled``.
+
+    This fixture's own job is deliberately small: it yields the mode name and,
+    for the ``crippled`` mode, sets ``annex.crippledfilesystem=true`` in git's
+    config environment. That must happen here -- before any ``create()`` /
+    ``clone()`` -- because git-annex decides crippledness at init time; with it
+    set, every repository the test creates comes up on an adjusted branch, as a
+    real crippled filesystem (e.g. Windows) forces.
+
+    The other two modes are realised *after* a repo exists, by the dataset
+    helpers rather than by this fixture:
+
+    - ``adjusted`` -- `_adjust_for_mode` runs ``git annex adjust`` on the new
+      repo, simulating an adjusted branch on a normal filesystem.
+    - ``normal``   -- nothing is adjusted; where a normal branch cannot exist (a
+      crippled filesystem) `_skip_normal_leg_on_crippled` skips the leg.
+    """
+    mode = request.param
+    if mode == "crippled":
+        # git reads GIT_CONFIG_KEY_<n>/VALUE_<n> on every invocation; compose
+        # with any pre-existing GIT_CONFIG_* entries rather than clobbering them.
+        n = int(os.environ.get("GIT_CONFIG_COUNT", "0"))
+        monkeypatch.setenv("GIT_CONFIG_KEY_{}".format(n), "annex.crippledfilesystem")
+        monkeypatch.setenv("GIT_CONFIG_VALUE_{}".format(n), "true")
+        monkeypatch.setenv("GIT_CONFIG_COUNT", str(n + 1))
+    return mode
+
+
+def _xfail_simulated_crippled(request, repo):
+    """xfail a test *only* when it runs against a SIMULATED crippled filesystem.
+
+    We fake a crippled fs by setting ``annex.crippledfilesystem=true`` (see the
+    `fs_mode` fixture). That is faithful enough to force adjusted branches, but
+    NOT to reproduce a history-moving reset whose target retains annexed
+    content: the simulation runs on a symlink-*capable* filesystem, so the
+    corresponding branch's locked symlink lands in the worktree as a phantom
+    modification that a genuinely symlink-less filesystem never produces, and
+    `git annex adjust`'s checkout then aborts
+    (see `test_reset_keeps_annexed_content_in_target`).
+
+    This is an artefact of the simulation, NOT a bug in `_annex_reset_target`:
+    on a genuinely symlink-less filesystem these legs PASS (verified on real
+    Windows). Marking xfail(strict=False) keeps the leg visible on Linux without
+    contorting production code to satisfy the simulation.
+
+    Why no setting can make the simulation faithful: the sim-vs-real-Windows
+    divergence traces, in git-annex's source, to a *compile-time*
+    ``#ifdef mingw32_HOST_OS`` on its inode-sentinel / restage path
+    (``Annex/InodeSentinal.hs`` ``getTSDelta``), not to any runtime config or
+    filesystem probe. A Linux-built git-annex cannot run the Windows code paths,
+    so no git/git-annex setting bridges the gap (and even a genuinely
+    symlink-less filesystem -- e.g. a vfat loopback mount -- would likely not
+    bridge it, since it would still be the Linux binary). Real Windows is the
+    only faithful check, which is exactly what this xfail defers to.
+    """
+    if repo.is_crippled_fs() and has_symlink_capability():
+        request.applymarker(pytest.mark.xfail(
+            strict=False,
+            reason="crippled-FS simulation on a symlink-capable filesystem "
+                   "cannot reproduce reset-to-retained-annex; only real Windows "
+                   "CI can validate this scenario"))
+
+
+def _skip_normal_leg_on_crippled(repo, mode):
+    """Honestly skip the ``normal`` leg where a normal branch cannot exist.
+
+    A crippled filesystem (e.g. real Windows) forces every repo onto an adjusted
+    branch, so ``create()``/``clone()`` come up managed no matter what -- there
+    is no normal-branch behaviour to test, and running the leg anyway would just
+    re-exercise the adjusted path under a misleading ``normal`` label. On a
+    normal filesystem this never triggers (the repo is genuinely unmanaged).
+
+    Called from the three constructors that build the *dataset-under-test*
+    (`_ds`, `_ds_with_subds`, `_clone`) -- never from the source helpers
+    (`_src_with_base_commit`, `_src_with_one_subds`), whose branch state is
+    irrelevant (it is only ever read corr-aware).
+
+    Unlike ``@skip_if_adjusted_branch``, which skips an *entire* test wherever
+    the filesystem forces adjusted branches -- hiding that behaviour from
+    crippled-FS CI -- this skips only the one impossible leg and keeps the
+    ``adjusted``/``crippled`` legs running.
+    """
+    if mode == "normal" and repo.is_managed_branch():
+        pytest.skip("normal branch N/A on a crippled filesystem")
+
+
+def _adjust_for_mode(ds, mode):
+    """Put DS on an adjusted branch when the mode needs a *simulated* one --
+    including any subdatasets, children before the parent, to dodge the
+    git-annex submodule/adjust crash fixed in 7.20191024. In ``crippled`` mode
+    the filesystem already forced it; in ``normal`` mode the repo stays on its
+    normal branch.
+    """
+    if mode != "adjusted":
+        return
+    for sub in ds.subdatasets(recursive=True, result_xfm="datasets",
+                              result_renderer="disabled"):
+        maybe_adjust_repo(sub.repo)
+    maybe_adjust_repo(ds.repo)
+
+
+def _is_adjusted_mode(mode):
+    """True for the modes whose repos live on an adjusted (managed) branch."""
+    return mode in ("adjusted", "crippled")
+
+
+def _corr(repo):
+    """The underlying real branch name regardless of whether it is adjusted."""
+    return repo.get_corresponding_branch() or repo.get_active_branch()
+
+
+def _assert_adjusted(repo, fs_mode):
+    """On an adjusted leg the repo must still be on its adjusted
+    branch after a reset (the re-adjust did not strand it on the corresponding
+    branch). A no-op on the normal leg.
+    """
+    if _is_adjusted_mode(fs_mode):
+        ok_(repo.is_managed_branch())
+
+
+def _assert_reset_ok(res, repo, fs_mode, target_sha):
+    """The three universal invariants of a successful reset (see section B):
+    the call is ok, the corresponding branch tip is at the target, and -- on an
+    adjusted leg -- the repo is still adjusted (`_assert_adjusted`). Scenario-
+    specific assertions (e.g. a discarded file is gone) stay inline in the test.
+    """
+    assert_in_results(res, action="reset", status="ok")
+    eq_(corresponding_hexsha(repo), target_sha)
+    _assert_adjusted(repo, fs_mode)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers: dataset
+# ---------------------------------------------------------------------------
+
+# Construct dataset under control
+def _ds(path, mode, name="ds"):
+    """A single dataset in the given fs/branch mode."""
+    ds = Dataset(path / name).create()
+    _adjust_for_mode(ds, mode)
+    _skip_normal_leg_on_crippled(ds.repo, mode)
+    return ds
+
+
+def _ds_with_subds(path, mode, name="ds"):
+    """A dataset under control with one subdataset `sub`, created directly
+    (no clone) -- the recursive analogue of `_ds`.
+
+    Use this whenever a recursive test only needs a super+sub to operate on
+    locally. Only tests that resolve a target against a *sibling* clone a source
+    (`_src_with_subds` + `_clone(..., recursive=True)`), where the source IS the
+    sibling.
+    """
+    ds = Dataset(path / name).create()
+    ds_sub = ds.create("sub")
+    ds.save()
+    (ds.pathobj / "base.txt").write_text("BASE")
+    (ds_sub.pathobj / "subbase.txt").write_text("BASE")
+    ds.save(recursive=True)
+    _adjust_for_mode(ds, mode)
+    _skip_normal_leg_on_crippled(ds.repo, mode)
+    return ds
+
+
+def _clone(ds_src, path, mode, recursive=False, name="clone"):
+    """Install a clone of DS_SRC (optionally recursive); the source becomes the
+    clone's sibling. For tests that resolve a target against a sibling.
+    """
+    ds_clone = install(source=ds_src.path, path=path / name,
+                       recursive=recursive, result_xfm="datasets")
+    _adjust_for_mode(ds_clone, mode)
+    _skip_normal_leg_on_crippled(ds_clone.repo, mode)
+    return ds_clone
+
+
+# Construct source dataset
+def _src_with_base_commit(path):
+    """A source dataset with one base commit, in whatever branch state the
+    filesystem gives: a normal branch on a normal fs, an adjusted branch on a
+    crippled one (Windows CI).
+
+    Callers must read its history via `corresponding_hexsha`, never plain HEAD.
+    """
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "base.txt").write_text("BASE")
+    ds_src.save("")
+    return ds_src
+
+
+def _src_with_subds(path):
+    """Source superdataset with one subdataset `sub`, saved recursively.
+
+    For recursive tests that resolve a target against a *sibling* (the source
+    becomes the clone's origin, via `_clone(..., recursive=True)`). Tests that
+    only need a local super+sub should use `_ds_with_subds` instead.
+    """
+    ds_src = Dataset(path / "source").create()
+    ds_sub = ds_src.create("sub")
+    ds_src.save()
+
+    (ds_src.pathobj / "base.txt").write_text("BASE")
+    (ds_sub.pathobj / "subbase.txt").write_text("BASE")
+    ds_src.save(recursive=True)
+    return ds_src
+
+
+# Get sibling and subdataset
+def _sibling(repo):
+    # harness-independent: use the repo's actual remote, not DEFAULT_REMOTE
+    return repo.get_remotes()[0]
+
+
+def _subds(ds):
+    return ds.subdatasets(result_xfm="datasets", result_renderer="disabled")[0]
+
+
+# ---------------------------------------------------------------------------
+# A. Contract / guard (non-recursive)
+# ---------------------------------------------------------------------------
+
+@with_tempfile(mkdir=True)
+def test_reset_unsupported_follow_rejected(path=None):
+    """An unsupported `follow` value must yield a clean ValueError, not silently
+    fall through. The `EnsureChoice` constraint only guards the CLI path; this
+    exercises the Python API, where the hand-rolled check in __call__ is the
+    only thing rejecting bad values.
+    """
+    path = Path(path)
+    ds = Dataset(path / "ds").create()
+    with pytest.raises(ValueError):
+        ds.reset(follow="bogus", on_failure="ignore")
+
+
+# ---------------------------------------------------------------------------
+# B. Core hard-reset (non-recursive)
+# ---------------------------------------------------------------------------
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_to_explicit_commit(path=None, *, fs_mode):
+    path = Path(path)
+    ds = _ds(path, fs_mode)
+
+    parent = corresponding_hexsha(ds.repo)
+    (ds.pathobj / "discard.txt").write_text("DISCARD")
+    ds.save()
+    neq_(corresponding_hexsha(ds.repo), parent)
+
+    res = ds.reset(target=parent)
+    _assert_reset_ok(res, ds.repo, fs_mode, parent)
+    assert_false((ds.pathobj / "discard.txt").exists())
+
+
+@slow  # ~10s
+# @skip_if_adjusted_branch  # need a normal source + a deliberately-adjusted clone
+@with_tempfile(mkdir=True)
+def test_is_current_head_routing(path=None, *, fs_mode):
+    """Unit test for the strategy dispatch `_is_current_head`: True exactly when
+    TARGET denotes the current real-history HEAD (reset takes the cheap
+    `_reset_adjusted_view` path), False when real history moves (the
+    corresponding-branch path). `_is_current_head` is only called on adjusted/crippled,
+    and no-op otherwise.
+
+    The comparison is corr-aware: on an adjusted branch the literal HEAD is the
+    adjusting commit, one *above* the real-history tip (the corresponding-branch
+    tip). Resetting to either the literal HEAD or the real-history HEAD should yield
+    the same result.
+
+    Reset-the-view-in-place cases: plain ``HEAD``, the corr-tip SHA (the
+    "real HEAD" a user copies out of ``git log``), the adjusting-commit SHA (the
+    top of ``git log``), and a sibling ref already at the corr-tip.
+
+    Real-history moves: ``HEAD~1`` (drops a real commit), an older SHA, and a diverged
+    sibling. (Unresolvable targets are rejected before this function, so they
+    are not exercised here.)
+    """
+    if fs_mode == "normal":
+        pytest.skip("branch needs to be adjusted")
+
+    path = Path(path)
+    ds_src = _src_with_base_commit(path)
+    # on crippled FS, also source ds is forced into adjusted mode
+    # unadjust so that the call targets the corresponding branch underneath
+    maybe_unadjust_repo(ds_src.repo)
+
+    ds = _clone(ds_src, path, fs_mode)
+
+    corr_tip = corresponding_hexsha(ds.repo)          # real-history HEAD (base commit)
+    view_tip = ds.repo.get_hexsha("HEAD")             # adjusting commit (top of git log)
+    older = corresponding_hexsha(ds.repo, "HEAD~1")   # one real commit back (dataset creation)
+    neq_(corr_tip, view_tip)  # the dispatch only bites because HEAD sits above corr-tip; does not apply to normal
+
+    # no real move -> view reset
+    ok_(_is_current_head(ds.repo, "HEAD"))
+    ok_(_is_current_head(ds.repo, corr_tip))                # corr-tip SHA
+    ok_(_is_current_head(ds.repo, view_tip))                # adjusting-commit SHA
+    ok_(_is_current_head(ds.repo, f"{_sibling(ds.repo)}/{_corr(ds.repo)}"))  # sibling already at corr-tip
+
+    # real move -> corresponding-branch reset
+    assert_false(_is_current_head(ds.repo, "HEAD~1"))       # drops a real commit
+    assert_false(_is_current_head(ds.repo, older))          # non-corr-tip SHA
+
+    # diverged sibling: advance the source, fetch -> remote ref no longer at corr-tip
+    (ds_src.pathobj / "advance_src.txt").write_text("ADVANCED")
+    ds_src.save()
+    ds.repo.fetch(remote=_sibling(ds.repo))
+    assert_false(_is_current_head(ds.repo, f"{_sibling(ds.repo)}/{_corr(ds.repo)}"))
+
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_annexed_content_recoverable(path=None, *, fs_mode):
+    """git reset never touches .git/annex/objects -> content survives (parity)."""
+    path = Path(path)
+    ds = _ds(path, fs_mode)
+
+    parent = corresponding_hexsha(ds.repo)
+    (ds.pathobj / "data.bin").write_text("PRECIOUS")
+    ds.save()
+    # ensure file is annexed -> has key and content
+    key = ds.repo.get_file_annexinfo("data.bin").get("key")
+    ok_(key)  # fail loudly, not a silent skip
+    ok_(ds.repo.file_has_content("data.bin"))
+
+    res = ds.reset(target=parent)
+    _assert_reset_ok(res, ds.repo, fs_mode, parent)
+    assert_false((ds.pathobj / "data.bin").exists())  # removed file from worktree
+    ok_(ds.repo.get_contentlocation(key))             # left content intact in annex store
+
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_keeps_annexed_content_in_target(path=None, *, fs_mode, request):
+    """The raison d'etre of `datalad reset` on an adjusted branch: a history-moving
+    reset whose TARGET still RETAINS annexed content (the common case -- you
+    reset to keep some history, not to wipe it). The corresponding branch
+    *records* such a file as locked (a git mode-120000 symlink entry); a crippled
+    fs cannot render a real symlink, so it materialises that locked entry as a
+    stand-in regular file holding the object path, while the adjusted worktree
+    carries a copy of the actual unlocked content. The re-adjust must bridge that
+    locked-record / unlocked-worktree transition without choking.
+    """
+    path = Path(path)
+    ds = _ds(path, fs_mode)
+    _xfail_simulated_crippled(request, ds.repo)
+
+    (ds.pathobj / "keep.bin").write_text("KEEP")
+    ds.save()
+    keep_sha = corresponding_hexsha(ds.repo)
+    keep_key = ds.repo.get_file_annexinfo("keep.bin").get("key")
+    ok_(keep_key)  # keep.bin is really annexed (else the test has no teeth)
+
+    (ds.pathobj / "discard.bin").write_text("DISCARD")
+    ds.save()
+    neq_(corresponding_hexsha(ds.repo), keep_sha)
+
+    res = ds.reset(target=keep_sha)
+    _assert_reset_ok(res, ds.repo, fs_mode, keep_sha)
+    assert_false((ds.pathobj / "discard.bin").exists())  # discarded file gone
+    ok_(ds.repo.file_has_content("keep.bin"))            # retained file's content in the annex store...
+    eq_((ds.pathobj / "keep.bin").read_text(), "KEEP")   # ...and materialised in the worktree
+
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_to_sibling(path=None, *, fs_mode):
+    path = Path(path)
+    ds_src = _src_with_base_commit(path)
+    ds_clone = _clone(ds_src, path, fs_mode)
+
+    corr = _corr(ds_clone.repo)
+    sibling = _sibling(ds_clone.repo)
+    target = corresponding_hexsha(ds_src.repo)
+
+    (ds_clone.pathobj / "local.txt").write_text("LOCAL")
+    ds_clone.save()
+    neq_(corresponding_hexsha(ds_clone.repo), target)
+
+    res = ds_clone.reset(target=f"{sibling}/{corr}")
+    _assert_reset_ok(res, ds_clone.repo, fs_mode, target)
+    assert_false((ds_clone.pathobj / "local.txt").exists())  # removed local divergence
+
+
+@slow  # ~12s
+@with_tempfile(mkdir=True)
+def test_reset_to_sibling_no_resurrection_or_work_loss(path=None, *, fs_mode):
+    """gh-7772: on an adjusted branch a history-moving reset must reconcile
+    git-annex's ``synced/<corr>`` ref to the target. If it does not, that ref
+    still points at the discarded commit, and the next ``save`` -- which syncs on
+    an adjusted branch -- merges it back. Two things then break, both severe:
+
+    - *resurrection*: the commit the user just discarded comes back.
+    - *work loss* (worse): the commit the user made *after* the reset is dropped
+      in that sync -- real new work silently disappears.
+    """
+    path = Path(path)
+    ds_src = _src_with_base_commit(path)
+    ds_clone = _clone(ds_src, path, fs_mode)
+
+    corr = _corr(ds_clone.repo)
+    sibling = _sibling(ds_clone.repo)
+    target = corresponding_hexsha(ds_src.repo)
+
+    # the commit to discard, marked by a file that lives only here
+    (ds_clone.pathobj / "discard.txt").write_text("DISCARD")
+    ds_clone.save()
+    discard_sha = corresponding_hexsha(ds_clone.repo)
+    neq_(discard_sha, target)
+
+    synced = f"synced/{corr}"
+    if _is_adjusted_mode(fs_mode):
+        # Seed the gh-7772 hazard explicitly: a stale synced/<corr> at the
+        # discarded commit.
+        ds_clone.repo.call_git(["branch", "-f", synced, discard_sha])
+
+    res = ds_clone.reset(target=f"{sibling}/{corr}")
+    _assert_reset_ok(res, ds_clone.repo, fs_mode, target)
+    if _is_adjusted_mode(fs_mode):
+        # direct teeth: reset moved synced/<corr> onto the reset tip, so the next
+        # sync has nothing stale to merge back.
+        eq_(ds_clone.repo.get_hexsha(synced),
+            corresponding_hexsha(ds_clone.repo))
+
+    # genuine new work on top of the reset; this save (a sync on an adjusted
+    # branch) is what would merge a stale synced/<corr> back in.
+    (ds_clone.pathobj / "precious.txt").write_text("PRECIOUS")
+    ds_clone.save()
+
+    # teeth #1 -- no resurrection: the discarded commit is back neither in the
+    # worktree nor in history.
+    assert_false((ds_clone.pathobj / "discard.txt").exists())
+    assert_false(
+        ds_clone.repo.is_ancestor(discard_sha, corresponding_hexsha(ds_clone.repo)))
+    # teeth #2 -- no work loss: the new work survived the sync, with its content.
+    eq_((ds_clone.pathobj / "precious.txt").read_text(), "PRECIOUS")
+
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_nonexistent_target_errors(path=None, *, fs_mode):
+    path = Path(path)
+    ds = _ds(path, fs_mode)
+
+    before = corresponding_hexsha(ds.repo)
+    assert_in_results(
+        ds.reset(target="no-such-ref", on_failure="ignore"),
+        action="reset", status="error")
+    eq_(corresponding_hexsha(ds.repo), before)  # unchanged
+    if _is_adjusted_mode(fs_mode):
+        # the error-restore path must not leave us stranded on corr
+        ok_(ds.repo.is_managed_branch())
+
+
+# ---------------------------------------------------------------------------
+# C. Default HEAD & Dirty-tree parity (don't-refuse: match `git reset --hard`)
+# ---------------------------------------------------------------------------
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_default_head_clean_is_noop(path=None, *, fs_mode):
+    path = Path(path)
+    ds = _ds(path, fs_mode)
+
+    before = corresponding_hexsha(ds.repo)
+    res = ds.reset()  # default HEAD, clean tree
+    _assert_reset_ok(res, ds.repo, fs_mode, before)  # no-op: ok, unchanged, still adjusted
+
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_discards_unsaved_modification(path=None, *, fs_mode):
+    path = Path(path)
+    ds = _ds(path, fs_mode)
+
+    tracked = ds.pathobj / "tracked.txt"
+    tracked.write_text("CLEAN")
+    ds.save()
+    tracked_sha = corresponding_hexsha(ds.repo)
+
+    ds.unlock("tracked.txt", result_renderer="disabled")  # writable in place (no-op if adjusted)
+    tracked.write_text("DIRTY")                           # uncommitted modification
+
+    res = ds.reset()
+    _assert_reset_ok(res, ds.repo, fs_mode, tracked_sha)
+    eq_(tracked.read_text(), "CLEAN")  # modification discarded -> committed content restored
+
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_keeps_untracked(path=None, *, fs_mode):
+    path = Path(path)
+    ds = _ds(path, fs_mode)
+
+    tracked = ds.pathobj / "tracked.txt"
+    tracked.write_text("CLEAN")
+    ds.save()
+    tracked_sha = corresponding_hexsha(ds.repo)
+    ds.unlock("tracked.txt", result_renderer="disabled")  # writable in place (no-op if adjusted)
+    tracked.write_text("DIRTY")  # give the reset something real to do (teeth)
+    untracked = ds.pathobj / "untracked.txt"
+    untracked.write_text("KEEP")
+
+    res = ds.reset()
+    _assert_reset_ok(res, ds.repo, fs_mode, tracked_sha)
+    eq_(tracked.read_text(), "CLEAN")    # tracked modification discarded
+    eq_(untracked.read_text(), "KEEP")   # untracked file survived, with its content
+
+
+# ---------------------------------------------------------------------------
+# D. Relative targets (HEAD~N discards exactly N real commits)
+# ---------------------------------------------------------------------------
+
+@slow  # ~8s
+@with_tempfile(mkdir=True)
+def test_reset_discards_n_commits(path=None, *, fs_mode, request):
+    """Resolve the relative ref on the corresponding branch (N=N) and not on
+    the adjusted branch (N=N+1) where the 'git-annex adjusted branch' commit
+    sits on top of N real commits.
+    """
+    path = Path(path)
+    ds = _ds(path, fs_mode)
+    _xfail_simulated_crippled(request, ds.repo)
+
+    (ds.pathobj / "first.txt").write_text("FIRST")
+    ds.save()
+    first_sha = corresponding_hexsha(ds.repo)
+    (ds.pathobj / "second.txt").write_text("SECOND")
+    ds.save()
+    neq_(corresponding_hexsha(ds.repo), first_sha)
+
+    res = ds.reset(target="HEAD~1")
+    _assert_reset_ok(res, ds.repo, fs_mode, first_sha)
+    assert_false((ds.pathobj / "second.txt").exists())    # discarded commit's file gone
+    eq_((ds.pathobj / "first.txt").read_text(), "FIRST")  # kept commit's file materialised
+
+
+# ---------------------------------------------------------------------------
+# E. Recursive (-r) with --follow
+# ---------------------------------------------------------------------------
+
+@slow  # ~12s
+@with_tempfile(mkdir=True)
+def test_reset_recursive_default_resets_each_to_own_head(path=None, *, fs_mode):
+    path = Path(path)
+    ds = _ds_with_subds(path, fs_mode)
+    ds_sub = _subds(ds)
+
+    super_file = ds.pathobj / "super.txt"
+    super_file.write_text("CLEAN")
+    ds.save("super.txt")  # annexed; scoped: not the diverged sub
+    super_sha = corresponding_hexsha(ds.repo)
+
+    sub_file = ds_sub.pathobj / "sub.txt"
+    sub_file.write_text("CLEAN")
+    ds_sub.save("sub.txt")
+    sub_sha = corresponding_hexsha(ds_sub.repo)
+
+    eq_(super_file.read_text(), "CLEAN")
+    eq_(sub_file.read_text(), "CLEAN")
+
+    # unlock (no-op if adjusted), then make unCLEAN edits in both -- to discard
+    ds.unlock("super.txt", result_renderer="disabled")
+    super_file.write_text("DIRTY")
+    ds_sub.unlock("sub.txt", result_renderer="disabled")
+    sub_file.write_text("DIRTY")
+
+    eq_(super_file.read_text(), "DIRTY")
+    eq_(sub_file.read_text(), "DIRTY")
+
+    res = ds.reset(recursive=True)  # default HEAD
+    _assert_reset_ok(res, ds.repo, fs_mode, super_sha)
+    _assert_reset_ok(res, ds_sub.repo, fs_mode, sub_sha)
+    eq_(super_file.read_text(), "CLEAN")
+    eq_(sub_file.read_text(), "CLEAN")
+
+
+@slow  # ~12s
+@with_tempfile(mkdir=True)
+def test_reset_recursive_follow_parentds(path=None, *, fs_mode, request):
+    path = Path(path)
+    ds = _ds_with_subds(path, fs_mode)
+    ds_sub = _subds(ds)
+    # parentds snaps the sub back over retained annex content -- the one
+    # combination the crippled-fs simulation can't render (passes on real Windows)
+    _xfail_simulated_crippled(request, ds.repo)
+
+    super_sha = corresponding_hexsha(ds.repo)
+    sub_pin = corresponding_hexsha(ds_sub.repo)
+
+    (ds_sub.pathobj / "sub.txt").write_text("DISCARD")
+    ds_sub.save()
+    neq_(corresponding_hexsha(ds_sub.repo), sub_pin)
+
+    res = ds.reset(recursive=True, follow="parentds")
+    _assert_reset_ok(res, ds.repo, fs_mode, super_sha)
+    _assert_reset_ok(res, ds_sub.repo, fs_mode, sub_pin)
+    assert_false((ds_sub.pathobj / "sub.txt").exists())    # discarded commit's file gone
+
+
+@slow  # ~12s
+@pytest.mark.parametrize("follow", [None, "parentds"])
+@with_tempfile(mkdir=True)
+def test_reset_recursive_to_sibling(path=None, *, fs_mode, follow):
+    """Reset subds either to its own sibling's head or following parent's record.
+
+    Bring sibling's parent and subds out-of-sync, i.e. subds's head is at a different
+    commit than what parent records. Then reset with --follow=None or --follow=parentds.
+    """
+    path = Path(path)
+    ds_src = _src_with_subds(path)
+    ds_src_sub = _subds(ds_src)
+
+    sibling_sha = corresponding_hexsha(ds_src.repo)
+    sub_pin = corresponding_hexsha(ds_src_sub.repo)  # what the super records for the sub
+
+    ds = _clone(ds_src, path, fs_mode, recursive=True)
+    ds_sub = _subds(ds)
+
+    # advance sibling-sub, save locally, so sibling-parent & -sub are out-of-sync
+    # this creates two distinct reset target for the clone-sub
+    (ds_src_sub.pathobj / "advance_sub.txt").write_text("ADVANCED")
+    ds_src_sub.save()
+    sub_tip = corresponding_hexsha(ds_src_sub.repo)
+    neq_(sub_tip, sub_pin)
+
+    # clone diverges from sibling, so reset has something to do
+    (ds.pathobj / "diverge_clone.txt").write_text("DISCARD")
+    (ds_sub.pathobj / "diverge_clone_sub.txt").write_text("DISCARD")
+    ds.save(recursive=True)
+    neq_(corresponding_hexsha(ds.repo), sibling_sha)
+    # the teeth: ds_sub has genuinely diverged from its sibling, as well as from what
+    # sibling's parent recorded
+    neq_(corresponding_hexsha(ds_sub.repo), sub_pin)
+    neq_(corresponding_hexsha(ds_sub.repo), sub_tip)
+
+    # crucial: the test only works if clone-sub KNOWS about sibling-sub's state
+    ds_sub.repo.fetch(remote=_sibling(ds_sub.repo))
+
+    target = f"{_sibling(ds.repo)}/{_corr(ds.repo)}"
+    res = ds.reset(recursive=True, target=target, follow=follow)
+    _assert_reset_ok(res, ds.repo, fs_mode, sibling_sha)
+    assert_false((ds.pathobj / "diverge_clone_sub.txt").exists())  # the divergence in sub is discarded
+
+    # depending on the --follow argument, sub_ds should now match either
+    # sub_pin (parentds) or sub_tip (default)
+    if follow == "parentds":
+        _assert_reset_ok(res, ds_sub.repo, fs_mode, sub_pin)      # snapped to recorded pin
+        # lexists, not exists: on a normal branch the annexed file is a locked
+        # symlink to (cloned-not-fetched) absent content, so exists() would follow
+        # the broken symlink and report False even though the entry is present.
+        assert_false(os.path.lexists(ds_sub.pathobj / "advance_sub.txt"))  # the advance was never seen by parent
+    else:
+        _assert_reset_ok(res, ds_sub.repo, fs_mode, sub_tip)   # resolved in its own sibling
+        ok_(os.path.lexists(ds_sub.pathobj / "advance_sub.txt"))  # the advance is present
+
+
+@slow  # ~10s
+@pytest.mark.parametrize("target_form", ["sha", "relative"])
+@with_tempfile(mkdir=True)
+def test_reset_recursive_history_coordinate_requires_parentds(
+        path=None, *, fs_mode, request, target_form):
+    """A raw SHA and a relative ref (HEAD~1) are both parent-history coordinates
+    with no per-subdataset meaning -> refused under -r unless --follow=parentds,
+    which interprets them in the super and snaps subdatasets to the recorded
+    pins. After the advance below, both forms name the parent-before-advance.
+    """
+    path = Path(path)
+    ds = _ds_with_subds(path, fs_mode)
+    ds_sub = _subds(ds)
+
+    # the reset moves history over retained annex content -- the one
+    # combination the crippled-fs simulation can't render (passes on real Windows)
+    # see _xfail_simulated_crippled
+    _xfail_simulated_crippled(request, ds.repo)
+
+    parent_sha = corresponding_hexsha(ds.repo)
+    sub_pin = corresponding_hexsha(ds_sub.repo)  # what the super records for the sub
+
+    # the parent advances, so the reset has real work to do
+    (ds.pathobj / "super.txt").write_text("DISCARD")
+    ds.save()
+    neq_(corresponding_hexsha(ds.repo), parent_sha)
+    # the subds advances too, but the parent still records the old pointer
+    (ds_sub.pathobj / "sub.txt").write_text("DISCARD")
+    ds_sub.save()
+    neq_(corresponding_hexsha(ds_sub.repo), sub_pin)
+
+    target = parent_sha if target_form == "sha" else "HEAD~1"
+
+    # no per-subds meaning -> refuse unless parentds is explicit
+    assert_in_results(
+        ds.reset(target=target, recursive=True, on_failure="ignore"),
+        action="reset", status="impossible")
+    neq_(corresponding_hexsha(ds.repo), parent_sha)  # untouched
+
+    # with --follow=parentds: the super interprets it locally; subds snap to pins
+    res = ds.reset(target=target, recursive=True, follow="parentds")
+    _assert_reset_ok(res, ds.repo, fs_mode, parent_sha)
+    _assert_reset_ok(res, ds_sub.repo, fs_mode, sub_pin)
+    assert_false((ds.pathobj / "super.txt").exists())    # super's advance discarded
+    assert_false((ds_sub.pathobj / "sub.txt").exists())  # sub's advance discarded
+
+
+@slow  # ~12s
+@with_tempfile(mkdir=True)
+def test_reset_recursion_limit(path=None, *, fs_mode):
+    # super -> sub -> subsub; -R 1 resets the super and its direct sub but stops
+    # short of the nested subsub: exactly two reset records, not three.
+    path = Path(path)
+    ds_src = Dataset(path / "ds").create()
+    ds_src_sub = ds_src.create("sub")
+    ds_src_sub.create("subsub")
+    ds_src.save(recursive=True)
+    _adjust_for_mode(ds_src, fs_mode)  # children before parent
+
+    ds = _clone(ds_src, path, fs_mode, recursive=True)
+    ds_sub = _subds(ds)
+    ds_sub_sub = _subds(ds_sub)
+
+    super_sha = corresponding_hexsha(ds.repo)
+    sub_sha = corresponding_hexsha(ds_sub.repo)
+    subsub_before = corresponding_hexsha(ds_sub_sub.repo)
+
+    (ds.pathobj / "super.txt").write_text("DISCARD")
+    ds.save()
+    neq_(corresponding_hexsha(ds_sub.repo), super_sha)
+
+    (ds_sub.pathobj / "sub.txt").write_text("DISCARD")
+    ds_sub.save()
+    neq_(corresponding_hexsha(ds_sub.repo), sub_sha)
+
+    (ds_sub_sub.pathobj / "subsub.txt").write_text("KEEP")
+    ds_sub_sub.save()
+    subsub_sha = corresponding_hexsha(ds_sub_sub.repo)
+    neq_(subsub_sha, subsub_before)
+
+    target = f"{_sibling(ds.repo)}/{_corr(ds.repo)}"
+    res = ds.reset(target=target, recursive=True, recursion_limit=1)
+    assert_result_count(res, 2, action="reset")  # super + direct sub, NOT subsub
+    _assert_reset_ok(res, ds.repo, fs_mode, super_sha)
+    _assert_reset_ok(res, ds_sub.repo, fs_mode, sub_sha)
+    # no reset happened in subsub, but we can assert sha identity and adjusted mode
+    _assert_reset_ok(res, ds_sub_sub.repo, fs_mode, subsub_sha)
+    assert_false((ds.pathobj / "super.txt").exists())    # super's last commit is discarded
+    assert_false((ds_sub.pathobj / "sub.txt").exists())  # sub's last commit is discarded
+    ok_((ds_sub_sub.pathobj / "subsub.txt").exists())    # subsub's last commit is kept
+
+
+# ---------------------------------------------------------------------------
+# F. Adjust-mode preservation (non-unlock)
+# ---------------------------------------------------------------------------
+
+@slow  # ~8s
+@skip_if_adjusted_branch
+@with_tempfile(mkdir=True)
+@pytest.mark.parametrize("adjust_mode, expected_string", [
+    ("--fix", "fixed"),
+    ("--hide-missing", "hidemissing"),
+], ids=["fix", "hidemissing"])
+def test_reset_preserves_adjust_mode(path=None, *, adjust_mode, expected_string):
+    """Test that reset preserves the original adjust mode when moving history.
+
+    For --hide-missing, this test is expected to xfail because datalad core
+    doesn't support parsing that adjustment mode (AnnexRepo.get_corresponding_branch
+    only resolves `(unlocked)` and `(fixed)`).
+    """
+    # Mark the --hide-missing case as xfail
+    if adjust_mode == "--hide-missing":
+        pytest.xfail(
+            "`--hide-missing` is unsupported by datalad *core*, not by reset: "
+            "AnnexRepo.get_corresponding_branch only resolves `(unlocked)` and "
+            "`(fixed)` adjusted branches -- for `(hidemissing)` it returns a "
+            "malformed corresponding-branch name, so reset cannot even resolve "
+            "the branch to reset and `_get_adjust_mode` is never reached. "
+            "If core learns `(hidemissing)` this xpasses and the xfail can be removed."
+        )
+
+    path = Path(path)
+    ds = Dataset(path / "ds").create()
+
+    # Adjust to the specified mode
+    ds.repo.call_annex(["adjust", adjust_mode])
+    ok_(expected_string in ds.repo.get_active_branch())
+
+    target = corresponding_hexsha(ds.repo)
+    (ds.pathobj / "discard.txt").write_text("DISCARD")
+    ds.save()
+    neq_(corresponding_hexsha(ds.repo), target)
+
+    # A history-moving target routes through _reset_corresponding_branch,
+    # the only place where a re-adjust could flip the mode
+    res = ds.reset(target=target)
+    assert_in_results(res, action="reset", status="ok")
+    eq_(corresponding_hexsha(ds.repo), target)
+    assert_false((ds.pathobj / "discard.txt").exists())
+    ok_(ds.repo.is_managed_branch())
+    branch = ds.repo.get_active_branch()
+    assert expected_string in branch, \
+        f"reset flipped the adjust mode to {branch!r} (expected {expected_string} preserved)"

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -1002,9 +1002,9 @@ def test_update_how_subds_different(path=None, *, follow, action):
 
 
 @slow  # ~15s
-@skip_if_adjusted_branch
+@pytest.mark.parametrize("on_adjusted", [False, True])
 @with_tempfile(mkdir=True)
-def test_update_reset_dirty(path=None):
+def test_update_reset_dirty(path=None, *, on_adjusted):
     path = Path(path)
     ds_src = Dataset(path / "source").create()
     ds_src_s1 = ds_src.create("s1")
@@ -1013,30 +1013,51 @@ def test_update_reset_dirty(path=None):
 
     ds_clone = install(source=ds_src.path, path=path / "clone",
                        recursive=True, result_xfm="datasets")
+    ds_clone_s1 = Dataset(ds_clone.pathobj / "s1")
+    ds_clone_s2 = Dataset(ds_clone.pathobj / "s2")
+
+    if on_adjusted:
+        # Exercise the adjusted-branch reset path (_annex_reset_target) for both
+        # the parent and the subdatasets. Adjust subdatasets before the parent
+        # to dodge the git-annex submodule/adjust crash fixed in 7.20191024.
+        for d in (ds_clone_s1, ds_clone_s2, ds_clone):
+            maybe_adjust_repo(d.repo)
+        if not ds_clone.repo.is_managed_branch():
+            pytest.skip("test requires adjusted branch support")
+    elif ds_clone.repo.is_managed_branch():
+        # A crippled filesystem forces adjusted branches, so the non-adjusted
+        # leg is impossible here; the adjusted leg still runs natively. (Skip
+        # per-leg rather than the whole function with @skip_if_adjusted_branch,
+        # so this adjusted-branch fix is also exercised on crippled-fs CI.)
+        pytest.skip("filesystem forces adjusted branches; non-adjusted leg N/A")
 
     (ds_src_s1.pathobj / "foo").write_text("foo")
     (ds_src_s2.pathobj / "bar").write_text("bar")
     ds_src.save(recursive=True)
 
-    ds_clone_s1 = Dataset(ds_clone.pathobj / "s1")
-    ds_clone_s2 = Dataset(ds_clone.pathobj / "s2")
     (ds_clone_s1.pathobj / "dirt").write_text("")
 
     res = ds_clone.update(follow="sibling", how="reset", recursive=True,
                           on_failure="ignore")
 
     assert_result_count(res, 1, path=ds_clone.path,
-                        action=f"update.reset", status="error")
+                        action="update.reset", status="error")
     assert_result_count(res, 1, path=ds_clone_s1.path,
-                        action=f"update.reset", status="error")
+                        action="update.reset", status="error")
     assert_result_count(res, 1, path=ds_clone_s2.path,
-                        action=f"update.reset", status="ok")
+                        action="update.reset", status="ok")
 
-    # s2 was reset...
-    eq_(ds_src_s2.repo.get_hexsha(), ds_clone_s2.repo.get_hexsha())
+    # Compare real histories with corresponding_hexsha: it reads each repo's
+    # corresponding branch when adjusted, so neither the (adjusted) clone nor
+    # the (crippled-fs) sibling needs unadjusting just to be observed.
+    # s2 was reset to the sibling ...
+    eq_(corresponding_hexsha(ds_src_s2.repo),
+        corresponding_hexsha(ds_clone_s2.repo))
     # ... but s1 and the top-level dataset stayed behind due to the dirty tree.
-    eq_(ds_src.repo.get_hexsha("HEAD~"), ds_clone.repo.get_hexsha())
-    eq_(ds_src_s1.repo.get_hexsha("HEAD~"), ds_clone_s1.repo.get_hexsha())
+    eq_(corresponding_hexsha(ds_src.repo, "HEAD~"),
+        corresponding_hexsha(ds_clone.repo))
+    eq_(corresponding_hexsha(ds_src_s1.repo, "HEAD~"),
+        corresponding_hexsha(ds_clone_s1.repo))
 
     assert_repo_status(ds_clone.path,
                        modified=[ds_clone_s1.repo.path,
@@ -1320,7 +1341,7 @@ def test_update_merge_adjusted_no_leftover_synced(path=None):
     if synced_branch in ds_clone.repo.get_branches():
         ds_clone.repo.call_git(["branch", "-D", synced_branch])
 
-    # Advance the sibling so the merge has something to pull. 
+    # Advance the sibling so the merge has something to pull.
     (ds_src.pathobj / "new.txt").write_text("new")
     ds_src.save(message="new commit")
 

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -25,6 +25,7 @@ from datalad.api import (
     update,
 )
 from datalad.distribution.update import _process_how_args
+from datalad.distribution.utils import corresponding_hexsha
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.external_versions import external_versions
 from datalad.support.gitrepo import GitRepo
@@ -41,7 +42,6 @@ from datalad.tests.utils_pytest import (
     assert_repo_status,
     assert_result_count,
     assert_status,
-    corresponding_hexsha,
     create_tree,
     eq_,
     known_failure_windows,

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -41,10 +41,12 @@ from datalad.tests.utils_pytest import (
     assert_repo_status,
     assert_result_count,
     assert_status,
+    corresponding_hexsha,
     create_tree,
     eq_,
     known_failure_windows,
     maybe_adjust_repo,
+    maybe_unadjust_repo,
     neq_,
     ok_,
     ok_file_has_content,
@@ -1039,6 +1041,65 @@ def test_update_reset_dirty(path=None):
     assert_repo_status(ds_clone.path,
                        modified=[ds_clone_s1.repo.path,
                                  ds_clone_s2.repo.path])
+
+
+@slow  # ~10s
+@pytest.mark.parametrize("divergence", ["local_discard", "remote_discard"])
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted(path=None, *, divergence):
+    """`update --how=reset` must actually run on an adjusted branch following a sibling.
+
+    Two ways the corresponding branch can differ from the sibling:
+    ``local_discard`` (clone has an extra local commit) and ``remote_discard``
+    (the sibling moved back without the clone, e.g. via --force push).
+    Either way, target determination and the reset itself must work on the adjusted branch.
+
+    Regression: target determination used the *adjusted* branch name (e.g.
+    ``adjusted/master(unlocked)``) and built a nonexistent
+    ``<remote>/adjusted/master(unlocked)`` ref, so the command aborted with
+    "Could not determine update target".  It must instead resolve the
+    corresponding branch and reset to ``<remote>/<corresponding>``.
+    """
+    path = Path(path)
+
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "remote.txt").write_text("base commit")
+    ds_src.save()
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+
+    if divergence == 'local_discard':
+        (ds_clone.pathobj / "local.txt").write_text("local only, discard me by reset")
+        ds_clone.save()
+    elif divergence == 'remote_discard':
+        # A raw git reset --hard must move the sibling's corresponding branch
+        # -- the one rewrite that needs an unadjust here (see maybe_unadjust_repo).
+        maybe_unadjust_repo(ds_src.repo)
+        ds_src.repo.call_git(["reset", "--hard", "HEAD~"])
+
+    # Read both real tips with corresponding_hexsha (corr-aware)
+    target_hexsha = corresponding_hexsha(ds_src.repo)
+    pre_update_hexsha = corresponding_hexsha(ds_clone.repo)
+    neq_(pre_update_hexsha, target_hexsha)  # the local clone has diverged
+
+    # reset local clone to sibling (previously raised "Could not determine update target")
+    assert_in_results(
+        ds_clone.update(follow="sibling", how="reset"),
+        action="update.reset", status="ok")
+
+    # The corresponding branch matches the sibling again (local commit gone)...
+    post_update_hexsha = corresponding_hexsha(ds_clone.repo)
+    eq_(post_update_hexsha, target_hexsha)
+    # ... the adjusted view's anchor (basis) was re-anchored to the target too,
+    # otherwise the next git annex adjust would rebuild the view from the wrong basis
+    adjusted = ds_clone.repo.get_active_branch()
+    eq_(ds_clone.repo.get_hexsha(f"refs/basis/{adjusted}"), target_hexsha)
+    # ... and we are still on the adjusted branch.
+    ok_(ds_clone.repo.is_managed_branch())
 
 
 def test_process_how_args():

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -1292,6 +1292,44 @@ def test_update_reset_adjusted_no_resurrection_on_push(path=None):
     eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
 
 
+@slow  # ~10s
+@with_tempfile(mkdir=True)
+def test_update_merge_adjusted_no_leftover_synced(path=None):
+    """`update --how=merge` on an adjusted branch must not leave a zombie synced/.
+
+    On adjusted branches `update --how=merge` runs `git annex sync`, which
+    creates a `synced/<branch>` ref. Left behind, that ref is a "zombie": a
+    later sync (run internally by save/push) can merge it back and resurrect
+    discarded commits (gh-7772). Mirror `AnnexRepo.localsync`'s delete-if-created
+    hygiene -- if this sync created `synced/<branch>`, remove it again.
+    """
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "base.txt").write_text("base")
+    ds_src.save()
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+    corr_branch = ds_clone.repo.get_corresponding_branch()
+    synced_branch = f"synced/{corr_branch}"
+
+    # Start from a clean slate so we only judge the synced/ this merge creates.
+    if synced_branch in ds_clone.repo.get_branches():
+        ds_clone.repo.call_git(["branch", "-D", synced_branch])
+
+    # Advance the sibling so the merge has something to pull. 
+    (ds_src.pathobj / "new.txt").write_text("new")
+    ds_src.save(message="new commit")
+
+    # The merge runs git-annex-sync, which creates synced/<branch> ...
+    ds_clone.update(how="merge")
+    # ... and must clean up the synced/ it created (delete-if-created).
+    assert_not_in(synced_branch, ds_clone.repo.get_branches())
+
+
 def test_process_how_args():
     # --merge maps onto --how values. It has no equivalent of --how-subds,
     # --which just gets set to --how's value when unspecified.

--- a/datalad/distribution/tests/test_update.py
+++ b/datalad/distribution/tests/test_update.py
@@ -1102,6 +1102,196 @@ def test_update_reset_adjusted(path=None, *, divergence):
     ok_(ds_clone.repo.is_managed_branch())
 
 
+@slow  # ~12s
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted_resets_synced(path=None):
+    """Reset on an adjusted branch must STICK across a later git-annex-sync.
+
+    On crippled filesystems (Windows), DataLad uses adjusted branches, and
+    git-annex keeps ``synced/<branch>`` refs tracking the corresponding branch.
+    If ``_annex_reset_target`` reset the corresponding branch but left
+    ``synced/<branch>`` at the old (newer) state, the next ``git annex sync``
+    would merge it back in, resurrecting the intentionally-discarded commits.
+
+    We check both halves: right after the reset *and* after a real sync, BOTH
+    the corresponding branch and ``synced/<branch>`` sit at the target -- so the
+    discard holds, and the following sync stays safe too.
+    See https://github.com/datalad/datalad/issues/7772
+    """
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "file1.txt").write_text("initial")
+    ds_src.save()
+
+    ds_clone = install(
+        source=ds_src.path, path=path / "clone",
+        result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+
+    corr_branch = ds_clone.repo.get_corresponding_branch()
+    target_hexsha = corresponding_hexsha(ds_clone.repo)
+
+    # Advance source.
+    (ds_src.pathobj / "file2.txt").write_text("new")
+    ds_src.save()
+
+    # Merge into the adjusted clone, advancing the corresponding branch.
+    ds_clone.update(sibling=DEFAULT_REMOTE, how="merge")
+    post_update_hexsha = corresponding_hexsha(ds_clone.repo)
+    neq_(post_update_hexsha, target_hexsha)
+
+    # Simulate a synced/ branch left behind by git-annex (as happens on
+    # Windows) by creating synced/<branch> at the post-merge state.
+    synced_branch = f"synced/{corr_branch}"
+    ds_clone.repo.call_git(
+        ["branch", "-f", synced_branch, post_update_hexsha])
+    ok_(synced_branch in ds_clone.repo.get_branches())
+
+    # Reset to the old state via _annex_reset_target.
+    from datalad.distribution.update import _annex_reset_target
+    for r in _annex_reset_target(ds_clone.repo, None, target_hexsha):
+        eq_(r["status"], "ok")
+
+    # PRE-SYNC: _annex_reset_target's direct contract -- BOTH the corresponding
+    # branch AND synced/<branch> must now sit at the reset target.
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+    eq_(ds_clone.repo.get_hexsha(synced_branch), target_hexsha)
+
+    # ACID + DURABILITY: a real git-annex-sync must NOT resurrect the discarded
+    # commit, AND must leave BOTH refs at the target -- so the *next* sync is
+    # safe too (no re-armed synced/ left to merge back in).
+    ds_clone.repo.call_annex(
+        ["sync", "--no-push", "--no-pull", "--no-commit",
+         "--no-content", "--no-resolvemerge"])
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+    eq_(ds_clone.repo.get_hexsha(synced_branch), target_hexsha)
+
+
+@slow  # ~15s
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted_no_resurrection_on_save(path=None):
+    """local_discard: a `save` after reset must not resurrect a discarded commit.
+
+    Realistic adjusted-branch flow (public API only, no raw git-annex commands):
+    ``update --how=merge`` leaves a local ``synced/<branch>`` behind; a later
+    ``update --how=reset`` discards a local commit; if ``synced/<branch>`` is
+    not reconciled, the next ``save`` (which runs git-annex-sync internally)
+    merges it back, resurrecting the discarded commit.  Requires BOTH fixes:
+    target determination on adjusted branches (so reset runs at all) and the
+    synced/ reset inside ``_annex_reset_target``.
+    """
+    path = Path(path)
+
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "base.txt").write_text("base commit")
+    ds_src.save(message="add a base commit")
+
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+    corr_branch = ds_clone.repo.get_corresponding_branch()
+
+    # `update --how merge` to create the underlying `synced/<branch>`
+    ds_clone.update(how="merge")
+
+    # Store sibling's state as the reset target -- a corr-aware read, so the
+    # sibling can stay adjusted (we never rewrite it); no unadjust needed.
+    target_hexsha = corresponding_hexsha(ds_src.repo)
+
+    # A local commit that the reset will discard.
+    (ds_clone.pathobj / "local.txt").write_text("discard me")
+    ds_clone.save(message="local commit to be discarded")
+    discard = ds_clone.repo.get_hexsha(corr_branch)
+    neq_(discard, target_hexsha)
+
+    # Reset to the sibling, discarding the local commit.
+    assert_in_results(ds_clone.update(how="reset"),
+                      action="update.reset", status="ok")
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+
+    # The reckoning: a normal save must NOT resurrect the discarded commit,
+    # and must NOT lose the fresh work added on top. `save` runs git-annex-sync
+    # internally, which is where a zombie synced/<branch> would merge the
+    # discarded commit back in.
+    (ds_clone.pathobj / "fresh.txt").write_text("fresh work")
+    ds_clone.save(message="fresh work after reset")
+    # the discarded commit did not come back ...
+    assert_false(ds_clone.repo.is_ancestor(discard, corr_branch))
+    ok_(not (ds_clone.pathobj / "local.txt").exists())
+    # ... and the fresh work survived.
+    ok_((ds_clone.pathobj / "fresh.txt").exists())
+
+
+@slow  # ~15s
+@with_tempfile(mkdir=True)
+def test_update_reset_adjusted_no_resurrection_on_push(path=None):
+    """remote_discard: a `push` after reset must not resurrect a discarded commit.
+
+    The sibling grows a commit, the clone pulls it via ``update --how=merge``
+    (seeding the zombie ``synced/<branch>``), then the sibling rewinds it (as a
+    history rewrite / --force push would).  The clone resets to match the
+    rewound sibling, discarding the commit -- but if ``synced/<branch>`` is not
+    reconciled, the next ``push`` (which runs the same git-annex-sync via
+    ``push``'s internal ``localsync``) merges it back and resurrects the
+    discarded commit *on the sibling*.
+    """
+    path = Path(path)
+    ds_src = Dataset(path / "source").create()
+    (ds_src.pathobj / "base.txt").write_text("base commit")
+    ds_src.save()
+
+    # allow pushing back into the (non-bare) source's checked-out branch
+    ds_src.repo.config.set("receive.denyCurrentBranch", "updateInstead",
+                           scope="local")
+
+    ds_clone = install(source=ds_src.path, path=path / "clone",
+                       result_xfm="datasets")
+    maybe_adjust_repo(ds_clone.repo)
+    if not ds_clone.repo.is_managed_branch():
+        pytest.skip("test requires adjusted branch support")
+    corr_branch = ds_clone.repo.get_corresponding_branch()
+    src_branch = ds_src.repo.get_corresponding_branch() or DEFAULT_BRANCH
+
+    (ds_src.pathobj / "bad.txt").write_text("bad upstream commit")
+    ds_src.save(message="bad commit")
+
+    ds_clone.update(how="merge")
+    discard = ds_clone.repo.get_hexsha(corr_branch)
+    ok_((ds_clone.pathobj / "bad.txt").exists())
+
+    # Upstream rewinds the bad commit (history rewrite / --force push). A raw
+    # `git reset --hard` must move the sibling's corresponding branch, not its
+    # adjusted view. See maybe_unadjust_repo.
+    maybe_unadjust_repo(ds_src.repo)
+    ds_src.repo.call_git(["reset", "--hard", "HEAD~"])
+    target_hexsha = corresponding_hexsha(ds_src.repo)
+    neq_(discard, target_hexsha)
+
+    # The clone resets to match the rewound sibling, discarding the bad commit.
+    assert_in_results(ds_clone.update(how="reset"),
+                      action="update.reset", status="ok")
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+
+    # The reckoning: pushing back must NOT resurrect the bad commit. We push
+    # directly after the reset (no intervening local save) so that push's own
+    # internal localsync -- not a save -- is what would merge a zombie
+    # synced/<branch> back in.
+    ds_clone.push(to=DEFAULT_REMOTE)
+    # the discarded commit did not come back, on either side ...
+    assert_false(ds_src.repo.is_ancestor(discard, src_branch))
+    assert_false(ds_clone.repo.is_ancestor(discard, corr_branch))
+    # ... and both sides agree at the rewound target (good state preserved,
+    # nothing extra resurrected).
+    eq_(ds_src.repo.get_hexsha(src_branch), target_hexsha)
+    eq_(ds_clone.repo.get_hexsha(corr_branch), target_hexsha)
+
+
 def test_process_how_args():
     # --merge maps onto --how values. It has no equivalent of --how-subds,
     # --which just gets set to --how's value when unspecified.

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -578,10 +578,27 @@ def _annex_plain_merge(repo, _, target, opts=None):
 
 
 def _annex_sync(repo, remote, _target, opts=None):
-    yield _try_command(
+    # git-annex-sync creates a synced/<branch> ref. Mirror
+    # AnnexRepo.localsync's delete-if-created hygiene: if this sync created it,
+    # remove it again, so a later git-annex-sync (run internally by save/push)
+    # cannot merge the zombie back and resurrect discarded commits (gh-7772).
+    branch = repo.get_active_branch()
+    branch = repo.get_corresponding_branch(branch) or branch
+    synced_branch = 'synced/{}'.format(branch)
+    had_synced_branch = synced_branch in repo.get_branches()
+    res = _try_command(
         {"action": "update.annex_sync", "message": "Ran git-annex-sync"},
         repo.call_annex,
         ['sync', '--no-push', '--pull', '--no-commit', '--no-content', remote])
+    yield res
+    # Use -D (force): after a --pull sync, synced/<branch> may hold commits not
+    # reachable from the *adjusted* HEAD (they live on the corresponding branch
+    # and remote-tracking ref), so -d would refuse. Force-deleting the ref we
+    # just created loses nothing.
+    if res.get("status") != "error" \
+            and not had_synced_branch \
+            and synced_branch in repo.get_branches():
+        repo.call_git(['branch', '-D', synced_branch])
 
 
 def _annex_merge_target(repo, _remote, target, opts=None):

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -622,8 +622,10 @@ def _annex_reset_target(repo, _remote, target, opts=None):
     """Reset an adjusted branch to a specific target revision.
 
     This performs a hard reset on the corresponding branch, then re-adjusts
-    the branch to maintain the adjusted state. This is useful for
-    `how_subds='reset'` on adjusted branches.
+    the branch to maintain the adjusted state. It also resets any
+    ``synced/<branch>`` ref so that a subsequent ``git annex sync`` does not
+    merge the old (pre-reset) state back in — which is the root cause of
+    "zombie commits" on Windows / crippled filesystems (see #7772).
     """
     if repo.dirty:
         yield {"action": "update.reset",
@@ -641,6 +643,11 @@ def _annex_reset_target(repo, _remote, target, opts=None):
         try:
             # Reset to target
             repo.call_git(['reset', '--hard', target])
+            # Also reset synced/<branch> so git-annex-sync won't
+            # resurrect the discarded commits (#7772).
+            synced_branch = 'synced/{}'.format(corr_branch)
+            if synced_branch in repo.get_branches():
+                repo.call_git(['branch', '-f', synced_branch, corr_branch])
             # Re-adjust with --force to overwrite existing adjusted branch
             repo.call_annex(['adjust', adjust_mode, '--force'])
         except Exception:

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -19,6 +19,7 @@ from os.path import lexists
 
 from datalad.consts import ADJUSTED_BRANCH_EXPR
 from datalad.distribution.dataset import require_dataset
+from datalad.distribution.utils import _try_command
 from datalad.interface.base import (
     Interface,
     build_doc,
@@ -49,6 +50,10 @@ from datalad.support.param import Parameter
 from .dataset import (
     EnsureDataset,
     datasetmethod,
+)
+from .reset import (
+    _annex_reset_target,
+    _reset_hard,
 )
 
 lgr = logging.getLogger('datalad.distribution.update')
@@ -401,15 +406,25 @@ class Update(Interface):
                 if is_annex and reobtain_data:
                     update_fn = _reobtain(ds, update_fn)
 
-                for ures in update_fn(repo, sibling_, target, opts=fn_opts):
-                    # NOTE: Ideally the "merge" action would also be prefixed
-                    # with "update.", but a plain "merge" is used for backward
-                    # compatibility.
-                    if ures["status"] != "ok" and (
-                            ures["action"] == "merge" or
-                            ures["action"].startswith("update.")):
-                        saw_update_failure = True
-                    yield dict(res, **ures)
+                # Refuse a dirty working tree HERE instead of inside the reset helpers.
+                # `_reset_hard` / `_annex_reset_target` are now pure -- they
+                # always discard like `git reset --hard`, so they are shared reset engine
+                # between `update` and `reset`.
+                if how_curr == "reset" and repo.dirty:
+                    yield dict(res, action="update.reset", status="error",
+                               message="Refusing to reset dirty working tree")
+                    saw_update_failure = True
+                else:
+                    for ures in update_fn(repo, sibling_, target,
+                                          opts=fn_opts):
+                        # NOTE: Ideally the "merge" action would also be
+                        # prefixed with "update.", but a plain "merge" is used
+                        # for backward compatibility.
+                        if ures["status"] != "ok" and (
+                                ures["action"] == "merge" or
+                                ures["action"].startswith("update.")):
+                            saw_update_failure = True
+                        yield dict(res, **ures)
 
             if saw_update_failure:
                 update_failures.add(ds)
@@ -537,29 +552,6 @@ def _choose_update_fn(repo, how, is_annex=False, adjusted=False,
     return fn
 
 
-def _try_command(record, fn, *args, **kwargs):
-    """Call `fn`, catching a `CommandError`.
-
-    Parameters
-    ----------
-    record : dict
-        A partial result record. It should at least have 'action' and 'message'
-        fields. A 'status' value of 'ok' or 'error' will be added based on
-        whether calling `fn` raises a `CommandError`.
-
-    Returns
-    -------
-    A new record with a 'status' field.
-    """
-    try:
-        fn(*args, **kwargs)
-    except CommandError as exc:
-        ce = CapturedException(exc)
-        return dict(record, status="error", message=str(ce))
-    else:
-        return dict(record, status="ok")
-
-
 def _plain_merge(repo, _, target, opts=None):
     yield _try_command(
         {"action": "merge", "message": ("Merged %s", target)},
@@ -612,87 +604,6 @@ def _annex_merge_target(repo, _remote, target, opts=None):
         {"action": "update.annex_merge", "message": ("Merged %s", target)},
         repo.call_annex,
         ['merge', target])
-
-
-def _get_adjust_mode(branch_name):
-    """Extract the adjustment mode from an adjusted branch name.
-
-    E.g., 'adjusted/master(unlocked)' -> '--unlock'
-    """
-    match = ADJUSTED_BRANCH_EXPR.match(branch_name or '')
-    if not match:
-        # Default to unlocked mode as it is the most common adjustment,
-        # especially on crippled filesystems where unlocked behavior is expected.
-        return '--unlock'
-    mode = match.group('mode')
-    mode_to_option = {
-        'unlocked': '--unlock',
-        'locked': '--lock',
-        'fix': '--fix',
-        'fixed': '--fix',
-        'hidemissing': '--hide-missing',
-    }
-    return mode_to_option.get(mode, '--unlock')
-
-
-def _annex_reset_target(repo, _remote, target, opts=None):
-    """Reset an adjusted branch to a specific target revision.
-
-    This performs a hard reset on the corresponding branch, then re-adjusts
-    the branch to maintain the adjusted state. It also resets any
-    ``synced/<branch>`` ref so that a subsequent ``git annex sync`` does not
-    merge the old (pre-reset) state back in — which is the root cause of
-    "zombie commits" on Windows / crippled filesystems (see #7772).
-    """
-    if repo.dirty:
-        yield {"action": "update.reset",
-               "status": "error",
-               "message": "Refusing to reset dirty working tree"}
-        return
-
-    active_branch = repo.get_active_branch()
-    corr_branch = repo.get_corresponding_branch(active_branch)
-    adjust_mode = _get_adjust_mode(active_branch)
-
-    def do_reset():
-        # Checkout the corresponding branch
-        repo.call_git(['checkout', corr_branch])
-        try:
-            # Reset to target
-            repo.call_git(['reset', '--hard', target])
-            # Also reset synced/<branch> so git-annex-sync won't
-            # resurrect the discarded commits (#7772).
-            synced_branch = 'synced/{}'.format(corr_branch)
-            if synced_branch in repo.get_branches():
-                repo.call_git(['branch', '-f', synced_branch, corr_branch])
-            # Re-adjust with --force to overwrite existing adjusted branch
-            repo.call_annex(['adjust', adjust_mode, '--force'])
-        except Exception:
-            # Try to restore the adjusted branch so the repo isn't stranded
-            # on the corresponding branch
-            try:
-                repo.call_annex(['adjust', adjust_mode, '--force'])
-            except Exception:
-                lgr.debug(
-                    "Failed to restore adjusted branch %s after "
-                    "failed reset", active_branch, exc_info=True)
-            raise
-
-    yield _try_command(
-        {"action": "update.reset", "message": ("Reset to %s", target)},
-        do_reset)
-
-
-def _reset_hard(repo, _, target, opts=None):
-    if repo.dirty:
-        yield {"action": "update.reset",
-               "status": "error",
-               "message": "Refusing to reset dirty working tree"}
-    else:
-        yield _try_command(
-            {"action": "update.reset", "message": ("Reset to %s", target)},
-            repo.call_git,
-            ["reset", "--hard", target])
 
 
 def _checkout(repo, _, target, opts=None):

--- a/datalad/distribution/update.py
+++ b/datalad/distribution/update.py
@@ -485,6 +485,12 @@ def _choose_update_target(repo, branch, remote, cfg_remote):
              f"{repo.get_corresponding_branch(branch) or ''}" "@{upstream}"],
             read_only=True)
     elif branch:
+        # On an adjusted branch the active branch (e.g.
+        # 'adjusted/master(unlocked)') has no remote counterpart; the sibling
+        # tracks the corresponding branch ('master'). Resolve it so the target
+        # becomes e.g. 'origin/master' instead of the nonexistent
+        # 'origin/adjusted/master(unlocked)'.
+        branch = repo.get_corresponding_branch(branch) or branch
         remote_branch = "{}/{}".format(remote, branch)
         if repo.commit_exists(remote_branch):
             target = remote_branch

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -20,6 +20,10 @@ from giturlparse import parse as parse_git_url
 
 from datalad.log import log_progress
 from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import (
+    CapturedException,
+    CommandError,
+)
 from datalad.support.network import (
     RI,
     URL,
@@ -174,3 +178,41 @@ def _yield_ds_w_matching_siblings(
         lgr.info, pbar_id,
         'Finished checking pre-existing sibling configuration %s', ds,
     )
+
+
+def _try_command(record, fn, *args, **kwargs):
+    """Call `fn`, catching a `CommandError`.
+
+    Parameters
+    ----------
+    record : dict
+        A partial result record. It should at least have 'action' and 'message'
+        fields. A 'status' value of 'ok' or 'error' will be added based on
+        whether calling `fn` raises a `CommandError`.
+
+    Returns
+    -------
+    A new record with a 'status' field.
+    """
+    try:
+        fn(*args, **kwargs)
+    except CommandError as exc:
+        ce = CapturedException(exc)
+        return dict(record, status="error", message=str(ce))
+    else:
+        return dict(record, status="ok")
+
+
+def corresponding_hexsha(repo, ref="HEAD"):
+    """Hexsha of ``ref``, read from the corresponding branch when adjusted.
+
+    On a git-annex adjusted branch the literal HEAD carries an extra "adjusting"
+    commit on top of the real history, so a plain ``get_hexsha("HEAD")`` is off
+    by that commit. This resolves HEAD-relative refs (``HEAD``, ``HEAD~N``)
+    against the corresponding branch instead, while leaving absolute refs/SHAs
+    untouched. On a normal branch it is a plain ``get_hexsha(ref)``.
+    """
+    corr = repo.get_corresponding_branch()
+    if not corr:
+        return repo.get_hexsha(ref)
+    return repo.get_hexsha(ref.replace("HEAD", corr))

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -46,6 +46,7 @@ _group_1siblings = (
         ('datalad.distribution.create_sibling', 'CreateSibling'),
         ('datalad.distribution.siblings', 'Siblings', 'siblings'),
         ('datalad.distribution.update', 'Update'),
+        ('datalad.distribution.reset', 'Reset'),
     ])
 
 _group_2dataset = (

--- a/datalad/tests/test_tests_utils_pytest.py
+++ b/datalad/tests/test_tests_utils_pytest.py
@@ -42,6 +42,7 @@ from _pytest.outcomes import (
 )
 
 from datalad import cfg as dl_cfg
+from datalad.distribution.dataset import Dataset
 from datalad.support import path as op
 from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils_pytest import (
@@ -56,6 +57,7 @@ from datalad.tests.utils_pytest import (
     assert_re_in,
     assert_str_equal,
     assert_true,
+    corresponding_hexsha,
     eq_,
     fs_supports_filename,
     get_most_obscure_supported_name,
@@ -63,6 +65,9 @@ from datalad.tests.utils_pytest import (
     known_failure_githubci_win,
     known_failure_windows,
     local_testrepo_flavors,
+    maybe_adjust_repo,
+    maybe_unadjust_repo,
+    neq_,
     nok_startswith,
     ok_,
     ok_broken_symlink,
@@ -82,6 +87,7 @@ from datalad.tests.utils_pytest import (
     serve_path_via_http,
     signal_timeout,
     skip_if,
+    skip_if_adjusted_branch,
     skip_if_no_module,
     skip_if_no_network,
     skip_if_on_windows,
@@ -771,3 +777,66 @@ def test_signal_timeout_noop_without_sigalrm(monkeypatch):
     # but with SIGALRM removed it must be a pure no-op.
     with signal_timeout(0.001):
         time.sleep(0.05)
+
+
+#
+# Test the adjusted-branch helpers
+#
+
+@with_tempfile(mkdir=True)
+def test_corresponding_hexsha(path=None):
+    ds = Dataset(path).create()
+    maybe_adjust_repo(ds.repo)
+    corr = ds.repo.get_corresponding_branch()
+    old = ds.repo.get_hexsha(corr)
+
+    (ds.pathobj / "new.txt").write_text("NEW")
+    ds.save()
+    new = ds.repo.get_hexsha(corr)
+
+    neq_(old, new)
+    neq_(ds.repo.get_hexsha("HEAD"), new)
+
+    # valid non-HEAD refs that contain "HEAD" in the string
+    ds.repo.call_git(["branch", "myHEAD", new])
+    ds.repo.call_git(["update-ref", "ORIG_HEAD", new])
+
+    eq_(corresponding_hexsha(ds.repo), new)
+    eq_(corresponding_hexsha(ds.repo, corr), new)
+    eq_(corresponding_hexsha(ds.repo, old), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD~"), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD^"), old)
+    eq_(corresponding_hexsha(ds.repo, "HEAD@{0}"), new)
+    eq_(corresponding_hexsha(ds.repo, "myHEAD"), new)
+    eq_(corresponding_hexsha(ds.repo, "ORIG_HEAD"), new)
+
+    for bogus in ("bogus", "bogusHEAD", "HEAD~99"):
+        assert_raises(ValueError, corresponding_hexsha, ds.repo, bogus)
+
+
+@skip_if_adjusted_branch
+@with_tempfile(mkdir=True)
+def test_maybe_unadjust_repo_noop(path=None):
+    repo = Dataset(path).create().repo
+    branch, hexsha = repo.get_active_branch(), repo.get_hexsha("HEAD")
+    maybe_unadjust_repo(repo)
+    eq_(repo.get_active_branch(), branch)
+    eq_(repo.get_hexsha("HEAD"), hexsha)
+
+
+@with_tempfile(mkdir=True)
+def test_maybe_unadjust_repo(path=None):
+    ds = Dataset(path).create()
+    maybe_adjust_repo(ds.repo)
+    corr = ds.repo.get_corresponding_branch()
+    corr_hexsha = ds.repo.get_hexsha(corr)
+
+    maybe_unadjust_repo(ds.repo)
+    assert_false(ds.repo.is_managed_branch())
+    eq_(ds.repo.get_active_branch(), corr)
+    eq_(ds.repo.get_hexsha("HEAD"), corr_hexsha)
+
+    # idempotent: a second call is the no-op case
+    maybe_unadjust_repo(ds.repo)
+    eq_(ds.repo.get_active_branch(), corr)
+    eq_(ds.repo.get_hexsha("HEAD"), corr_hexsha)

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -1952,6 +1952,47 @@ def maybe_adjust_repo(repo):
         repo.adjust()
 
 
+def maybe_unadjust_repo(repo):
+    """Check out `repo`'s *corresponding* branch (the real history beneath
+    the adjusting commit), the inverse of `maybe_adjust_repo`.
+
+    Call this function before you need to modify the commit history of a source/
+    sibling repo that has been created on a crippled FS (e.g. Windows CI).
+    A crippled FS forces every repo onto the adjusted branch. A plain
+    ``git reset --hard`` must land on the corresponding branch (not the adjusted
+    view). On a repo that is not adjusted it is a no-op.
+
+    Caveats:
+
+    - only faithful for asserting SHA-identity after a history-rewrite. If you
+      try to assert content-identity, you'll need to materialize the content first
+      via e.g. ``git checkout -- .``.
+
+    - only plain ``git`` keeps the repo unadjusted. DataLad's ``save``, ``update``
+      and ``push`` run ``git annex sync`` internally, which re-adjusts the branch
+      on a crippled filesystem.
+    """
+    if repo.is_managed_branch():
+        corr_branch = repo.get_corresponding_branch()
+        adjusted = repo.get_active_branch()
+        repo.call_git(["checkout", corr_branch])
+        repo.call_git(["branch", "-D", adjusted])
+
+
+def corresponding_hexsha(repo, ref="HEAD"):
+    """Hexsha of ``ref``, read from the corresponding branch when adjusted.
+
+    A plain ``get_hexsha(HEAD)`` on an adjusted repo returns the SHA of the git-annex
+    "adjusting" commit which is just the view. To read the SHA of the real history,
+    HEAD-relative refs need to be resolved against the corresponding branch instead.
+    On a normal branch it is a plain ``get_hexsha(ref)``.
+    """
+    if (corr := repo.get_corresponding_branch()) and (
+            ref == "HEAD" or ref.startswith(("HEAD~", "HEAD^", "HEAD@"))):
+        ref = corr + ref[len("HEAD"):]
+    return repo.get_hexsha(ref)
+
+
 @lru_cache()
 @with_tempfile
 @with_tempfile

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -60,6 +60,7 @@ Dataset operations
    datalad install: Install a dataset from a (remote) source <generated/man/datalad-install>
    datalad no-annex: Configure a dataset to never put file content into an annex <generated/man/datalad-no-annex>
    datalad remove: Unlink components from a dataset <generated/man/datalad-remove>
+   datalad reset: Reset a dataset to a target revision, discarding local divergence <generated/man/datalad-reset>
    datalad subdatasets: Query and manipulate subdataset records of a dataset <generated/man/datalad-subdatasets>
    datalad unlock: Make dataset file content editable <generated/man/datalad-unlock>
 

--- a/docs/source/design/index.rst
+++ b/docs/source/design/index.rst
@@ -21,6 +21,7 @@ subsystems in DataLad.
    dataset_argument
    log_levels
    drop
+   reset
    python_imports
    miscpatterns
    exception_handling

--- a/docs/source/design/reset.rst
+++ b/docs/source/design/reset.rst
@@ -1,0 +1,181 @@
+.. -*- mode: rst -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+
+.. _chap_design_reset:
+
+************************************
+Reset a dataset to a target revision
+************************************
+
+.. topic:: Specification scope and status
+
+   A new command :command:`reset` is introduced to enable correct `git reset --hard`
+   behavior on an adjusted branch. Recursive operation (``--recursive``/``--follow``)
+   allows reset across the dataset hierarchy on both normal and adjusted branches.
+
+§1 The :command:`reset` command discards local divergence and sets a dataset to
+a target revision. On a normal branch ``datalad reset <target>`` is equivalent
+to ``git reset --hard <target>``; the command exists to do the same thing
+*correctly* on git-annex *adjusted* branches.
+
+§2 On adjusted branches (the default on Windows / crippled filesystems) a plain
+``git reset`` operates on the disposable adjusted *view* and leaves the
+*corresponding* branch -- the real history -- untouched, so the discarded
+commits can be resurrected by the next ``git annex sync`` (`#7772
+<https://github.com/datalad/datalad/issues/7772>`__). The destroyed view further
+prevents new work being committed and leads to its permanent loss via
+``datalad save`` (`#7872 <https://github.com/datalad/datalad/issues/7872>`__).
+:command:`reset` instead resets the corresponding branch, reconciles git-annex's
+``synced/<branch>`` ref, and regenerates the adjusted view, so a discard stays a
+discard.
+
+This is the governing principle for the whole specification: **whatever happens
+to a normal branch happens to the corresponding branch, after which
+``synced/<branch>`` is reconciled and the adjusted view is regenerated.** It
+applies uniformly to every target and mode below, so the rest of this document
+-- the use cases included -- describes only the normal-branch behavior. The one
+exception is a target that does not move history (e.g. plain ``HEAD``): there
+only the working tree changes, so the adjusted case is a plain ``git reset
+--hard`` on the view, with no corresponding-branch checkout and no re-adjust.
+
+§3 :command:`reset` performs a **hard** reset only; there is no mode flag, and
+``datalad reset <target>`` always resets ``HEAD``, the index, and the working
+tree to ``<target>``. This is a deliberate scope choice, not a temporary
+limitation. ``git reset``'s ``--soft`` and ``--mixed`` modes differ from
+``--hard`` only in *where they leave the undone changes* -- in the **staging
+area** (index) -- but DataLad does not expose a staging area: :command:`save`
+goes straight from the working tree to history (it is ``git add`` + ``git
+commit`` fused). Soft and mixed therefore have no place in the DataLad model.
+(Their interaction with git-annex's locked/unlocked file representation in the
+index is also unexplored, and out of scope for this command.)
+
+§4 The positional ``TARGET`` (default ``HEAD``) is any commit-ish: a SHA, a
+branch, a tag, a remote-tracking ref (e.g. ``origin/main``), ``HEAD``, or
+``HEAD~N`` (the latter under ``--recursive`` only with ``--follow=parentds``,
+see §12).
+
+§5 ``HEAD~N`` discards exactly *N* real commits on both normal and adjusted
+branches (an *N=N* rule, no off-by-one). On an adjusted branch the relative ref
+is resolved on the corresponding branch that sits below the git-annex adjusting
+commit. The view HEAD is not counted as real commit.
+
+§6 With a dirty working tree, :command:`reset` matches ``git reset --hard``: it
+discards **tracked** modifications (and anything staged) but **keeps
+untracked** files (it is not ``git clean``). This differs from
+:command:`update`'s ``--how=reset``, which refuses on a dirty tree (see §13).
+
+§7 Annexed content is never deleted: ``git reset`` does not touch
+``.git/annex/objects``, so content stays recoverable until ``git annex
+unused``/gc, on both branch types.
+
+§8 In recursive operation (``--recursive``) the default resolves ``TARGET``
+**independently in each dataset** -- a local operation with no cross-dataset
+following. ``HEAD`` means each dataset's own ``HEAD`` (i.e. discard each
+dataset's tracked changes in place); ``origin/main`` means each dataset's own
+``origin/main``. This presumes a ``TARGET`` that names a *current state* present
+in every dataset (``HEAD``, a branch, a tag, a remote-tracking ref); a *history
+coordinate* -- a SHA or ``HEAD~N`` -- has no such per-dataset meaning and is
+instead handled by ``--follow=parentds`` (§9, detailed in §11--§12).
+
+§9 ``--follow=parentds`` opts into the alternative: the superdataset resets to
+``TARGET``, and each subdataset resets to the revision the (reset) super
+*records* for it. The superdataset is reset first, so the recorded revisions
+are current. Use this to reconcile an intentionally out-of-sync hierarchy to
+the superdataset's pins.
+
+§10 The default mode of ``--follow`` is deliberately **not** named ``sibling`` (as in
+:command:`update`): :command:`reset` is primarily a local operation that
+resolves the user's target per dataset, which *generalizes*
+:command:`update`'s sibling semantics (they coincide only for tracking-ref
+targets such as ``origin/main``). The meaningful axis is parent-authority
+(``--follow=parentds``) versus each-dataset-resolves-the-target (default), so
+the default is left unnamed -- it is the absence of following.
+
+§11 A raw commit SHA is a parent-history coordinate with no meaning under
+per-dataset local resolution. A SHA ``TARGET`` combined with ``--recursive``
+therefore requires ``--follow=parentds`` to be set explicitly; otherwise the
+command refuses with an ``impossible`` result whose message hints that, to
+reset each subdataset to the revision the super records, the user should add
+``--follow=parentds``.
+
+§12 A relative target (``HEAD~N``) is, like a SHA (§11), a coordinate in *this*
+dataset's history, so under ``--recursive`` it likewise requires
+``--follow=parentds`` -- the superdataset resolves it and each subdataset
+follows the recorded revision; without it the command refuses with the same
+hint. Plain ``HEAD`` (no offset) is exempt: it moves no history and is resolved
+per dataset in the default mode (each dataset discards its own working-tree
+changes, see §8).
+
+§13 :command:`reset` shares its reset engine with :command:`update`'s
+``--how=reset`` (both must reset the corresponding branch and reconcile
+``synced/`` on adjusted branches). The shared engine is a *pure* hard reset:
+it always discards, like ``git reset --hard``, and does not inspect the working
+tree. :command:`update` keeps its stricter contract of refusing a dirty tree by
+guarding for that itself, before delegating to the engine; :command:`reset`
+does not (§6), so :command:`update`'s behavior is unchanged.
+
+Use cases
+=========
+
+The use cases below operate on a superdataset `super` with one subdataset
+`sub`; `super` has a sibling ``origin``. Unless stated otherwise, commands are
+run in the root of `super`. Per the governing principle (§2), only the
+normal-branch behavior is stated; on an adjusted branch the same applies to the
+corresponding branch, with the view regenerated. U1-U3 are specifically the new
+capability on an adjusted branch -- on a normal branch the same behavior is
+achieved with ``git reset --hard``.
+
+- U1: ``datalad reset origin/main`` (adjusted branch)
+
+  Reset the current branch to the sibling's branch, discarding local commits
+  (equivalent to ``git reset --hard origin/main``).
+
+- U2: ``datalad reset`` (adjusted branch)
+
+  Default ``TARGET`` is ``HEAD``: discard tracked uncommitted/staged changes,
+  keeping untracked files and all commits.
+
+- U3: ``datalad reset HEAD~2`` (adjusted branch)
+
+  Discard the last two commits of the current branch.
+
+- U4: ``datalad reset HEAD -r``
+
+  Discard tracked changes in `super` and `sub`; each dataset stays on its own
+  ``HEAD`` (`sub`'s local commits are kept).
+
+- U5: ``datalad reset HEAD -r --follow=parentds``
+
+  Leave `super` where it is and reset `sub` to the revision `super` records for
+  it -- discarding `sub`'s committed divergence to snap it back to the pin.
+
+- U6: ``datalad reset <SHA> -r``
+
+  Error: a raw SHA has no per-subdataset meaning; the message hints at adding
+  ``--follow=parentds``.
+
+- U7: ``datalad reset <SHA> -r --follow=parentds``
+
+  Reset `super` to ``<SHA>`` and reset `sub` to the revision that commit records
+  for it.
+
+- U8: ``datalad reset HEAD~1 -r --follow=parentds``
+
+  Reset `super` to its ``HEAD~1`` and reset `sub` to the revision that commit
+  records for it -- as in U7, since a relative ref is, like a SHA, a coordinate
+  in `super`'s history. (Without ``--follow=parentds`` this is refused, just
+  like the bare-SHA U6.)
+
+- U9: ``datalad reset origin/main -r``
+
+  Each dataset resets to its own ``origin/main`` (the target is resolved locally
+  in `super` and in `sub`).
+
+- U10: ``datalad reset <branch> -r``
+
+  Each dataset resets to its own local ``<branch>`` (default per-dataset
+  resolution, as in U9). This brings an entire superdataset hierarchy onto a
+  shared working branch in a single command -- useful in the nested git-worktree
+  workflow, where the branch produced in each worktree otherwise has to be
+  shipped back by hand, one dataset at a time (see the `git-worktree workflow
+  post <https://blog.datalad.org/posts/git-worktree-workflow/>`__).


### PR DESCRIPTION
- Closes #7872, #7878, #7782.

The new command `datalad reset` adds two new functionalities: 

- correct `git reset --hard` behavior on adjusted branches, e.g., Windows / crippled FS
- reset a whole dataset hierarchy, either with the target resolved independently or following the parent (on both normal and adjusted branches)

An annexed repo is forced onto the unlocked adjusted branch by default on a crippled FS. However, a plain `git reset --hard` on an adjusted branch only resets the *view* without touching the real history. Upon the next `git annex sync` (routinely exercised by `save`/ `update` / `push`),  the discarded commit resurrects (via the underlying `refs/basis/<adjusted>` for `save` or the `synced/` branch otherwise), and worse: new work is permanently lost upon subsequent `datalad save` (see #7872). 

The cure is to reset the *corresponding* branch, reconcile the synced branch (to prevent resurrection, see #7772), and force-rebuild the *view* from the *corresponding* branch (which automatically reconciles the `refs/basis/<adjusted>` as well). In the core, it is the same workaround I suggested in #7782 and applied to BF #7881.

**Note: this PR is stacked on #7881 (`update --how=reset` and `reset` naturally share the same reset engine), please merge that one first.**

In addition, `-r/--recursive` provides a convenient way to reset across a whole hierarchy. This is useful if you want to reset a nested worktree to the main worktree, reset the hierarchy to a tag/sibling, get a clean state everywhere, or reset subdatasets to the pointers recorded by the superdataset (if they are deliberately out of sync).

### Testing / Highlights
The main effort of this PR was invested in writing tests that cover different branch / FS modes: normal, adjusted, and crippled. Tests are only skipped per leg, e.g., normal is skipped on a crippled FS. All three legs run on Linux with the limitation that the crippled mode is only simulated and fails to capture the crippled FS faithfully for a history-moving reset whose target retains annexed content (-> XFAIL on Linux, PASS on Windows).

I verified all tests on both Linux AND Windows.

### AI-in-the-loop
I designed the command; Claude wrote the prose for the design doc. Claude drafted both tests and production code; I rewrote or refined all tests and accepted the final version of Claude's production code unmodified. I managed the commit history; Claude assisted with the prose. I reviewed all code and prose. Claude wrote the changelog; I wrote this PR.