### PR TITLE
Define public API for datalad.support.network module

### DIFF
--- a/datalad/support/network.py
+++ b/datalad/support/network.py
@@ -62,6 +62,25 @@ from datalad.utils import (
     on_windows,
 )
 
+# Public interface of this module.  Everything else is considered internal
+# and might change without notice, even though it might be imported
+# elsewhere within datalad itself.
+__all__ = [
+    # Resource identifiers
+    'RI',
+    'URL',
+    'PathRI',
+    'SSHRI',
+    'DataLadRI',
+    'GitTransportRI',
+    # Helpers to classify resource identifiers
+    'is_url',
+    'is_ssh',
+    'is_datalad_compat_ri',
+    # Conversion of local paths to file:// URLs
+    'get_local_file_url',
+]
+
 # !!! Lazily import requests where needed -- needs 30ms or so
 # import requests
 


### PR DESCRIPTION
### Overview

This PR adds an explicit `__all__` declaration to the `datalad/support/network.py` module to define its public API. The module exports resource identifier classes (`RI`, `URL`, `PathRI`, `SSHRI`, `DataLadRI`, `GitTransportRI`), helper functions for classification (`is_url`, `is_ssh`, `is_datalad_compat_ri`), and a utility function for path conversion (`get_local_file_url`).

### Rationale

Explicitly defining `__all__` provides several benefits:
- **Clear API contract**: Users and maintainers can easily identify which symbols are part of the public API
- **Better IDE support**: Tools can provide accurate autocompletion and documentation for public exports
- **Maintenance clarity**: The comment notes that everything else is considered internal and may change without notice, even if imported elsewhere in datalad
- **Documentation**: Makes it explicit what should be documented and what is implementation detail

### Changes

- Added `__all__` list with 9 public symbols organized into three categories:
  - Resource identifiers (5 classes)
  - Classification helpers (3 functions)
  - Path conversion utility (1 function)

### Testing

No testing needed — this is a documentation/API declaration change that doesn't alter runtime behavior.

https://claude.ai/code/session_01UrJiX2X6ik1vMAG3aet8w6