### PR TITLE
BF: create-sibling - don't require git-annex on target for no-annex datasets

### DIFF
--- a/changelog.d/pr-7888.md
+++ b/changelog.d/pr-7888.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- `create-sibling` no longer requires `git-annex` on the target (remote or local) when the source dataset is a plain-git dataset (`--no-annex`, i.e. marked with a `.noannex` file).  Previously it errored out with `No working git-annex installation. It's required on the remote machine to create a sibling` even though no annex functionality would be used.  Via [PR #7888](https://github.com/datalad/datalad/pull/7888) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/distribution/create_sibling.py
+++ b/datalad/distribution/create_sibling.py
@@ -780,10 +780,19 @@ class CreateSibling(Interface):
         # TODO: centralize and generalize template symbol handling
         replicate_local_structure = "%RELNAME" not in target_dir
 
-        if not shell.get_annex_version():
+        # git-annex is only needed if any of the local datasets to process
+        # is a git-annex repository.  Plain-git datasets (e.g. created with
+        # --no-annex, marked by a .noannex file) can be sibling-ed onto a
+        # remote that has no git-annex installed.
+        any_annex = any(
+            isinstance(Dataset(cd['path']).repo, AnnexRepo)
+            for cd in to_process
+        )
+        if any_annex and not shell.get_annex_version():
             raise MissingExternalDependency(
                 'git-annex',
                 msg="It's required on the {} machine to create a sibling"
+                    " for a git-annex enabled dataset"
                     .format('remote' if ssh_sibling else 'local'))
 
         #

--- a/datalad/distribution/tests/test_create_sibling.py
+++ b/datalad/distribution/tests/test_create_sibling.py
@@ -19,6 +19,7 @@ from os.path import (
     exists,
 )
 from os.path import join as opj
+from unittest.mock import patch
 
 import pytest
 
@@ -890,6 +891,31 @@ def test_local_path_target_dir(path=None):
         sshurl=str(path / "e"), target_dir="d%RELNAME")
     ok_((path / "e" / "d").exists())
     ok_((path / "e" / "d-subds").exists())
+
+
+@skip_if_on_windows
+@with_tempfile(mkdir=True)
+def test_no_annex_no_remote_annex_required(path=None):
+    # A plain-git (no-annex) dataset should not require git-annex on the
+    # target machine to create a sibling.  Regression test: previously,
+    # create-sibling unconditionally checked for git-annex presence and
+    # errored out even for datasets without annex.
+    path = Path(path)
+    ds = Dataset(path / "src").create(annex=False)
+    ok_((ds.pathobj / ".noannex").exists())
+
+    with patch.object(_RunnerAdapter, "get_annex_version", return_value=""):
+        # plain-git dataset: works without annex on the target
+        ds.create_sibling(name="plain", sshurl=str(path / "target-plain"))
+        ok_((path / "target-plain").exists())
+
+        # annex dataset: still errors when target lacks git-annex
+        ds_annex = Dataset(path / "annex").create()
+        assert_raises(
+            Exception,
+            ds_annex.create_sibling,
+            name="annex", sshurl=str(path / "target-annex"),
+        )
 
 
 @slow  # 12sec on Yarik's laptop


### PR DESCRIPTION
Previously `create-sibling` unconditionally checked for a `git-annex` installation on the target (remote via SSH or local path) and errored out with

    No working git-annex installation.
    It's required on the remote machine to create a sibling

even when the source dataset was a plain-git dataset (created with `--no-annex`, marked by a `.noannex` file) and thus wouldn't invoke any git-annex operations on the target.

Guard the check with a scan of the datasets to process: only require git-annex on the target when at least one of them is an `AnnexRepo`.

