### PR TITLE
DEP: bump minimum Git version 2.25.0 -> 2.31.0

### DIFF
--- a/changelog.d/pr-7887.md
+++ b/changelog.d/pr-7887.md
@@ -1,0 +1,13 @@
+### 🔩 Dependencies
+
+- Bump minimum required Git version from 2.25.0 to 2.31.0.  The `-c
+  key=value` config-override propagation to subprocesses added in
+  [PR #7858](https://github.com/datalad/datalad/pull/7858) relies on
+  Git's `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>`
+  environment mechanism, which was introduced in Git 2.31.0 (2021-03).
+  On older Git the CLI override was silently ignored.  This bump makes the
+  requirement explicit at startup rather than manifesting as a silent
+  feature loss.  Git 2.31 is available on all currently-supported LTS
+  distributions.
+  Via [PR #7887](https://github.com/datalad/datalad/pull/7887)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -75,12 +75,12 @@ from datalad.consts import (
     RESERVED_NAMES_WIN,
 )
 from datalad.core.local.repo import repo_from_path
-from datalad.dochelpers import single_or_plural
 from datalad.dataset.gitrepo import GitRepo as CoreGitRepo
 from datalad.dataset.gitrepo import (
     _get_dot_git,
     path_based_str_repr,
 )
+from datalad.dochelpers import single_or_plural
 from datalad.log import log_progress
 from datalad.support.due import (
     Doi,
@@ -819,7 +819,7 @@ class GitRepo(CoreGitRepo):
     # should do it once
     _config_checked = False
 
-    GIT_MIN_VERSION = "2.25.0"
+    GIT_MIN_VERSION = "2.31.0"
     git_version = None
 
     @classmethod


### PR DESCRIPTION
PR #7858's `-c key=value` config-override propagation uses Git's `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_<n>`/`GIT_CONFIG_VALUE_<n>` env mechanism, introduced in Git 2.31.0.  On Git < 2.31 the CLI override was silently a no-op.  Make the requirement explicit at startup rather than manifesting as feature loss.

tools/ci/install-minimum-git.sh already extracts the value from GIT_MIN_VERSION, so the `cron-only` minimum-git leg (which has been failing `test_cfg_override` + `test_cli_configoverrides` every day since 2026-05-14) automatically retargets to 2.31.0 without further CI changes.

Distro impact is narrow: among currently-supported LTSes, only Debian bullseye (oldoldstable, git 1:2.30.2-1+deb11u5) sits below the new floor, and its LTS support window closes soon (2026-08).  Every other supported distro (bookworm 2.39, Ubuntu 22.04 2.34, Ubuntu 24.04 2.43, RHEL 9 2.39) is well above 2.31.

git-annex's own Git floor is unchanged and independent (`git >= 2.22` in both our declared minimum annex 10.20230126 and the latest 10.20260624), so this bump is strictly stricter than what our annex requires.
