### PR TITLE
DOC: document 'make -C docs html doctest' in CONTRIBUTING Quick Reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,9 @@ pytest --cov=datalad path/to/tests                          # with coverage
 tox -e lint                   # codespell + pylint
 tox -e typing                 # mypy
 make code-analysis            # flake8 + pylint
+
+# Docs
+make -C docs html doctest     # build HTML docs + run doctests
 ```
 
 ## Files organization


### PR DESCRIPTION
Documents the docs build in CONTRIBUTING: adds `make -C docs html doctest` to the Quick Reference, and should be run before pushing only when a change touches rendered content (a docstring, or `.rst`/`.rst.in` under `docs/`) — so contributors catch docstring/RST errors locally instead of when the docs CI goes red.
