### PR TITLE
RF: exclude local jj/venv dirs from codespell scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ include = ["datalad*"]
 version = { attr = "datalad.__version__" }
 
 [tool.codespell]
-skip = '.venv,venvs,.git,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem,trash,dist,.cache,.npm,,.local,.duct'
+skip = '.venv,venvs,venv,.git,.jj,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem,trash,dist,.cache,.npm,,.local,.duct'
 check-hidden = true
 # commitish - vote if we want to fix (should be committish) -- used in GitRepo API
 # froms - plural "from" introduced by export_archive_ora


### PR DESCRIPTION
Adds `.jj` and `venv` to codespell's `skip` list in `pyproject.toml`. Both otherwise produce a flood of false positives and binary-decode warnings when running `tox -e lint` locally, even though they are gitignored (codespell honors its own skip list, not `.gitignore`).
