### PR TITLE
NF: avoid crash on get_toppath  - return `None` on non-existing path

### DIFF
--- a/changelog.d/20260701_091428_lgray95_bf_get_toppath_crash.md
+++ b/changelog.d/20260701_091428_lgray95_bf_get_toppath_crash.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- `get_toppath()` now returns `None` instead of crashing with `TypeError` when
+  called on a path whose existence can't be verified (e.g. a broken symlink or
+  a nonexistent directory).  Discovered while investigating
+  [#7882](https://github.com/datalad/datalad/issues/7882).
+  (by [@LiamDGray](https://github.com/LiamDGray))

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1228,6 +1228,8 @@ class GitRepo(CoreGitRepo):
         except OSError:
             toppath = GitRepo.get_toppath(dirname(path), follow_up=follow_up,
                                           git_options=git_options)
+            if toppath is None:
+                return None
 
         # normalize the report, because, e.g. on windows it can come out
         # with improper directory separators (C:/Users/datalad)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -796,6 +796,16 @@ def test_GitRepo_get_toppath(repo=None, tempdir=None, repo2=None):
     eq_(GitRepo.get_toppath(tempdir), None)
 
 
+def test_GitRepo_get_toppath_nonexistent():
+    # gh-7882: get_toppath with a nonexistent path should return None,
+    # not crash with TypeError when the OSError recursion reaches root
+    # without finding any parent .git
+    eq_(GitRepo.get_toppath(
+        '/tmp/__datalad_crash_test__/a/b/c/d', follow_up=True), None)
+    eq_(GitRepo.get_toppath(
+        '/tmp/__datalad_crash_test__/a/b/c/d', follow_up=False), None)
+
+
 @with_tempfile(mkdir=True)
 def test_GitRepo_dirty(path=None):
 

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -800,10 +800,12 @@ def test_GitRepo_get_toppath_nonexistent():
     # gh-7882: get_toppath with a nonexistent path should return None,
     # not crash with TypeError when the OSError recursion reaches root
     # without finding any parent .git
-    eq_(GitRepo.get_toppath(
-        '/tmp/__nonexisting__/a/b/c/d', follow_up=True), None)
-    eq_(GitRepo.get_toppath(
-        '/tmp/__nonexisting__/a/b/c/d', follow_up=False), None)
+    import tempfile
+    unique_base = tempfile.mkdtemp()
+    os.rmdir(unique_base)
+    nonexistent = op.join(unique_base, 'a', 'b', 'c', 'd')
+    eq_(GitRepo.get_toppath(nonexistent, follow_up=True), None)
+    eq_(GitRepo.get_toppath(nonexistent, follow_up=False), None)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -801,9 +801,9 @@ def test_GitRepo_get_toppath_nonexistent():
     # not crash with TypeError when the OSError recursion reaches root
     # without finding any parent .git
     eq_(GitRepo.get_toppath(
-        '/tmp/__datalad_crash_test__/a/b/c/d', follow_up=True), None)
+        '/tmp/__nonexisting__/a/b/c/d', follow_up=True), None)
     eq_(GitRepo.get_toppath(
-        '/tmp/__datalad_crash_test__/a/b/c/d', follow_up=False), None)
+        '/tmp/__nonexisting__/a/b/c/d', follow_up=False), None)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -796,13 +796,11 @@ def test_GitRepo_get_toppath(repo=None, tempdir=None, repo2=None):
     eq_(GitRepo.get_toppath(tempdir), None)
 
 
-def test_GitRepo_get_toppath_nonexistent():
+@with_tempfile
+def test_GitRepo_get_toppath_nonexistent(unique_base=None):
     # gh-7882: get_toppath with a nonexistent path should return None,
     # not crash with TypeError when the OSError recursion reaches root
     # without finding any parent .git
-    import tempfile
-    unique_base = tempfile.mkdtemp()
-    os.rmdir(unique_base)
     nonexistent = op.join(unique_base, 'a', 'b', 'c', 'd')
     eq_(GitRepo.get_toppath(nonexistent, follow_up=True), None)
     eq_(GitRepo.get_toppath(nonexistent, follow_up=False), None)


### PR DESCRIPTION
When get_toppath() is called on a nonexistent path, the OSError handler recurses to parent directories via dirname(). If no ancestor has a .git, the recursive call returns None, and str(Path(None)) raises TypeError.

Fix: return None early when the OSError fallback also returns None.

This is an invited (by @yarikoptic) follow-up to the gh-7882 symlinked-dataset fix: the OSError handler's upward walk was what caused the wrong parent .git to be found when the original path was a broken symlink.