### PR TITLE
Skip tests on external-service outages; versions in pytest header; fix runner-test ordering race

### DIFF
--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -74,6 +74,7 @@ from datalad.tests.utils_pytest import (
     skip_if_adjusted_branch,
     skip_if_no_network,
     skip_if_on_windows,
+    skip_if_url_is_not_available,
     skip_ssh,
     slow,
     swallow_logs,
@@ -1342,10 +1343,27 @@ def test_inherit_src_candidates(lcl=None, storepath=None, url=None):
             'ria+%s#{id}' % url)
 
 
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+def test_ria_http_local_store(lcl=None, storepath=None, url=None):
+    # hermetic stand-in for test_ria_http_storedataladorg (gh-7912).
+    # test_ria_http covers this too, but is @slow and so deselected by the
+    # default GitHub job's PYTEST_SELECTION.
+    ds = Dataset(op.join(lcl, 'ds')).create()
+    _move2store(Path(storepath), ds)
+    riaclone = clone('ria+{}#{}'.format(url, ds.id), op.join(lcl, 'clone'))
+    ok_(riaclone.is_installed())
+    eq_(riaclone.id, ds.id)
+
+
 @skip_if_no_network
+@pytest.mark.flaky(retries=2, delay=5, only_on=[IncompleteResultsError])
 @with_tempfile()
 def test_ria_http_storedataladorg(path=None):
-    # can we clone from the store w/o any dedicated config
+    # an outage of this external service is not a failure of this code
+    # base (gh-7912)
+    skip_if_url_is_not_available('http://store.datalad.org/')
     ds = clone('ria+http://store.datalad.org#{}'.format(datalad_store_testds_id), path)
     ok_(ds.is_installed())
     eq_(ds.id, datalad_store_testds_id)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -74,7 +74,6 @@ from datalad.tests.utils_pytest import (
     skip_if_adjusted_branch,
     skip_if_no_network,
     skip_if_on_windows,
-    skip_if_url_is_not_available,
     skip_ssh,
     slow,
     swallow_logs,
@@ -1357,13 +1356,12 @@ def test_ria_http_local_store(lcl=None, storepath=None, url=None):
     eq_(riaclone.id, ds.id)
 
 
-@skip_if_no_network
+# an outage of this external service is not a failure of this code base
+# (gh-7912), so gate on it actually answering rather than on network at large.
+@skip_if_no_network(url='http://store.datalad.org/')
 @pytest.mark.flaky(retries=2, delay=5, only_on=[IncompleteResultsError])
 @with_tempfile()
 def test_ria_http_storedataladorg(path=None):
-    # an outage of this external service is not a failure of this code
-    # base (gh-7912)
-    skip_if_url_is_not_available('http://store.datalad.org/')
     ds = clone('ria+http://store.datalad.org#{}'.format(datalad_store_testds_id), path)
     ok_(ds.is_installed())
     eq_(ds.id, datalad_store_testds_id)

--- a/datalad/distributed/tests/test_create_sibling_gitea.py
+++ b/datalad/distributed/tests/test_create_sibling_gitea.py
@@ -13,6 +13,7 @@ import requests
 from datalad.api import create_sibling_gitea
 from datalad.tests.utils_pytest import (
     skip_if_no_network,
+    skip_if_url_is_not_available,
     with_tempfile,
 )
 
@@ -20,9 +21,13 @@ from .test_create_sibling_ghlike import check4real
 
 
 @skip_if_no_network
-@pytest.mark.flaky(retries=3, only_on=[requests.exceptions.HTTPError])
+@pytest.mark.flaky(retries=3, delay=5, only_on=[requests.exceptions.HTTPError])
 @with_tempfile
 def test_gitea(path=None):
+    # demo.gitea.com is Gitea's public demo instance: no SLA, reset
+    # regularly, and unreachable for long stretches. Its outage is not a
+    # failure of this code base (gh-7912).
+    skip_if_url_is_not_available('https://demo.gitea.com/api/v1/version')
     check4real(
         create_sibling_gitea,
         path,

--- a/datalad/distributed/tests/test_create_sibling_gitea.py
+++ b/datalad/distributed/tests/test_create_sibling_gitea.py
@@ -13,21 +13,19 @@ import requests
 from datalad.api import create_sibling_gitea
 from datalad.tests.utils_pytest import (
     skip_if_no_network,
-    skip_if_url_is_not_available,
     with_tempfile,
 )
 
 from .test_create_sibling_ghlike import check4real
 
 
-@skip_if_no_network
+# demo.gitea.com is Gitea's public demo instance: no SLA, reset regularly, and
+# unreachable for long stretches. Its outage is not a failure of this code base
+# (gh-7912), so gate on it actually answering rather than on network at large.
+@skip_if_no_network(url='https://demo.gitea.com/api/v1/version')
 @pytest.mark.flaky(retries=3, delay=5, only_on=[requests.exceptions.HTTPError])
 @with_tempfile
 def test_gitea(path=None):
-    # demo.gitea.com is Gitea's public demo instance: no SLA, reset
-    # regularly, and unreachable for long stretches. Its outage is not a
-    # failure of this code base (gh-7912).
-    skip_if_url_is_not_available('https://demo.gitea.com/api/v1/version')
     check4real(
         create_sibling_gitea,
         path,

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -307,6 +307,13 @@ class BaseDownloader(object, metaclass=ABCMeta):
                 # So we didn't know if authentication necessary, and it
                 # seems to be necessary, so Let's ask the user to setup
                 # authentication mechanism for this website
+                if not ui.is_interactive:
+                    # no way to prompt, so surface the original failure
+                    # instead of dying inside the credentials dialog
+                    lgr.error(
+                        "Interface is non interactive, so we are "
+                        "reraising: %s", ce)
+                    raise e
                 self._enter_credentials(
                     url,
                     denied_msg=access_denied,

--- a/datalad/pytest_plugin.py
+++ b/datalad/pytest_plugin.py
@@ -26,6 +26,21 @@ import re
 from pathlib import Path
 
 
+def pytest_report_header(config) -> list[str]:
+    """Report versions of datalad and its dependencies at session start
+
+    `datalad.conftest` already dumps these at teardown; a CI failure is
+    triaged from the top of the log, so report them there too (gh-7911).
+    """
+    # imported here, not at module level: this plugin is loaded through the
+    # pytest11 entry point, where importing datalad is not free
+    from datalad.support.external_versions import external_versions
+
+    # query datalad's own version so it is included in the dump
+    external_versions['datalad']
+    return [external_versions.dumps(query=True)]
+
+
 def pytest_configure(config):
     """Register datalad custom markers and pytest configuration.
 

--- a/datalad/runner/protocol.py
+++ b/datalad/runner/protocol.py
@@ -200,10 +200,20 @@ class WitlessProtocol:
             8,
             'Process %i exited with return code %i',
             self.process.pid, return_code)
-        # give captured process output back to the runner as string(s)
+        # give captured process output back to the runner as string(s).
+        # Decode with 'surrogateescape': output of a command is not
+        # guaranteed to be valid in `encoding` -- POSIX file names are
+        # arbitrary byte strings, and 3rd party libraries (e.g. libmagic
+        # used by git-annex) may echo raw bytes into their messages.  A
+        # strict decode would fail the entire command over such output,
+        # even when it is a mere warning on stderr, and would discard the
+        # very output needed to tell what happened.  'surrogateescape'
+        # keeps those bytes recoverable via
+        # `.encode(encoding, 'surrogateescape')`, the same way Python
+        # itself handles undecodable file names.
         results: dict[str, Any] = {
             name: (
-                bytes(byt).decode(self.encoding)
+                bytes(byt).decode(self.encoding, errors='surrogateescape')
                 if byt is not None
                 else '')
             for name, byt in self.fd_infos.values()

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -704,15 +704,23 @@ def test_concurrent_generator_reading() -> None:
         t.join()
 
     collected_outputs = [
-        output_tuple[1]
-        for output_tuple in output_queue.queue
-        if output_tuple[1] is not None
+        (thread_number, int(output.split("#")[1]))
+        for thread_number, output in output_queue.queue
+        if output is not None
     ]
-    assert len(collected_outputs) == number_of_lines
-    assert collected_outputs == [
-        f"result#{i}"
-        for i in range(number_of_lines)
-    ]
+
+    # The merged order of `output_queue` is not deterministic: a reader
+    # thread can be preempted between `next()` returning and its `put()`,
+    # while other threads receive and enqueue later results (gh-7910).
+    # Assert only what is guaranteed -- every result delivered exactly
+    # once, and each thread's own results in generation order, since
+    # `next()` is serialized by `_ResultGenerator.send_lock`.
+    assert sorted(i for _, i in collected_outputs) == list(range(number_of_lines))
+    last_seen: dict[int, int] = {}
+    for thread_number, i in collected_outputs:
+        assert i > last_seen.get(thread_number, -1), \
+            f"thread {thread_number} received result#{i} out of order"
+        last_seen[thread_number] = i
 
 
 def test_same_thread_reenter_detection() -> None:

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -23,7 +23,10 @@ from collections.abc import (
 )
 from itertools import count
 from queue import Queue
-from threading import Thread
+from threading import (
+    Lock,
+    Thread,
+)
 from time import sleep
 from typing import (
     Any,
@@ -681,14 +684,23 @@ def test_concurrent_generator_reading() -> None:
     )
     result_generator = threaded_runner.run()
 
+    # `_ResultGenerator.send()` hands out results in generation order, under
+    # its own lock.  This test used to observe that order in two unlocked
+    # steps -- `next()`, then `put()` -- so a thread preempted between them
+    # let other threads enqueue later results first, and the merged order
+    # drifted by an adjacent swap (gh-7910).  Serializing the observation
+    # with the handout makes `output_queue` reflect the generation order.
+    read_lock = Lock()
+
     def thread_main(thread_number: int, result_generator: Iterator[str], output_queue: Queue[tuple[int, Optional[str]]]) -> None:
         while True:
-            try:
-                output = next(result_generator)
-            except StopIteration:
-                output_queue.put((thread_number, None))
-                break
-            output_queue.put((thread_number, output))
+            with read_lock:
+                try:
+                    output = next(result_generator)
+                except StopIteration:
+                    output_queue.put((thread_number, None))
+                    break
+                output_queue.put((thread_number, output))
 
     caller_threads = []
     for c in range(number_of_threads):
@@ -704,23 +716,15 @@ def test_concurrent_generator_reading() -> None:
         t.join()
 
     collected_outputs = [
-        (thread_number, int(output.split("#")[1]))
-        for thread_number, output in output_queue.queue
-        if output is not None
+        output_tuple[1]
+        for output_tuple in output_queue.queue
+        if output_tuple[1] is not None
     ]
-
-    # The merged order of `output_queue` is not deterministic: a reader
-    # thread can be preempted between `next()` returning and its `put()`,
-    # while other threads receive and enqueue later results (gh-7910).
-    # Assert only what is guaranteed -- every result delivered exactly
-    # once, and each thread's own results in generation order, since
-    # `next()` is serialized by `_ResultGenerator.send_lock`.
-    assert sorted(i for _, i in collected_outputs) == list(range(number_of_lines))
-    last_seen: dict[int, int] = {}
-    for thread_number, i in collected_outputs:
-        assert i > last_seen.get(thread_number, -1), \
-            f"thread {thread_number} received result#{i} out of order"
-        last_seen[thread_number] = i
+    assert len(collected_outputs) == number_of_lines
+    assert collected_outputs == [
+        f"result#{i}"
+        for i in range(number_of_lines)
+    ]
 
 
 def test_same_thread_reenter_detection() -> None:

--- a/datalad/tests/test_pytest_plugin.py
+++ b/datalad/tests/test_pytest_plugin.py
@@ -43,6 +43,9 @@ def test_plugin_registers_markers(pytester):
     result = pytester.runpytest_subprocess("--markers")
     # Check that key markers are registered (not order-dependent)
     output = result.stdout.str()
+    # the versions header is emitted by our pytest_report_header (gh-7911);
+    # asserting it here proves the pytest11 entry point is wired up at all
+    assert "Versions:" in output
     assert "@pytest.mark.network: marks tests requiring network access" in output
     assert "@pytest.mark.slow: marks slow tests" in output
     assert "@pytest.mark.integration: marks integration tests" in output

--- a/datalad/tests/test_pytest_plugin.py
+++ b/datalad/tests/test_pytest_plugin.py
@@ -43,9 +43,6 @@ def test_plugin_registers_markers(pytester):
     result = pytester.runpytest_subprocess("--markers")
     # Check that key markers are registered (not order-dependent)
     output = result.stdout.str()
-    # the versions header is emitted by our pytest_report_header (gh-7911);
-    # asserting it here proves the pytest11 entry point is wired up at all
-    assert "Versions:" in output
     assert "@pytest.mark.network: marks tests requiring network access" in output
     assert "@pytest.mark.slow: marks slow tests" in output
     assert "@pytest.mark.integration: marks integration tests" in output
@@ -69,6 +66,11 @@ def test_plugin_markers_work(pytester):
     result = pytester.runpytest_subprocess("-v", "-m", "network")
     result.stdout.fnmatch_lines(["*test_with_network*PASSED*"])
     assert "test_without_marker" not in result.stdout.str()
+    # the versions line comes from our pytest_report_header (gh-7911), and
+    # asserting it on a real session is the only check that the pytest11
+    # entry point is wired up at all.  It must not be asserted on a
+    # `--markers` run: that exits before a session starts, so no header.
+    assert "Versions:" in result.stdout.str()
 
 
 @pytest.mark.ai_generated

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -227,6 +227,13 @@ def skip_if_url_is_not_available(url, regex=None):
             pytest.skip("%s matched %r -- skipping the test" % (url, regex))
     except DownloadError:
         pytest.skip("%s failed to download" % url)
+    except Exception as exc:
+        # Anything else raised while merely probing availability also means
+        # we could not reach the URL.  Notably a 403 sends the downloader
+        # down its credential-entry path, which cannot work in a
+        # non-interactive test session.  (`pytest.skip` above raises a
+        # BaseException, so it is not caught here.)
+        pytest.skip("%s is not available: %r" % (url, exc))
 
 
 def check_not_generatorfunction(func):

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -236,25 +236,45 @@ def check_not_generatorfunction(func):
                            .format(func.__name__))
 
 
-def skip_if_no_network(func=None):
+def skip_if_no_network(func=None, url=None):
     """Skip test completely in NONETWORK settings
 
     If not used as a decorator, and just a function, could be used at the module level
+
+    Parameters
+    ----------
+    url: str, optional
+      Also skip if this URL cannot be retrieved, so that an outage of a
+      third-party service a test depends on does not turn CI red (gh-7912).
+      `datalad.tests.nonetwork` alone cannot express that: it only says
+      whether there is network at all, not whether this particular host
+      answers.  Given `url`, this must be used as a decorator --
+      `@skip_if_no_network(url=...)` -- since the URL is probed when the
+      test runs, not when the module is imported.
     """
-    check_not_generatorfunction(func)
 
     def check_and_raise():
         if dl_cfg.get('datalad.tests.nonetwork'):
             pytest.skip("Skipping since no network settings", allow_module_level=True)
+        if url is not None:
+            skip_if_url_is_not_available(url)
 
-    if func:
-        @wraps(func)
+    def decorate(func_):
+        check_not_generatorfunction(func_)
+
+        @wraps(func_)
         @attr('network')
         @attr('skip_if_no_network')
         def  _wrap_skip_if_no_network(*args, **kwargs):
             check_and_raise()
-            return func(*args, **kwargs)
+            return func_(*args, **kwargs)
         return  _wrap_skip_if_no_network
+
+    if func:
+        return decorate(func)
+    elif url is not None:
+        # invoked with arguments, so we are the decorator factory
+        return decorate
     else:
         check_and_raise()
 

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -227,13 +227,6 @@ def skip_if_url_is_not_available(url, regex=None):
             pytest.skip("%s matched %r -- skipping the test" % (url, regex))
     except DownloadError:
         pytest.skip("%s failed to download" % url)
-    except Exception as exc:
-        # Anything else raised while merely probing availability also means
-        # we could not reach the URL.  Notably a 403 sends the downloader
-        # down its credential-entry path, which cannot work in a
-        # non-interactive test session.  (`pytest.skip` above raises a
-        # BaseException, so it is not caught here.)
-        pytest.skip("%s is not available: %r" % (url, exc))
 
 
 def check_not_generatorfunction(func):


### PR DESCRIPTION
Fixes #7910, #7911, #7912.

## What each issue needed

**#7910 — `test_concurrent_generator_reading` ordering race.** The runner's ordering guarantee is real and intact: `_ResultGenerator.send()` takes `send_lock` and returns `self.result_queue.popleft()` (`nonasyncrunner.py:97-99`), so results are handed out strictly in generation order however many threads contend. What raced was the *test's observation* of that order — `next()` and the subsequent `put()` into the shared queue were two unlocked steps, so a thread preempted between them let others enqueue later results first. That is the adjacent swap AppVeyor saw. The fix closes that gap with a test-side lock, and the original strict-order assertion is restored verbatim. Neither option in the issue was quite right — the runner needs no fix, and the assertion was not too strong; the test was measuring with an instrument that had a gap in it.

**#7911 — versions in the session header.** `datalad.conftest` already dumps `external_versions` at *teardown*; a CI failure is triaged from the top of the log. Three lines in `pytest_report_header` emit the same dump at session start. Rendered header in [this thread](https://github.com/datalad/datalad/pull/7913#discussion_r3962013046).

**#7912 — outages must not turn CI red.** `skip_if_no_network` now optionally takes the URL a test depends on, so `@skip_if_no_network(url=...)` gates on that host actually answering rather than on network at large. Used by `test_gitea` (`demo.gitea.com`) and `test_ria_http_storedataladorg` (`store.datalad.org`). Plus `test_ria_http_local_store`, a hermetic `ria+http` clone (~3s) built from the existing `_move2store` + `@serve_path_via_http`.

## The one production change

`BaseDownloader._handle_authentication` already reraises the original exception rather than prompting when the UI is non-interactive — but only under `if needs_authentication:`. The `needs_authentication is None` branch ("we did not know whether auth was needed", which is what a plain 403 on an unauthenticated URL hits) went straight to `_enter_credentials` and its `ui.yesno`. `yesno` lives on `InteractiveUI`, while `QuietConsoleLog` (`tests-noninteractive`) and `SilentConsoleLog` (`no-progress`) derive from `ConsoleLog` and lack it — so **any access-denied response in a non-interactive session died with `AttributeError: 'QuietConsoleLog' object has no attribute 'yesno'` instead of the `DownloadError` the docstring promises.**

The fix applies the same four-line guard to that branch. `ui.is_interactive` is exactly `False` for the backends missing `yesno` and `True` for `DialogUI`, so it is precisely the right condition:

| backend | `is_interactive` | has `yesno` |
|---|---|---|
| `ConsoleLog` / `QuietConsoleLog` / `SilentConsoleLog` | `False` | no |
| `DialogUI` | `True` | yes |

This matters for #7912 directly: without it the new gating only works for connection-level failures, since any 4xx would crash inside the credentials dialog instead of skipping.

## Notes for reviewers

**`@optional_args` was deliberately not used** for the new `url` argument, though it is the idiom for `skip_if`, `with_tempfile` and `skip_known_failure`. It treats a no-argument call as "decorating with arguments", so `skip_if_no_network()` would return a decorator instead of skipping — silently turning three existing guards into no-ops (`downloaders/tests/test_s3.py:42`, `downloaders/tests/test_http.py:355`, and `test_tests_utils_pytest.py:535` which asserts it returns `None`), plus breaking `test_ria_basics.py:608`'s `skip_if_no_network(f)(None)`. The existing `func=None` shape is kept, branching to a decorator factory only when `url` is given. `nonetwork` is still checked first, so a no-network run does no probing.

**`datasets-tests.datalad.org` is deliberately not gated.** A run of the network job hit a live outage of it ([issuecomment-5593702857](https://github.com/datalad/datalad/pull/7913#issuecomment-5593702857)) — that is datalad's own test infrastructure and is expected to be up, unlike the third-party services above.

**This started ~7x larger and was cut down.** The first draft grew its own external-service probing subsystem in `pytest_plugin.py` (a `web_reachable` fixture, module cache, lock, thread pool, two env vars), a hand-rolled dependency-version walker over `importlib.metadata`, and a session-scoped RIA-store fixture in a new `conftest.py`. Three independent reviews found most of it duplicated machinery datalad already has:

| Reinvented | Already existed |
|---|---|
| probe subsystem + `web_reachable` fixture (~205 lines incl. tests) | `skip_if_url_is_not_available()`, now reachable via `skip_if_no_network(url=...)` |
| `_get_dependency_versions()` over `importlib.metadata` (~45 lines) | `external_versions.dumps(query=True)` |
| session-scoped RIA fixture, new `conftest.py` (52 lines) | `_move2store()` + `@serve_path_via_http` |

Delegating the version dump is also *better* output: it includes `cmd:annex`, `cmd:git` and `cmd:bundled-git` — the versions that actually explain a datalad CI failure — and drops dev-extra noise plus the pytest plugins that pytest's own `plugins:` header already lists. It also follows CONTRIBUTING.md's rule to use `external_versions` for version handling.

**Deliberate deviations from the issues as written:**

- **#7912 asked for `pytest-rerunfailures`.** Not added — this repo already depends on `pytest-retry` (#7754) and the two conflict over the `flaky` marker; installing both would break the existing marks on `test_gitea`, `test_download_ftp` and `test_rerun_merges`.
- **#7912 asked for a session-scoped local-RIA fixture.** Not added — it would have re-implemented `_move2store`/`serve_path_via_http`, and a session-scoped `HTTPPath` holds an `os.environ` patch open for the whole session and bypasses the `datalad.tests.temp.dir` policy that the `/var/tmp/sym link` CI job exists to stress. The test itself is kept, built from the existing helpers.
- **#7911 asked for a `web_reachable` fixture and a `datasets.datalad.org` probe.** Superseded. `datasets.datalad.org` gated nothing — no test consumed it.
- `requests.exceptions.ConnectionError` is **not** added to `only_on`: pytest-retry matches exception types exactly, not by subclass, so it would not catch `ConnectTimeout`/`ReadTimeout`/`SSLError` regardless.

## Still open for the reviewer

Serializing the observation in #7910 means threads contend on the test's lock rather than entering `send()` simultaneously, so it no longer exercises *simultaneous* entry — it exercises the generator being driven by 100 threads in turn. The two are mutually exclusive: a global order cannot be observed without serializing the observation. Say the word and I'll add a separate test for the interleaving-safe invariants (no loss, no duplication, per-thread monotonicity).

## Validation

The #7910 race is far too rare to demonstrate by repetition (the issue saw 1 occurrence in 162 job logs; 0/150 here under full CPU load). It was isolated by widening the window instead — a single `time.sleep(0)` between `next()` and `put()`, forcing a GIL yield exactly where the preemption happens:

| variant | runs violating the strict-order assertion |
|---|---|
| unlocked (as it was) | **30/30** |
| lock-serialized (this fix) | **0/30** |

`test_concurrent_generator_reading` then passed **300/300** with all 4 cores saturated; the full `test_nonasyncrunner.py` is 25/25.

Also run: `datalad/downloaders/tests/` 32 passed / 20 skipped (covers the production change), `test_tests_utils_pytest.py` + `test_nonasyncrunner.py` 79 passed / 8 skipped, `test_ria_http_local_store` passing, and **both gated tests skipping for real** — the downloader fix means this sandbox's 403 on `store.datalad.org` now surfaces as `AccessDeniedError`, so that skip path is exercised here for the first time rather than erroring. `flake8` output is byte-identical to the base commit on every touched file; `isort` and `codespell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1Ph17Zr5JA3Q5oibnyymF