### PR TITLE
BF+DOC: make rerun fail like run does, and document exit-code handling

### DIFF
--- a/changelog.d/pr-7906.md
+++ b/changelog.d/pr-7906.md
@@ -1,0 +1,3 @@
+### 📝 Documentation
+
+- BF+DOC: make rerun fail like run does, and document exit-code handling.  Fixes [#6427](https://github.com/datalad/datalad/issues/6427) via [PR #7906](https://github.com/datalad/datalad/pull/7906) (by [@yarikoptic-gitmate](https://github.com/yarikoptic-gitmate))

--- a/changelog.d/pr-7906.md
+++ b/changelog.d/pr-7906.md
@@ -1,3 +1,8 @@
-### 📝 Documentation
+### 🐛 Bug Fixes
 
-- BF+DOC: make rerun fail like run does, and document exit-code handling.  Fixes [#6427](https://github.com/datalad/datalad/issues/6427) via [PR #7906](https://github.com/datalad/datalad/pull/7906) (by [@yarikoptic-gitmate](https://github.com/yarikoptic-gitmate))
+- `rerun` now fails the same way as `run`: it does not re-execute a command
+  whose inputs could not be obtained, and does not save the results of a
+  re-execution whose exit code differs from the recorded one.  Also documents
+  how the recorded exit code is handled by both commands.
+  [PR #7906](https://github.com/datalad/datalad/pull/7906)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -129,6 +129,20 @@ class Run(Interface):
     input or output preparation. This default ``stop`` behavior can be
     overridden via [CMD: --on-failure ... CMD][PY: `on_failure=...` PY].
 
+    || REFLOW >>
+    The exit code of the command is always part of the run record (``exit``
+    field), also when it is zero. With
+    [CMD: --on-failure ignore CMD][PY: `on_failure='ignore'` PY] a non-zero
+    exit does not prevent the modifications from being saved, and the
+    resulting provenance record is a regular run record that carries that
+    exit code. Like any other run, this requires the command to have
+    actually modified the dataset -- a command that leaves the dataset
+    unmodified is not recorded, whether it failed or not.
+    :command:`datalad rerun` compares the exit code of a re-execution against
+    the recorded one, see that command's documentation for the exact
+    semantics.
+    << REFLOW ||
+
     In the presence of subdatasets, the full dataset hierarchy will be checked
     for unsaved changes prior command execution, and changes in any dataset
     will be saved after execution. Any modification of subdatasets is also

--- a/datalad/local/rerun.py
+++ b/datalad/local/rerun.py
@@ -414,11 +414,16 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
             rerun_dsid = res["run_info"].get("dsid")
             if rerun_dsid is not None and rerun_dsid != dset.id:
                 skip_or_pick(hexsha, res, "was ran from a different dataset")
-                # not a failure: the commit is cherry picked or skipped
-                # rather than re-executed, which is the correct outcome
-                # here.  Reporting it as such also keeps a range replay
-                # going, rather than aborting it under the command's
-                # 'stop' on_failure default.
+                # `run` duplicates its record into every modified
+                # subdataset, so a subdataset's history can contain run
+                # commits recorded by the superdataset.  Such a commit is
+                # cherry picked or skipped instead of being re-executed
+                # here -- the correct outcome, hence 'notneeded' and not
+                # 'impossible'.  This also matters for the 'stop'
+                # on_failure default above: it is dispatched on status
+                # alone, so an 'impossible' here would abort a range
+                # replay (`--since=`) at the first such commit instead of
+                # continuing with the ones this dataset can re-execute.
                 res["status"] = "notneeded"
             else:
                 res["rerun_action"] = "run"
@@ -619,8 +624,11 @@ def _report(dset, results):
     ds_repo = dset.repo
     for res in results:
         if "run_info" in res:
-            # no "diff" for records that will not be re-executed
-            # (e.g. recorded in a different dataset)
+            # only records that will be re-executed have a "diff" (it is
+            # set right next to the 'notneeded' above).  This used to be
+            # tested as status != "impossible", which was merely a proxy
+            # for the same condition and stopped holding when that status
+            # became 'notneeded'.
             if "diff" in res:
                 res["diff"] = list(res["diff"])
                 # Add extra information that is useful in the report but not

--- a/datalad/local/rerun.py
+++ b/datalad/local/rerun.py
@@ -71,18 +71,12 @@ class Rerun(Interface):
     matches the one recorded in the run record. A command that is on record to
     have exited non-zero (see :command:`datalad run`) is therefore reported as
     "ok" when it fails again in the same way, and as "error" when it exits with
-    a different non-zero code. A re-execution that exits with 0 is always
+    a different non-zero code -- in which case, as for :command:`datalad run`,
+    no modifications are saved. A re-execution that exits with 0 is always
     considered successful, also when the record has a non-zero exit code; such
     a change in behavior can only be detected by comparing the ``exit`` field
     of the new run record with that of the record it was derived from (the last
     entry of its ``chain``).
-    << REFLOW ||
-
-    || REFLOW >>
-    Unlike :command:`datalad run`, which stops before saving when the command
-    fails, the default ``continue`` behavior of this command saves the
-    modifications also when the exit code does not match, and reports the error
-    at the end of the operation.
     << REFLOW ||
 
     *Report mode*
@@ -113,6 +107,13 @@ class Rerun(Interface):
       dataset to a previous state. The working trees of any subdatasets remain
       unchanged.
     """
+    # `rerun` is routinely used as a shortcut for repeating a previous `run`,
+    # so it must fail in the same way: do not re-execute a command when its
+    # inputs could not be obtained (or its outputs not be prepared), and do
+    # not save the results of a command that failed in a way that was not
+    # recorded.  Can be overridden via the common 'on_failure' parameter.
+    on_failure = 'stop'
+
     _params_ = dict(
         revision=Parameter(
             args=("revision",),
@@ -413,7 +414,12 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
             rerun_dsid = res["run_info"].get("dsid")
             if rerun_dsid is not None and rerun_dsid != dset.id:
                 skip_or_pick(hexsha, res, "was ran from a different dataset")
-                res["status"] = "impossible"
+                # not a failure: the commit is cherry picked or skipped
+                # rather than re-executed, which is the correct outcome
+                # here.  Reporting it as such also keeps a range replay
+                # going, rather than aborting it under the command's
+                # 'stop' on_failure default.
+                res["status"] = "notneeded"
             else:
                 res["rerun_action"] = "run"
                 res["diff"] = diff_revision(dset, hexsha)
@@ -613,7 +619,9 @@ def _report(dset, results):
     ds_repo = dset.repo
     for res in results:
         if "run_info" in res:
-            if res["status"] != "impossible":
+            # no "diff" for records that will not be re-executed
+            # (e.g. recorded in a different dataset)
+            if "diff" in res:
                 res["diff"] = list(res["diff"])
                 # Add extra information that is useful in the report but not
                 # needed for the rerun.

--- a/datalad/local/rerun.py
+++ b/datalad/local/rerun.py
@@ -424,6 +424,10 @@ def _rerun_as_results(dset, revrange, since, branch, onto, message):
                 # alone, so an 'impossible' here would abort a range
                 # replay (`--since=`) at the first such commit instead of
                 # continuing with the ones this dataset can re-execute.
+                # A replay that re-executes nothing at all is still
+                # reported as a failure, see the end of _rerun().
+                # TODO: add --on-foreign-run=error|auto if a need arises
+                # for more detailed control
                 res["status"] = "notneeded"
             else:
                 res["rerun_action"] = "run"
@@ -452,8 +456,11 @@ def _rerun(dset, results, assume_ready=None, explicit=False, jobs=None):
     new_bases = {}  # original hexsha => reran hexsha
     branch_to_restore = ds_repo.get_active_branch()
     head = onto = ds_repo.get_hexsha()
+    ran_any = False
+    saw_run_commit = False
     for res in results:
         lgr.info(_get_rerun_log_msg(res))
+        saw_run_commit = saw_run_commit or "run_info" in res
         rerun_action = res.get("rerun_action")
         if not rerun_action:
             yield res
@@ -556,6 +563,7 @@ def _rerun(dset, results, assume_ready=None, explicit=False, jobs=None):
                 _mark_nonrun_result(res, "pick")
                 yield res
         elif rerun_action == "run":
+            ran_any = True
             run_info = res["run_info"]
             # Keep a "rerun" trail.
             if "chain" in run_info:
@@ -598,6 +606,18 @@ def _rerun(dset, results, assume_ready=None, explicit=False, jobs=None):
         ds_repo.update_ref("refs/heads/" + branch_to_restore,
                            "HEAD")
         ds_repo.checkout(branch_to_restore)
+
+    if saw_run_commit and not ran_any:
+        # The range did contain run commits, but none of them could be
+        # re-executed here (a range with none at all is already reported
+        # by _rerun_as_results()).  Do not exit 0 having run nothing: the
+        # individual commits are reported as 'notneeded' so that a mixed
+        # range keeps going, so this is the only place left to say that
+        # the request as a whole came to nothing.
+        yield get_status_dict(
+            "run", ds=dset, status="impossible",
+            message="no run commit in the given revision range could be "
+                    "re-executed in this dataset")
 
 
 def _get_rerun_log_msg(res):

--- a/datalad/local/rerun.py
+++ b/datalad/local/rerun.py
@@ -64,6 +64,27 @@ class Rerun(Interface):
     then re-execute the command in the recorded path (if it was inside
     the dataset). Afterwards, all modifications will be saved.
 
+    *Exit code of the re-executed command*
+
+    || REFLOW >>
+    A re-execution is considered successful when the exit code of the command
+    matches the one recorded in the run record. A command that is on record to
+    have exited non-zero (see :command:`datalad run`) is therefore reported as
+    "ok" when it fails again in the same way, and as "error" when it exits with
+    a different non-zero code. A re-execution that exits with 0 is always
+    considered successful, also when the record has a non-zero exit code; such
+    a change in behavior can only be detected by comparing the ``exit`` field
+    of the new run record with that of the record it was derived from (the last
+    entry of its ``chain``).
+    << REFLOW ||
+
+    || REFLOW >>
+    Unlike :command:`datalad run`, which stops before saving when the command
+    fails, the default ``continue`` behavior of this command saves the
+    modifications also when the exit code does not match, and reports the error
+    at the end of the operation.
+    << REFLOW ||
+
     *Report mode*
 
     || REFLOW >>

--- a/datalad/local/tests/test_rerun.py
+++ b/datalad/local/tests/test_rerun.py
@@ -355,7 +355,9 @@ def test_run_failure(path=None):
     with assert_raises(IncompleteResultsError):
         ds.rerun(run_hexsha, result_renderer=None)
     eq_(hexsha_pre_rerun, ds.repo.get_hexsha())
-    ok_(ds.repo.dirty)
+    # note: whether the working tree is left dirty depends on the file
+    # system -- on an adjusted branch the output is removed rather than
+    # unlocked before the command, so it comes back identical
     ds.save()
 
     # We don't show instructions if the caller specified us not to save.
@@ -373,16 +375,12 @@ def test_rerun_range_with_foreign_run_commit(path=None):
     # that the subdataset itself cannot re-execute
     ds.run("echo super >>{}".format(op.join("sub", "from-super")))
     sub.run("echo own >>own")
-    hexsha_pre_rerun = sub.repo.get_hexsha()
     # replaying a range must skip that record and continue with the commit
     # that does belong to this dataset
     res = sub.rerun(since="", return_type="list")
     assert_result_count(res, 1, action="run", rerun_action="skip",
                         status="notneeded")
-    # the command of this dataset was re-executed and recorded
-    neq_(hexsha_pre_rerun, sub.repo.get_hexsha())
-    assert_result_count(res, 1, action="run", status="ok",
-                        path=sub.path)
+    assert_result_count(res, 1, action="run", status="ok", path=sub.path)
 
 
 @with_tempfile(mkdir=True)
@@ -402,9 +400,8 @@ def test_rerun_unavailable_input(path=None):
     with assert_raises(IncompleteResultsError):
         ds.rerun(result_renderer=None)
     # the command was not executed, and nothing was recorded
-    eq_(hexsha_pre_rerun, ds.repo.get_hexsha())
-    assert_repo_status(ds.path)
     eq_(marker_pre_rerun, (ds.pathobj / "marker").read_text())
+    eq_(hexsha_pre_rerun, ds.repo.get_hexsha())
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/local/tests/test_rerun.py
+++ b/datalad/local/tests/test_rerun.py
@@ -111,7 +111,7 @@ def test_rerun(path=None, nodspath=None):
     eq_(ds.id, sub_info["dsid"])
     assert_result_count(
         sub.rerun(return_type="list", on_failure="ignore"),
-        1, status="impossible", action="run", rerun_action="skip")
+        1, status="notneeded", action="run", rerun_action="skip")
     eq_('xx\n', open(probe_path).read())
 
     # Rerun fails with a dirty repo.
@@ -346,11 +346,65 @@ def test_run_failure(path=None):
     assert_in_results(ds.rerun(result_renderer=None, on_failure="ignore"),
                       action="run", status="error")
 
+    # ... and, like `run`, such a re-execution does not save anything
+    ds.run("echo a >>modme && [ ! -e trigger ]")
+    run_hexsha = ds.repo.get_hexsha()
+    create_tree(ds.path, {"trigger": "x"})
+    ds.save("trigger")
+    hexsha_pre_rerun = ds.repo.get_hexsha()
+    with assert_raises(IncompleteResultsError):
+        ds.rerun(run_hexsha, result_renderer=None)
+    eq_(hexsha_pre_rerun, ds.repo.get_hexsha())
+    ok_(ds.repo.dirty)
+    ds.save()
+
     # We don't show instructions if the caller specified us not to save.
     remove(msgfile)
     with assert_raises(IncompleteResultsError):
         ds.run("false", explicit=True, outputs=None, on_failure="stop")
     assert_false(op.exists(msgfile))
+
+
+@with_tempfile(mkdir=True)
+def test_rerun_range_with_foreign_run_commit(path=None):
+    ds = Dataset(path).create()
+    sub = ds.create("sub")
+    # a run recorded in the superdataset leaves a record in the subdataset
+    # that the subdataset itself cannot re-execute
+    ds.run("echo super >>{}".format(op.join("sub", "from-super")))
+    sub.run("echo own >>own")
+    hexsha_pre_rerun = sub.repo.get_hexsha()
+    # replaying a range must skip that record and continue with the commit
+    # that does belong to this dataset
+    res = sub.rerun(since="", return_type="list")
+    assert_result_count(res, 1, action="run", rerun_action="skip",
+                        status="notneeded")
+    # the command of this dataset was re-executed and recorded
+    neq_(hexsha_pre_rerun, sub.repo.get_hexsha())
+    assert_result_count(res, 1, action="run", status="ok",
+                        path=sub.path)
+
+
+@with_tempfile(mkdir=True)
+def test_rerun_unavailable_input(path=None):
+    ds = Dataset(path).create()
+    create_tree(ds.path, {"in.dat": "content"})
+    ds.save()
+    # the command appends, so any (re-)execution is detectable
+    ds.run("echo ran >>marker", inputs=["in.dat"])
+    assert_repo_status(ds.path)
+    # no other copy of the content exists, so a rerun cannot get it
+    ds.drop("in.dat", reckless="availability")
+    assert_false(ds.repo.file_has_content("in.dat"))
+
+    hexsha_pre_rerun = ds.repo.get_hexsha()
+    marker_pre_rerun = (ds.pathobj / "marker").read_text()
+    with assert_raises(IncompleteResultsError):
+        ds.rerun(result_renderer=None)
+    # the command was not executed, and nothing was recorded
+    eq_(hexsha_pre_rerun, ds.repo.get_hexsha())
+    assert_repo_status(ds.path)
+    eq_(marker_pre_rerun, (ds.pathobj / "marker").read_text())
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/local/tests/test_rerun.py
+++ b/datalad/local/tests/test_rerun.py
@@ -374,6 +374,7 @@ def test_rerun_range_with_foreign_run_commit(path=None):
     # a run recorded in the superdataset leaves a record in the subdataset
     # that the subdataset itself cannot re-execute
     ds.run("echo super >>{}".format(op.join("sub", "from-super")))
+    foreign_hexsha = sub.repo.get_hexsha()
     sub.run("echo own >>own")
     # replaying a range must skip that record and continue with the commit
     # that does belong to this dataset
@@ -381,6 +382,14 @@ def test_rerun_range_with_foreign_run_commit(path=None):
     assert_result_count(res, 1, action="run", rerun_action="skip",
                         status="notneeded")
     assert_result_count(res, 1, action="run", status="ok", path=sub.path)
+
+    # but a replay that re-executes nothing at all is a failure, rather
+    # than a silent no-op
+    assert_in_results(
+        sub.rerun(foreign_hexsha, result_renderer=None, on_failure="ignore"),
+        action="run", status="impossible")
+    with assert_raises(IncompleteResultsError):
+        sub.rerun(foreign_hexsha, result_renderer=None)
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
`rerun` is routinely used as a shortcut for repeating a previous `run`, so the two should fail the same way. They did not: `Run` sets `on_failure = 'stop'`, `Rerun` inherited the global `'continue'` default. This PR makes them congruent and documents the exit-code semantics that were undocumented on both sides.

## The divergence was not a decision

- **1042e588d** (2018, `ENH: run: Support runs with non-zero exit codes`) aborted both cases explicitly: a fresh run with a non-zero exit wrote `COMMIT_EDITMSG` and raised, and `_execute_command()` raised outright when a *rerun* exited differently than recorded.
- **9595f5e50** (2021, gh-3071) turned both aborts into yielded `status="error"` records, deliberately — *"This allows callers to control whether the save happens via the standard `--on-failure` switch."*
- **0f5abc49c** (2022, for gh-6427) then gave `Run` — and only `Run` — the `'stop'` default, so a command is not executed after a failed input/output preparation.

`Rerun` was never given a matching default, so both of the 2018 behaviors were silently lost on the replay path. The rerun tests in 9595f5e50 were rewritten to assert only the error result (with `on_failure="ignore"`), so nothing covered the dataset state afterwards.

Two consequences, both verified before the change:

```
% datalad run -i in.dat 'sh -c "echo run2 >> marker"'     # origin gone
get(error): in.dat (file) [Unable to access these remotes: origin]
# command not executed, tree clean -- correct, this is gh-6427

% datalad rerun                                           # same dataset
get(error): in.dat (file) [Unable to access these remotes: origin]
run(ok): ... ; add(ok): marker ; save(ok): .
# command executed without its input, new run commit created, datalad exits 0
```

and a re-execution whose exit code did not match the recorded one still saved the modifications, where the equivalent `run` leaves them unsaved for inspection.

## Changes

- `Rerun.on_failure = 'stop'`, with the reasoning in a comment. Both commands now document `[Default: 'stop']`.
- A run commit recorded in a *different* dataset is reported `notneeded` rather than `impossible`. `run` duplicates its record into every modified subdataset, so a subdataset's history can contain run commits whose `dsid` is the superdataset's; such a commit is skipped or cherry picked instead of re-executed — the outcome 85d54231a intended ("skip or cherry pick the commit using the same logic that's used for non-run commits", and that commit relaxed `_rerun()`'s abort from any non-ok status to `error` so it would not stop the replay). Since `on_failure` dispatches on status alone, leaving it `impossible` would now abort a `--since=` replay at the first such commit. `_report()` keys on the presence of `diff` instead of that status.
- **A replay that re-executes nothing at all now fails.** Per-commit `notneeded` keeps a mixed range going, but when *every* run commit in the range belongs to another dataset, `rerun` used to exit 0 having done nothing. It now ends with an `impossible` result — which restores the failure the pre-`stop` code produced for `datalad rerun` on a single such commit, without giving up on ranges. A range with no run commits at all is untouched; `_rerun_as_results()` already reports that.
- Docs: the exit code is always in the run record; `--on-failure ignore` preserves a non-zero exit as a regular provenance record; nothing is recorded when the command did not modify the dataset (also when it failed); a re-execution is `ok` when it reproduces the recorded exit code, `error` when it exits with a *different* non-zero code, and — the one asymmetry left — always `ok` when it exits 0, so a command that stopped failing is only detectable by comparing `exit` against the record it was derived from (last entry of its `chain`).

## Tests

- `test_run_failure`: a re-execution with a mismatching exit code records nothing.
- `test_rerun_unavailable_input` (new): a rerun whose input cannot be obtained does not execute the command and records nothing.
- `test_rerun_range_with_foreign_run_commit` (new): a range replay skips a superdataset's run commit and continues with the subdataset's own one — this fails if the status goes back to `impossible` — and a replay of that commit alone raises `IncompleteResultsError` with an `impossible` result.
- `test_rerun`: the foreign-dsid expectation updated to `notneeded`.

The new assertions deliberately avoid `repo.dirty` and "a new commit exists": on an adjusted branch an output is removed rather than unlocked before a re-execution, so an appending command recreates it identically. The first CrippledFS run caught exactly that; fixed in 565bd68.

All 33 GitHub Actions checks are green on the current head `e6d11e35`, CrippledFS and the macOS matrix included. Locally `datalad/local/tests/test_rerun.py` (23 passed, 1 xfailed), `datalad/core/local/tests/test_run.py`, `test_run_procedure.py` and `interface/tests/test_docs.py` pass; codespell clean, no new flake8 findings.

## Notes for review

- This is a behavior change on `maint`: a mismatching rerun no longer commits. That is what `run` has always done. Labeled `semver-patch`, changelog snippet in `changelog.d/pr-7906.md` under Bug Fixes.
- Known, pre-existing and untouched here: under `--onto=`/`--branch=`, a foreign-dsid commit is *cherry picked*, producing a commit that carries the run record verbatim (`cmd`, `exit`, `chain: []`) although the command was never executed — the only signal is that the record's `dsid` belongs to another dataset. Making the pick visible in the result stream, and recording the picked hexsha in `chain`, are both possible; see the review thread.
- `# TODO: add --on-foreign-run=error|auto if a need arises for more detailed control` sits next to the status, for the day this needs explicit control.
- Follow-up left out on purpose: the `COMMIT_EDITMSG` recovery record is still only written for non-rerun failures (`if not rerun_info and cmd_exitcode`), so a failed rerun leaves an uncommitted state without one. Dropping that guard would complete the symmetry, but `Run.custom_result_renderer()` is what points users at the file and `Rerun` has no such renderer.
- For #7902/#7903: `--on-cmd-failure` should apply to both commands with the same default. #7903 also carries over `if cmd_exitcode and expected_exit != cmd_exitcode`, so the "recorded non-zero, now exits 0" case stays unflagged — worth deciding there. It also targets `maint` although #7902 is labeled `enhancement`.

## PR checklist

- [x] Overview of the changes provided above
- [x] Changelog snippet in `changelog.d/pr-7906.md`
- [x] Relates to #7902 / #7903 and gh-6427; deliberately no `Fixes` keyword — the divergence has no issue of its own, and gh-6427 is only referenced, not closed by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpYt6fWVTvbRn4CH9pPBb8