### PR TITLE
BF: nested datalad run - fix crash when command commits in a subdataset below a plain dir

### DIFF
--- a/changelog.d/pr-7904.md
+++ b/changelog.d/pr-7904.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- `run` no longer crashes with `'NoneType' object has no attribute 'get_hexsha'` when the command creates a commit in a subdataset reached through an ordinary directory (e.g. `dataset/plaindir//subds`).  Saving such a result treated plaindirs as datasets, and caused the outer datalad commit to fail.  Introduced with the new `datalad run` behavior in [PR #7821](https://github.com/datalad/datalad/pull/7821).  Via [PR #7904](https://github.com/datalad/datalad/pull/7904) (by [@asmacdo](https://github.com/asmacdo))

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -75,8 +75,12 @@ def _parent_ds_path(path, ds_path):
 
     Returns None when `path` is not underneath `ds_path` -- which
     `_parse_sub_status` from ``git submodule status --recursive`` never
-    produces, but a future caller might.
+    produces, but a future caller might.  Checked up front, so a stray
+    path that happens to sit inside some *other* dataset does not send
+    the walk climbing an unrelated hierarchy.
     """
+    if not ut.Path(path).is_relative_to(ds_path):
+        return None
     parent = ut.Path(path).parent
     while True:
         parent_path = str(parent)

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -65,6 +65,31 @@ def _status_props(result):
     return {k: v for k, v in result.items() if k not in _STATUS_SKIP_KEYS}
 
 
+def _parent_ds_path(path, ds_path):
+    """Nearest ancestor of `path` that is a dataset, at or under `ds_path`
+
+    A subdataset need not be a direct child of its superdataset -- plain
+    directories can sit in between (``study/derivatives/thing``).  Those
+    have no repo, hence no HEAD, and must be skipped rather than treated
+    as datasets.
+
+    Returns None when `path` is not underneath `ds_path` -- which
+    `_parse_sub_status` from ``git submodule status --recursive`` never
+    produces, but a future caller might.
+    """
+    parent = ut.Path(path).parent
+    while True:
+        parent_path = str(parent)
+        if parent_path == ds_path:
+            return parent_path
+        if parent == parent.parent:
+            # filesystem root reached without hitting ds_path
+            return None
+        if Dataset(parent_path).repo is not None:
+            return parent_path
+        parent = parent.parent
+
+
 def _inject_sub_info(paths_by_ds, since_map, _since_sub_info, ds_path):
     """Inject changed subdatasets that diff_dataset missed on adjusted branches.
 
@@ -91,22 +116,16 @@ def _inject_sub_info(paths_by_ds, since_map, _since_sub_info, ds_path):
             paths_by_ds[sub_path] = {}
 
         # Walk up to ds_path, registering each child as modified in
-        # its parent and ensuring since_map entries exist at each level.
-        # Termination: normally `parent_path == ds_path`.  Defensive
-        # second termination on `parent_path == child_path` covers the
-        # case where `sub_path` is not a descendant of `ds_path` (which
-        # `_parse_sub_status` from `git submodule status --recursive`
-        # never produces, but a future caller might) — without it,
-        # `Path('/').parent == Path('/')` would loop forever.
+        # its parent dataset and ensuring since_map entries exist at
+        # each level.
         child_path = sub_path
-        while True:
-            parent_path = str(ut.Path(child_path).parent)
-            if parent_path == child_path:
+        while child_path != ds_path:
+            parent_path = _parent_ds_path(child_path, ds_path)
+            if parent_path is None:
                 lgr.debug("sub %s not under ds %s; aborting ancestor walk",
                           sub_path, ds_path)
                 break
-            child_repo = Dataset(child_path).repo
-            child_sha = child_repo.get_hexsha() if child_repo else cur_sha
+            child_sha = Dataset(child_path).repo.get_hexsha()
             child_pre = _since_sub_info.get(child_path, child_sha)
 
             pds_status = paths_by_ds.setdefault(parent_path, {})
@@ -119,8 +138,6 @@ def _inject_sub_info(paths_by_ds, since_map, _since_sub_info, ds_path):
                     parent_path,
                     Dataset(parent_path).repo.get_hexsha())
 
-            if parent_path == ds_path:
-                break
             child_path = parent_path
 
 

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -1235,6 +1235,32 @@ def test_run_merge_three_levels(path=None):
     ok_((leaf.pathobj / "foo").exists())
 
 
+# On adjusted branches `git annex sync` propagates a submodule pointer
+# update to the corresponding branch only for submodules at the repo's
+# top level; one nested under a directory (`derivatives/thing`) is left
+# behind, so the super keeps reporting the sub as modified.  Reproduced
+# with plain git/git-annex, no datalad involved, on both 10.20250630 and
+# 10.20260717.
+@known_failure_windows  # git-annex: nested submodule pointer not propagated
+@with_tempfile(mkdir=True)
+@pytest.mark.ai_generated
+def test_run_merge_sub_under_plain_dir(path=None):
+    """Sub nested under a plain directory -> merges in sub and super."""
+    ds = Dataset(path).create()
+    # not a direct child: `derivatives` is a plain directory
+    sub = ds.create(op.join("derivatives", "thing"))
+    assert_repo_status(ds.path)
+
+    ds.run('cd derivatives/thing && ' + touch_command + 'foo'
+           + ' && git add foo && git commit -m "inner"')
+    assert_repo_status(ds.path)
+
+    _assert_run_merge(sub)
+    _assert_run_merge(ds)
+
+    ok_((sub.pathobj / "foo").exists())
+
+
 @with_tempfile(mkdir=True)
 @pytest.mark.ai_generated
 def test_run_merge_no_subdataset_change(path=None):

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -1235,16 +1235,9 @@ def test_run_merge_three_levels(path=None):
     ok_((leaf.pathobj / "foo").exists())
 
 
-# On adjusted branches `git annex sync` propagates a submodule pointer
-# update to the corresponding branch only for submodules at the repo's
-# top level; one nested under a directory (`derivatives/thing`) is left
-# behind, so the super keeps reporting the sub as modified.  Reproduced
-# with plain git/git-annex, no datalad involved, on both 10.20250630 and
-# 10.20260717.
-@known_failure_windows  # git-annex: nested submodule pointer not propagated
 @with_tempfile(mkdir=True)
 @pytest.mark.ai_generated
-def test_run_merge_sub_under_plain_dir(path=None):
+def test_run_merge_sub_under_plain_dir(path=None, *, request):
     """Sub nested under a plain directory -> merges in sub and super."""
     ds = Dataset(path).create()
     # not a direct child: `derivatives` is a plain directory
@@ -1253,12 +1246,21 @@ def test_run_merge_sub_under_plain_dir(path=None):
 
     ds.run('cd derivatives/thing && ' + touch_command + 'foo'
            + ' && git add foo && git commit -m "inner"')
-    assert_repo_status(ds.path)
 
     _assert_run_merge(sub)
     _assert_run_merge(ds)
-
     ok_((sub.pathobj / "foo").exists())
+
+    if ds.repo.is_managed_branch():
+        # On adjusted branches `git annex sync` propagates a submodule
+        # pointer update to the corresponding branch only for submodules at
+        # the repo's top level, so the super keeps reporting this one
+        # modified.
+        # https://github.com/datalad/datalad/issues/7905
+        request.node.add_marker(pytest.mark.xfail(
+            strict=True,
+            reason="git-annex: nested submodule pointer not propagated"))
+    assert_repo_status(ds.path)
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/core/local/tests/test_save.py
+++ b/datalad/core/local/tests/test_save.py
@@ -21,6 +21,7 @@ from datalad.api import (
     install,
     save,
 )
+from datalad.core.local.save import _parent_ds_path
 from datalad.core.local.tests.test_run import (
     _assert_run_merge,
     _merge_ref,
@@ -1413,3 +1414,27 @@ def test_check_for_openfiles_invalid_config(tmp_path):
     ):
         with assert_raises(ValueError):
             ds.repo._check_for_openfiles({'dummy.txt': {}}, 'bogus')
+
+
+@pytest.mark.ai_generated
+def test_parent_ds_path(tmp_path):
+    """_parent_ds_path finds the nearest dataset ancestor, and stays inside ds"""
+    root = Dataset(str(tmp_path / 'root')).create()
+    # `plaindir` is an ordinary directory, not a dataset
+    mid = root.create(op.join('plaindir', 'mid'))
+    leaf = mid.create('leaf')
+    stray = Dataset(str(tmp_path / 'stray')).create()
+
+    # the plain directory in between is skipped, not mistaken for a dataset
+    eq_(_parent_ds_path(mid.path, root.path), root.path)
+    # a dataset ancestor below the reference dataset is honored
+    eq_(_parent_ds_path(leaf.path, root.path), mid.path)
+    # the reference dataset itself terminates the walk
+    eq_(_parent_ds_path(str(root.pathobj / 'plaindir'), root.path), root.path)
+
+    # a path that is not underneath the reference dataset yields None
+    eq_(_parent_ds_path(str(tmp_path / 'nowhere' / 'leaf'), root.path), None)
+    # ... including when it sits inside some *other* dataset, which must not
+    # send the walk climbing an unrelated hierarchy
+    eq_(_parent_ds_path(str(stray.pathobj / 'plaindir' / 'leaf'), root.path),
+        None)


### PR DESCRIPTION
When using the new `datalad run` functionality in 1.6+ and both conditions met: 
 - condition 1: subdatasets are separated by a plaindir (non-dataset), ie `root/plaindir//subrepo`,
 - condition 2: the command commits (ie datalad run)
 
The inner datalad run works, and is committed to the leaf, and the root.
The outer datalad run crashes, so its commit is missing from the root. 
`[ERROR  ] 'NoneType' object has no attribute 'get_hexsha' `

```
datalad run "datalad run \"echo 'broke' > plaindir/subrepo/t2\""
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) ===== 
run(ok): /tmp/datalad-run-byREmV (dataset) [echo 'broke' > plaindir/subrepo/t2]
add(ok): t2 (file)                                                                                            
save(ok): plaindir/subrepo (dataset)                                                                          
add(ok): plaindir/subrepo (dataset)                                                                           
add(ok): .gitmodules (file)                                                                                   
save(ok): . (dataset)                                                                                         
[INFO   ] == Command exit (modification check follows) =====                                                  
run(ok): /tmp/datalad-run-byREmV (dataset) [datalad run "echo 'broke' > plaindir/sub...]
[ERROR  ] 'NoneType' object has no attribute 'get_hexsha' 
```

It can also leave the root repo dirty, if the command commits but doesnt propagate the commit.

## Detailed Reproducer 

<details>
<summary>script</summary>

```console
# datalad run: crash when the command commits in a subdataset below a plain directory
#   root / plaindir // subrepo     //  dataset boundary, /  ordinary directory
# Run with a datalad that still has the bug (1.6.0 - 1.6.2, or master before the fix).
# No `set -e`: both `datalad run` calls are EXPECTED to fail.
export PS4='> '
set -xu
cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-nested-XXXXXXX)"

datalad create -c text2git root
datalad create -c text2git -d root root/plaindir/subrepo
cd root

# 1. nested run: inner run saves the whole chain, so only the OUTER record is lost
datalad run "datalad run \"echo 'broke' > plaindir/subrepo/t2\""
git log --oneline -1
datalad status -r

# 2. bare commit: nothing saves upward, so no run record at either level
datalad run -m outer -- git -C plaindir/subrepo commit --allow-empty -m inner
git log --all --grep=RUNCMD --oneline
datalad status -r
```
</details>

## Proposed change

`_inject_sub_info` now climbs to the nearest **dataset** ancestor instead of the immediate parent directory, via a new `_parent_ds_path` helper.  Plain directories in between are skipped rather than treated as datasets. 

<details>
<summary>Claude Details</summary>

The merge-commit machinery walks up by directory and assumes every ancestor is a dataset; a plain directory in the chain has no repo, so asking it for its HEAD raises.

```
[ERROR] 'NoneType' object has no attribute 'get_hexsha'
  File "datalad/core/local/save.py", line 120, in _inject_sub_info
    Dataset(parent_path).repo.get_hexsha())
```

The walk exists to record, at every level between the changed subdataset and the run's dataset, that a child moved. It stepped by filesystem parent and asked each stop for its HEAD, which only holds if every subdataset is a direct child of its superdataset.

Two further points on the change itself: the `child_repo ... else cur_sha` fallback is dropped, since with plain directories skipped every step of the walk is a dataset, and that fallback was only ever reached for the plain-directory case where it substituted the changed subdataset's own SHA for the directory. `_parent_ds_path` returning `None` absorbs the old defensive "not a descendant" loop termination.

### Which layouts are affected

Writing `//` for a dataset boundary and `/` for an ordinary directory:

| layout | affected |
| --- | --- |
| `root//leaf` | no |
| `root//mid//leaf` | no |
| `root/plaindir//leaf` | **yes** |
| `root//mid/plaindir//leaf` | **yes** |

Extra dataset levels are not the problem; a single ordinary directory anywhere in the chain is enough. This is why existing coverage missed it: the tests exercise a direct child and an all-datasets three-level chain, but never a plain directory in between.

### What it leaves behind

The run always exits 1, but how much is lost depends on what the command did.

In the nested-run case, the inner run saves the whole chain on its way out, so the working tree ends **clean** and the only casualty is the outer run's record: every run record present describes the *inner* command. Because the outer command was a pure wrapper, that record still happens to describe the net effect, which makes the failure easy to dismiss as noise. It is not: the point of the run-merge is that the first-parent chain reads as one commit per `run`, and here the mainline ends up describing something the user never typed.

With the fix, that nested run exits 0, the root's mainline records the outer command, and the inner run's own record is preserved on the merge's second parent:

```console
$ git log --first-parent --oneline -2
e4fcd2c [DATALAD RUNCMD] datalad run "echo 'broke' > plaindir/sub...
a77eda0 [DATALAD] Created subdataset

$ git log --oneline HEAD^2 -2
0453193 Remaining changes after command execution
7c555fa [DATALAD RUNCMD] echo 'broke' > plaindir/subrepo/t2
```

### Affected versions

Present in 1.6.0, 1.6.1, 1.6.2 and current `maint` / `master`.
Introduced by #7821: `6dfa285bd` added the walk with a guard on the HEAD lookup, and `69f1530ea` two days later removed that guard, turning a latent wrong-data path into a hard crash.
Restoring the guard alone would not be correct, since the walk would still enter plain directories into the save plan as datasets.

### Verification

- New test fails without the fix and passes with it.
- `datalad/core/local/tests/test_run.py` + `test_save.py`: 78 passed, 3 skipped, 1 xfailed.
- `datalad/local/tests/test_rerun.py`: 21 passed, 1 xfailed.
- Green against both git-annex 10.20250630 and 10.20260717.
- Checked end to end that the run now produces merge commits at both levels, a run record on the superdataset, and a clean recursive status, including with three plain directories in the chain.

</details>

## Known limitation on adjusted branches

Testing this led to finding another bug #7905, so I was not able to fully test crippled filesystem. (On adjusted branches, I've marked that test as xfail) 

