### PR TITLE
BF: rerun --since - do not silently skip leading non-run commits

### DIFF
--- a/changelog.d/pr-7908.md
+++ b/changelog.d/pr-7908.md
@@ -1,0 +1,8 @@
+### 🐛 Bug Fixes
+
+- `rerun --since=<sha>` no longer leaks the source branch's pre-`<since>`
+  ancestry into the rerun branch when the replayed range starts with
+  non-`run` commits.  Regression introduced in 1.4.1 by the fix for
+  [#4700](https://github.com/datalad/datalad/issues/4700).
+  [PR #7908](https://github.com/datalad/datalad/pull/7908)
+  (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad/local/rerun.py
+++ b/datalad/local/rerun.py
@@ -540,10 +540,20 @@ def _rerun(dset, results, assume_ready=None, explicit=False, jobs=None):
             if rerun_action == "run":
                 ds_repo.checkout(parent)
                 head = parent
-            else:
+            elif head != onto:
+                # Non-run commit on a merge side-branch: silent-skip to keep
+                # the original SHA available for the upcoming merge commit.
                 _mark_nonrun_result(res, "skip")
                 yield res
                 continue
+            else:
+                # Leading non-run commit under explicit --since (head still at
+                # onto, no run replay yet).  Previously silent-skipped here,
+                # which left new_bases unpopulated and caused the subsequent
+                # run iteration to checkout the source-branch parent, splicing
+                # source ancestry into the rerun branch.  Fix: record the base
+                # mapping and let skip-or-pick cherry-pick it below.
+                new_bases[parent] = head
         else:
             if parent != head:
                 new_bases[parent] = head

--- a/datalad/local/tests/test_rerun.py
+++ b/datalad/local/tests/test_rerun.py
@@ -1026,36 +1026,73 @@ def test_rerun_commit_message_check():
 @skip_if_adjusted_branch
 @with_tempfile(mkdir=True)
 def test_rerun_skip_regular_commits_before_first_runcmd(path=None):
-    """Test for issue #4700: regular commits before first RUNCMD are not cherry-picked"""
+    """Regression test for `rerun --since=<sha>` leading-non-run ancestry leak.
+
+    Covers two related bugs:
+
+    #4700 (fixed in 1.4.1): leading non-RUNCMD commits were silently dropped
+    by ``dropwhile()`` and never appeared on the rerun branch.
+
+    Follow-up bug introduced by the 1.4.1 fix: with an explicit ``--since``
+    boundary, non-RUNCMD commits are silently skipped by the elif at
+    ``datalad/local/rerun.py:500-507``. The *subsequent* run-command
+    iteration then checks out the ORIGINAL source-branch parent via
+    ``ds_repo.checkout(parent); head = parent``, splicing the source's
+    history past the ``--since`` boundary — including the boundary commit
+    itself — into the rerun branch's ancestry. The most easily-observed
+    symptom is that ``file1.txt`` (introduced by the boundary commit)
+    appears in the rerun-branch worktree even though its introducing commit
+    is meant to be excluded by ``--since``.
+    """
     ds = Dataset(path).create()
     initial_commit = ds.repo.get_hexsha()
 
-    # Create regular commits before any run commands
-    create_tree(ds.path, {"file1.txt": "content1", "file2.txt": "content2"})
-    ds.save(["file1.txt", "file2.txt"], message="Add files before run")
+    # Leading non-RUNCMD commit that will become the --since boundary
+    # (must be EXCLUDED from the rerun range).
+    create_tree(ds.path, {"file1.txt": "content1"})
+    ds.save("file1.txt", message="Add files before run #1")
+    files1_commit = ds.repo.get_hexsha()
 
-    # Create a run command
+    # Leading non-RUNCMD commit inside the --since range (must be picked).
+    create_tree(ds.path, {"file2.txt": "content2"})
+    ds.save("file2.txt", message="Add files before run #2")
+
+    # The RUNCMD.
     ds.run('echo "run output" > run_output.txt')
+    run_commit = ds.repo.get_hexsha()
 
-    # Create another regular commit after the run
+    # Trailing non-RUNCMD commit (covers the original #4700 scenario).
     create_tree(ds.path, {"file3.txt": "content3"})
     ds.save("file3.txt", message="Add file after run")
-
     head_commit = ds.repo.get_hexsha()
 
-    # Go back to initial commit and rerun everything
+    # Rerun {files2, run, files3}; files1 is the --since boundary and
+    # must be excluded per the docs.
     ds.repo.checkout(initial_commit, options=["--detach"])
-
-    # Rerun from the saved HEAD (issue #4700: without fix, regular commits before
-    # first RUNCMD would be dropped by dropwhile())
-    ds.rerun(revision=head_commit, since=initial_commit, branch="rerun-branch")
-
-    # Verify all files exist (with fix, regular commits are no longer dropped)
+    ds.rerun(revision=head_commit, since=files1_commit, branch="rerun-branch")
     ds.repo.checkout("rerun-branch")
-    ok_exists(op.join(path, "file1.txt"))
+
+    # Files inside the --since range were applied.
     ok_exists(op.join(path, "file2.txt"))
     ok_exists(op.join(path, "run_output.txt"))
     ok_exists(op.join(path, "file3.txt"))
+
+    # Primary observable of the ancestry-leak bug: without the fix,
+    # rerun-branch's ancestry includes the --since boundary commit, so
+    # its file (file1.txt) shows up in the worktree. This assertion fires
+    # deterministically against unfixed code (verified 20/20 in an
+    # empirical probe without date pinning).
+    assert not op.exists(op.join(path, "file1.txt")), \
+        "file1.txt should be excluded (its commit is the --since boundary)"
+
+    # Belt-and-braces: neither the --since boundary nor the original run
+    # commit should appear in the rerun-branch ancestry.
+    rerun_ancestry = ds.repo.call_git(
+        ["log", "--format=%H", "rerun-branch"]).split()
+    assert files1_commit not in rerun_ancestry, \
+        f"--since boundary {files1_commit[:7]} leaked into rerun-branch"
+    assert run_commit not in rerun_ancestry, \
+        f"original run commit {run_commit[:7]} leaked into rerun-branch"
 
 
 # -- Tests for rerunning run-merge commits --


### PR DESCRIPTION
## Summary

`datalad rerun --since=<sha> --branch=<name> <revision>` should replay
the commits in `(since, revision]`. When that range starts with
non-RUNCMD (regular) commits, the current implementation silently
*skips* them, and the subsequent run-command iteration then checks out
the **original source-branch parent by SHA**. That splices the
source's full history past `<sha>` — including `<sha>` itself — back
into the rerun branch's ancestry.

Practical impact: the rerun branch shares SHAs with the source
branch's pre-`<since>` region. Subsequent rebase / amend of source
implicitly mutates the rerun branch. The most easily-observed
symptom is that files introduced only by the `--since` boundary
commit show up in the rerun branch's worktree.

Regression from 1.4.1 (PR #7729, commit `8a8d49dd4`, fix for #4700).
Still present in 1.6.0.

## Verification

The TST commit strengthens
`test_rerun_skip_regular_commits_before_first_runcmd` (the previous
form was satisfied by both pre-#4700 and post-#4700-buggy code); the
BF commit makes it green. Run:

```
pytest -x datalad/local/tests/test_rerun.py::test_rerun_skip_regular_commits_before_first_runcmd
```

against each commit to see the transition.

Full post-fix: `test_rerun.py` 23 passed, 1 xfailed; `test_rerun_merges.py` 15 passed. Determinism probe (20 trials, no timestamp pinning): **20/20** fires on unfixed code.

---

<details><summary>Mechanism — what's happening in <code>_rerun()</code></summary>

The elif at `datalad/local/rerun.py` on current maint:

```python
elif parent != head and ds_repo.is_ancestor(onto, parent):
    if rerun_action == "run":
        ds_repo.checkout(parent)
        head = parent
    else:
        _mark_nonrun_result(res, "skip")
        yield res
        continue
```

The elif serves two roles:
1. **Run commits** — checks out source parent to recreate pre-command state.
2. **Non-run commits on merge side-branches** — silent-skip preserves the
   original SHA so the upcoming merge-replay step can use it as parent-2.

The bug is that the silent-skip `else` branch also fires for leading
non-run commits under explicit `--since`.  For those commits no
cherry-pick happens and `new_bases` is never populated.  The *next*
iteration (the RUN_COMMIT) finds its `parent` unmapped, the `"run"` arm
fires, and `ds_repo.checkout(parent); head = parent` checks out the
original source-branch parent — splicing source ancestry into the rerun
branch.

**Fix**: within the `else` arm, guard on `head != onto`.  When
`head == onto` the loop has not yet replayed any run commit (we are
processing a leading non-run commit); the commit must be cherry-picked
rather than silently skipped.  When `head != onto` a run has already
been replayed and the commit is on a merge side-branch; the original
silent-skip is correct.  Leading non-run commits that fall through
record `new_bases[parent] = head` so the subsequent run iteration
finds its remapped base via `new_base = new_bases.get(parent)`.

</details>

<details><summary>Regression evidence (three-criteria justification)</summary>

Per the standard checklist:

1. **Introducing commit identified**: `8a8d49dd4` (PR #7729) in 1.4.1.
2. **Prior version behaved differently**: pre-1.4.1 the `dropwhile()`
   filter discarded leading non-run commits before they entered
   `_rerun()`'s loop, so the silent-skip elif was never reached with a
   non-run commit. Pre-1.4.1 the observable was the *original* #4700
   bug — `rerun-branch` was missing the leading commits entirely. The
   1.4.1 fix removed the filter for the explicit-`since` path, which
   exposed this latent gap.
3. **Not mentioned in the commit message**: PR #7729's commit message
   claims only the intended effect (include regular commits before
   first RUNCMD). The ancestry-leak side-effect was not identified.

</details>

<details><summary>Post-iteration short-circuit — deliberately untouched</summary>

The post-iteration branch (`if new_head not in [head, res_hexsha]:
new_bases[res_hexsha] = new_head`) is left as-is. When a cherry-pick
truly produces `new_head == res_hexsha` (identical content + metadata),
the commits are graph-equivalent, so not recording the mapping is
harmless — subsequent `new_bases.get(parent)` returns None but
`parent == head` already, and no checkout is needed. This path is not
on the failing code trajectory.

</details>

## Test plan

- [x] `pytest -x datalad/local/tests/test_rerun.py::test_rerun_skip_regular_commits_before_first_runcmd` (fails at TST commit, passes at BF commit).
- [x] `pytest datalad/local/tests/test_rerun.py datalad/local/tests/test_rerun_merges.py` full suite: 38 passed, 1 xfailed.
- [ ] CI green on all supported Python / OS combinations.
- [ ] Reviewer sanity-check on adjusted-branch scenarios (the test is `@skip_if_adjusted_branch`, matching the surrounding tests).
