### PR TITLE
NF: push: add -u/--set-upstream to mimic `git push -u`

### DIFF
--- a/changelog.d/pr-7918.md
+++ b/changelog.d/pr-7918.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- NF: push: add -u/--set-upstream to mimic `git push -u`.  [PR #7918](https://github.com/datalad/datalad/pull/7918) (by [@yarikoptic-gitmate](https://github.com/yarikoptic-gitmate))

--- a/changelog.d/pr-7924.md
+++ b/changelog.d/pr-7924.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Command output that is not valid in the preferred encoding no longer fails the command.  `WitlessProtocol._prepare_result()` decoded the captured `stdout`/`stderr` strictly, so a single undecodable byte raised `UnicodeDecodeError` -- and, since that happens while assembling the result, discarded the very output needed to diagnose it.  A mere libmagic warning on `stderr` (as emitted by the copy bundled with git-annex when its magic database does not match) was enough to abort an unrelated `git annex get`.  Output is now decoded with `surrogateescape`, keeping such bytes recoverable via `.encode(encoding, 'surrogateescape')`, the way Python itself handles undecodable file names.  Via [PR #7924](https://github.com/datalad/datalad/pull/7924)

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -97,6 +97,15 @@ class Push(Interface):
             (i.e. a configured tracking branch, or a single sibling that is
             configured for push)""",
             constraints=EnsureStr() | EnsureNone()),
+        set_upstream=Parameter(
+            args=("-u", "--set-upstream"),
+            action='store_true',
+            doc="""configure the sibling given by [CMD: --to CMD][PY: `to`
+            PY] as the upstream (tracking) remote for the active branch,
+            as `git push -u` would (equivalent to running
+            `git branch --set-upstream-to`). Requires
+            [CMD: --to CMD][PY: `to` PY] to be given; without it, this
+            option errors out."""),
         since=Parameter(
             args=("--since",),
             constraints=EnsureStr() | EnsureNone(),
@@ -180,6 +189,7 @@ class Push(Interface):
             *,
             dataset=None,
             to=None,
+            set_upstream=False,
             since=None,
             data='auto-if-wanted',
             force=None,
@@ -190,6 +200,10 @@ class Push(Interface):
         # behavior. '' was/is (to be deprecated) used in `publish`. Alert user about the mistake
         if since == '':
             raise ValueError("'since' should point to commitish or use '^'.")
+        if set_upstream and not to:
+            raise ValueError(
+                "--set-upstream (-u) requires the target sibling to be "
+                "given via --to")
         # we resolve here, because we need to perform inspection on what was given
         # as an input argument further down
         paths = [resolve_path(p, dataset) for p in ensure_list(path)]
@@ -254,7 +268,8 @@ class Push(Interface):
             pbars = {}
             yield from _push(
                 dspath, dsrecords, to, data, force, jobs, res_kwargs.copy(), pbars,
-                got_path_arg=True if path else False)
+                got_path_arg=True if path else False,
+                set_upstream=set_upstream)
             # take down progress bars for this dataset
             for i, ds in pbars.items():
                 log_progress(lgr.info, i, 'Finished push of %s', ds)
@@ -421,7 +436,7 @@ def _transfer_data(repo, ds, target, content, data, force, jobs, res_kwargs,
 
 
 def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
-          got_path_arg=False):
+          got_path_arg=False, set_upstream=False):
     force_git_push = force in ('all', 'gitpush')
 
     # nothing recursive in here, we only need a repo to work with
@@ -721,6 +736,28 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
         res_kwargs.copy(),
     )
 
+    if set_upstream and active_branch:
+        # mimic `git push -u`: configure `target` as the upstream
+        # (tracking) remote for the active branch. The branch was just
+        # pushed above, so this is a cheap up-to-date push that merely
+        # has git record the tracking configuration -- the same as
+        # `git branch --set-upstream-to` would (but without requiring a
+        # pre-existing remote-tracking ref). Kept as a separate push, so
+        # this does not also mark internal branches (e.g. `git-annex`)
+        # that ride along in `refspecs2push` as tracking `target`.
+        yield from _push_refspecs(
+            repo,
+            target,
+            ['{0}:{0}'.format(active_branch)],
+            False,
+            res_kwargs.copy(),
+            set_upstream=True,
+        )
+        # git wrote the tracking configuration straight to the config
+        # file via the `git push` subprocess above -- make sure our own
+        # in-memory config cache picks it up too
+        repo.config.reload()
+
 
 def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
     # try to anticipate any flavor of an idea of a branch ending up in a refspec
@@ -734,11 +771,17 @@ def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
         )
 
 
-def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
+def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs,
+                    set_upstream=False):
+    git_options = []
+    if force_git_push:
+        git_options.append('--force')
+    if set_upstream:
+        git_options.append('--set-upstream')
     push_res = repo.push(
         remote=target,
         refspec=refspecs,
-        git_options=['--force'] if force_git_push else None,
+        git_options=git_options or None,
     )
     # TODO maybe compress into a single message whenever everything is
     # OK?

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -266,10 +266,20 @@ class Push(Interface):
             matched_anything = True
             lgr.debug('Pushing Dataset at %s', dspath)
             pbars = {}
-            yield from _push(
-                dspath, dsrecords, to, data, force, jobs, res_kwargs.copy(), pbars,
-                got_path_arg=True if path else False,
-                set_upstream=set_upstream)
+            pushed_ok = True
+            for res in _push(
+                    dspath, dsrecords, to, data, force, jobs, res_kwargs.copy(), pbars,
+                    got_path_arg=True if path else False):
+                if res.get('status') == 'error':
+                    pushed_ok = False
+                yield res
+            if set_upstream and pushed_ok:
+                # do this as a separate step, rather than threading
+                # `set_upstream` through `_push()`/`_push_refspecs()` --
+                # `_push()` is monkey-patched wholesale by some extensions
+                # (e.g. datalad-next), so changing its call signature here
+                # would break them
+                yield from _set_push_upstream(dspath, to, res_kwargs.copy())
             # take down progress bars for this dataset
             for i, ds in pbars.items():
                 log_progress(lgr.info, i, 'Finished push of %s', ds)
@@ -436,7 +446,7 @@ def _transfer_data(repo, ds, target, content, data, force, jobs, res_kwargs,
 
 
 def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
-          got_path_arg=False, set_upstream=False):
+          got_path_arg=False):
     force_git_push = force in ('all', 'gitpush')
 
     # nothing recursive in here, we only need a repo to work with
@@ -736,27 +746,36 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
         res_kwargs.copy(),
     )
 
-    if set_upstream and active_branch:
-        # mimic `git push -u`: configure `target` as the upstream
-        # (tracking) remote for the active branch. The branch was just
-        # pushed above, so this is a cheap up-to-date push that merely
-        # has git record the tracking configuration -- the same as
-        # `git branch --set-upstream-to` would (but without requiring a
-        # pre-existing remote-tracking ref). Kept as a separate push, so
-        # this does not also mark internal branches (e.g. `git-annex`)
-        # that ride along in `refspecs2push` as tracking `target`.
-        yield from _push_refspecs(
-            repo,
-            target,
-            ['{0}:{0}'.format(active_branch)],
-            False,
-            res_kwargs.copy(),
-            set_upstream=True,
-        )
-        # git wrote the tracking configuration straight to the config
-        # file via the `git push` subprocess above -- make sure our own
-        # in-memory config cache picks it up too
-        repo.config.reload()
+
+def _set_push_upstream(dspath, target, res_kwargs):
+    # mimic `git push -u`: configure `target` as the upstream (tracking)
+    # remote for the active branch of the dataset at `dspath`. Assumes the
+    # branch has just been pushed to `target` by a preceding, regular
+    # `_push()` call for the same dataset -- this performs one more, cheap
+    # ("everything up-to-date") push, just to have git itself record the
+    # tracking configuration, the same way `git push -u` does. Kept as a
+    # standalone call (rather than a `_push()`/`_push_refspecs()` param),
+    # so that datasets without a push (e.g. nothing needed pushing) do not
+    # get the corresponding branch pushed here.
+    repo = Dataset(dspath).repo
+    active_branch = repo.get_corresponding_branch() or repo.get_active_branch()
+    if not active_branch:
+        return
+    # a separate push, rather than folding into the caller's refspecs2push,
+    # so this does not also mark internal branches (e.g. `git-annex`) that
+    # ride along in the same push as tracking `target`
+    yield from _push_refspecs(
+        repo,
+        target,
+        ['{0}:{0}'.format(active_branch)],
+        False,
+        res_kwargs,
+        set_upstream=True,
+    )
+    # git wrote the tracking configuration straight to the config file via
+    # the `git push` subprocess above -- make sure our own in-memory config
+    # cache picks it up too
+    repo.config.reload()
 
 
 def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
@@ -772,7 +791,7 @@ def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
 
 
 def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs,
-                    set_upstream=False):
+                   set_upstream=False):
     git_options = []
     if force_git_push:
         git_options.append('--force')

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -74,6 +74,7 @@ from datalad.tests.utils_pytest import (
     skip_if_adjusted_branch,
     skip_if_no_network,
     skip_if_on_windows,
+    skip_if_url_is_not_available,
     skip_ssh,
     slow,
     swallow_logs,
@@ -1342,10 +1343,27 @@ def test_inherit_src_candidates(lcl=None, storepath=None, url=None):
             'ria+%s#{id}' % url)
 
 
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+def test_ria_http_local_store(lcl=None, storepath=None, url=None):
+    # hermetic stand-in for test_ria_http_storedataladorg (gh-7912).
+    # test_ria_http covers this too, but is @slow and so deselected by the
+    # default GitHub job's PYTEST_SELECTION.
+    ds = Dataset(op.join(lcl, 'ds')).create()
+    _move2store(Path(storepath), ds)
+    riaclone = clone('ria+{}#{}'.format(url, ds.id), op.join(lcl, 'clone'))
+    ok_(riaclone.is_installed())
+    eq_(riaclone.id, ds.id)
+
+
 @skip_if_no_network
+@pytest.mark.flaky(retries=2, delay=5, only_on=[IncompleteResultsError])
 @with_tempfile()
 def test_ria_http_storedataladorg(path=None):
-    # can we clone from the store w/o any dedicated config
+    # an outage of this external service is not a failure of this code
+    # base (gh-7912)
+    skip_if_url_is_not_available('http://store.datalad.org/')
     ds = clone('ria+http://store.datalad.org#{}'.format(datalad_store_testds_id), path)
     ok_(ds.is_installed())
     eq_(ds.id, datalad_store_testds_id)

--- a/datalad/core/distributed/tests/test_clone.py
+++ b/datalad/core/distributed/tests/test_clone.py
@@ -74,7 +74,6 @@ from datalad.tests.utils_pytest import (
     skip_if_adjusted_branch,
     skip_if_no_network,
     skip_if_on_windows,
-    skip_if_url_is_not_available,
     skip_ssh,
     slow,
     swallow_logs,
@@ -1357,13 +1356,12 @@ def test_ria_http_local_store(lcl=None, storepath=None, url=None):
     eq_(riaclone.id, ds.id)
 
 
-@skip_if_no_network
+# an outage of this external service is not a failure of this code base
+# (gh-7912), so gate on it actually answering rather than on network at large.
+@skip_if_no_network(url='http://store.datalad.org/')
 @pytest.mark.flaky(retries=2, delay=5, only_on=[IncompleteResultsError])
 @with_tempfile()
 def test_ria_http_storedataladorg(path=None):
-    # an outage of this external service is not a failure of this code
-    # base (gh-7912)
-    skip_if_url_is_not_available('http://store.datalad.org/')
     ds = clone('ria+http://store.datalad.org#{}'.format(datalad_store_testds_id), path)
     ok_(ds.is_installed())
     eq_(ds.id, datalad_store_testds_id)

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -102,6 +102,11 @@ def test_invalid_call(origin=None, tdir=None):
         ValueError,
         ds.push, to='target', since='')
 
+    # --set-upstream/-u without --to is not supported, see gh-7917
+    assert_raises(
+        ValueError,
+        ds.push, set_upstream=True)
+
 
 @pytest.mark.ai_generated
 @with_tempfile(mkdir=True)
@@ -304,6 +309,36 @@ def check_push(annex, src_path, dst_path):
 @pytest.mark.parametrize("annex", [False, True])
 def test_push(annex):
     check_push(annex)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_push_set_upstream(src_path=None, dst_path=None):
+    # gh-7917: -u/--set-upstream should mimic `git push -u`
+    ds = Dataset(src_path).create(annex=False)
+    ds_repo = ds.repo
+    mk_push_target(ds, 'target', dst_path, annex=False)
+
+    # nothing is tracking anything yet
+    eq_(ds_repo.get_tracking_branch(), (None, None))
+
+    res = ds.push(to='target', set_upstream=True, **ckwa)
+    # the branch is pushed for the first time ('ok'), and the extra
+    # up-to-date push done to have git record the tracking
+    # configuration is reported as 'notneeded'
+    assert_status(['ok', 'notneeded'], res)
+
+    # the active branch is now tracking 'target'
+    eq_(
+        ds_repo.get_tracking_branch(),
+        ('target', 'refs/heads/{}'.format(DEFAULT_BRANCH)))
+
+    # and this is not just config bookkeeping -- an argument-less push/pull
+    # now works
+    (ds.pathobj / 'a_file').write_text('some content')
+    ds.save(message="Some content", **ckwa)
+    res = ds.push(**ckwa)
+    assert_in_results(res, action='publish', status='ok', target='target')
 
 
 def check_datasets_order(res, order='bottom-up'):

--- a/datalad/distributed/tests/test_create_sibling_gitea.py
+++ b/datalad/distributed/tests/test_create_sibling_gitea.py
@@ -13,6 +13,7 @@ import requests
 from datalad.api import create_sibling_gitea
 from datalad.tests.utils_pytest import (
     skip_if_no_network,
+    skip_if_url_is_not_available,
     with_tempfile,
 )
 
@@ -20,9 +21,13 @@ from .test_create_sibling_ghlike import check4real
 
 
 @skip_if_no_network
-@pytest.mark.flaky(retries=3, only_on=[requests.exceptions.HTTPError])
+@pytest.mark.flaky(retries=3, delay=5, only_on=[requests.exceptions.HTTPError])
 @with_tempfile
 def test_gitea(path=None):
+    # demo.gitea.com is Gitea's public demo instance: no SLA, reset
+    # regularly, and unreachable for long stretches. Its outage is not a
+    # failure of this code base (gh-7912).
+    skip_if_url_is_not_available('https://demo.gitea.com/api/v1/version')
     check4real(
         create_sibling_gitea,
         path,

--- a/datalad/distributed/tests/test_create_sibling_gitea.py
+++ b/datalad/distributed/tests/test_create_sibling_gitea.py
@@ -13,21 +13,19 @@ import requests
 from datalad.api import create_sibling_gitea
 from datalad.tests.utils_pytest import (
     skip_if_no_network,
-    skip_if_url_is_not_available,
     with_tempfile,
 )
 
 from .test_create_sibling_ghlike import check4real
 
 
-@skip_if_no_network
+# demo.gitea.com is Gitea's public demo instance: no SLA, reset regularly, and
+# unreachable for long stretches. Its outage is not a failure of this code base
+# (gh-7912), so gate on it actually answering rather than on network at large.
+@skip_if_no_network(url='https://demo.gitea.com/api/v1/version')
 @pytest.mark.flaky(retries=3, delay=5, only_on=[requests.exceptions.HTTPError])
 @with_tempfile
 def test_gitea(path=None):
-    # demo.gitea.com is Gitea's public demo instance: no SLA, reset
-    # regularly, and unreachable for long stretches. Its outage is not a
-    # failure of this code base (gh-7912).
-    skip_if_url_is_not_available('https://demo.gitea.com/api/v1/version')
     check4real(
         create_sibling_gitea,
         path,

--- a/datalad/downloaders/base.py
+++ b/datalad/downloaders/base.py
@@ -307,6 +307,13 @@ class BaseDownloader(object, metaclass=ABCMeta):
                 # So we didn't know if authentication necessary, and it
                 # seems to be necessary, so Let's ask the user to setup
                 # authentication mechanism for this website
+                if not ui.is_interactive:
+                    # no way to prompt, so surface the original failure
+                    # instead of dying inside the credentials dialog
+                    lgr.error(
+                        "Interface is non interactive, so we are "
+                        "reraising: %s", ce)
+                    raise e
                 self._enter_credentials(
                     url,
                     denied_msg=access_denied,

--- a/datalad/pytest_plugin.py
+++ b/datalad/pytest_plugin.py
@@ -26,6 +26,21 @@ import re
 from pathlib import Path
 
 
+def pytest_report_header(config) -> list[str]:
+    """Report versions of datalad and its dependencies at session start
+
+    `datalad.conftest` already dumps these at teardown; a CI failure is
+    triaged from the top of the log, so report them there too (gh-7911).
+    """
+    # imported here, not at module level: this plugin is loaded through the
+    # pytest11 entry point, where importing datalad is not free
+    from datalad.support.external_versions import external_versions
+
+    # query datalad's own version so it is included in the dump
+    external_versions['datalad']
+    return [external_versions.dumps(query=True)]
+
+
 def pytest_configure(config):
     """Register datalad custom markers and pytest configuration.
 

--- a/datalad/runner/protocol.py
+++ b/datalad/runner/protocol.py
@@ -200,10 +200,20 @@ class WitlessProtocol:
             8,
             'Process %i exited with return code %i',
             self.process.pid, return_code)
-        # give captured process output back to the runner as string(s)
+        # give captured process output back to the runner as string(s).
+        # Decode with 'surrogateescape': output of a command is not
+        # guaranteed to be valid in `encoding` -- POSIX file names are
+        # arbitrary byte strings, and 3rd party libraries (e.g. libmagic
+        # used by git-annex) may echo raw bytes into their messages.  A
+        # strict decode would fail the entire command over such output,
+        # even when it is a mere warning on stderr, and would discard the
+        # very output needed to tell what happened.  'surrogateescape'
+        # keeps those bytes recoverable via
+        # `.encode(encoding, 'surrogateescape')`, the same way Python
+        # itself handles undecodable file names.
         results: dict[str, Any] = {
             name: (
-                bytes(byt).decode(self.encoding)
+                bytes(byt).decode(self.encoding, errors='surrogateescape')
                 if byt is not None
                 else '')
             for name, byt in self.fd_infos.values()

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -704,15 +704,23 @@ def test_concurrent_generator_reading() -> None:
         t.join()
 
     collected_outputs = [
-        output_tuple[1]
-        for output_tuple in output_queue.queue
-        if output_tuple[1] is not None
+        (thread_number, int(output.split("#")[1]))
+        for thread_number, output in output_queue.queue
+        if output is not None
     ]
-    assert len(collected_outputs) == number_of_lines
-    assert collected_outputs == [
-        f"result#{i}"
-        for i in range(number_of_lines)
-    ]
+
+    # The merged order of `output_queue` is not deterministic: a reader
+    # thread can be preempted between `next()` returning and its `put()`,
+    # while other threads receive and enqueue later results (gh-7910).
+    # Assert only what is guaranteed -- every result delivered exactly
+    # once, and each thread's own results in generation order, since
+    # `next()` is serialized by `_ResultGenerator.send_lock`.
+    assert sorted(i for _, i in collected_outputs) == list(range(number_of_lines))
+    last_seen: dict[int, int] = {}
+    for thread_number, i in collected_outputs:
+        assert i > last_seen.get(thread_number, -1), \
+            f"thread {thread_number} received result#{i} out of order"
+        last_seen[thread_number] = i
 
 
 def test_same_thread_reenter_detection() -> None:

--- a/datalad/runner/tests/test_nonasyncrunner.py
+++ b/datalad/runner/tests/test_nonasyncrunner.py
@@ -23,7 +23,10 @@ from collections.abc import (
 )
 from itertools import count
 from queue import Queue
-from threading import Thread
+from threading import (
+    Lock,
+    Thread,
+)
 from time import sleep
 from typing import (
     Any,
@@ -681,14 +684,23 @@ def test_concurrent_generator_reading() -> None:
     )
     result_generator = threaded_runner.run()
 
+    # `_ResultGenerator.send()` hands out results in generation order, under
+    # its own lock.  This test used to observe that order in two unlocked
+    # steps -- `next()`, then `put()` -- so a thread preempted between them
+    # let other threads enqueue later results first, and the merged order
+    # drifted by an adjacent swap (gh-7910).  Serializing the observation
+    # with the handout makes `output_queue` reflect the generation order.
+    read_lock = Lock()
+
     def thread_main(thread_number: int, result_generator: Iterator[str], output_queue: Queue[tuple[int, Optional[str]]]) -> None:
         while True:
-            try:
-                output = next(result_generator)
-            except StopIteration:
-                output_queue.put((thread_number, None))
-                break
-            output_queue.put((thread_number, output))
+            with read_lock:
+                try:
+                    output = next(result_generator)
+                except StopIteration:
+                    output_queue.put((thread_number, None))
+                    break
+                output_queue.put((thread_number, output))
 
     caller_threads = []
     for c in range(number_of_threads):
@@ -704,23 +716,15 @@ def test_concurrent_generator_reading() -> None:
         t.join()
 
     collected_outputs = [
-        (thread_number, int(output.split("#")[1]))
-        for thread_number, output in output_queue.queue
-        if output is not None
+        output_tuple[1]
+        for output_tuple in output_queue.queue
+        if output_tuple[1] is not None
     ]
-
-    # The merged order of `output_queue` is not deterministic: a reader
-    # thread can be preempted between `next()` returning and its `put()`,
-    # while other threads receive and enqueue later results (gh-7910).
-    # Assert only what is guaranteed -- every result delivered exactly
-    # once, and each thread's own results in generation order, since
-    # `next()` is serialized by `_ResultGenerator.send_lock`.
-    assert sorted(i for _, i in collected_outputs) == list(range(number_of_lines))
-    last_seen: dict[int, int] = {}
-    for thread_number, i in collected_outputs:
-        assert i > last_seen.get(thread_number, -1), \
-            f"thread {thread_number} received result#{i} out of order"
-        last_seen[thread_number] = i
+    assert len(collected_outputs) == number_of_lines
+    assert collected_outputs == [
+        f"result#{i}"
+        for i in range(number_of_lines)
+    ]
 
 
 def test_same_thread_reenter_detection() -> None:

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -16,6 +16,7 @@ import os
 import signal
 import sys
 import unittest.mock
+from locale import getpreferredencoding
 from threading import (
     Lock,
     Thread,
@@ -99,6 +100,25 @@ def test_runner_stdout_capture() -> None:
     assert isinstance(res, dict)
     eq_(res['stdout'].rstrip(), test_msg)
     ok_(not res['stderr'])
+
+
+@pytest.mark.ai_generated
+def test_runner_undecodable_output() -> None:
+    # command output is not guaranteed to be valid in the target encoding:
+    # POSIX file names are arbitrary byte strings, and 3rd party libraries
+    # may echo raw bytes into their messages.  Such output must not fail
+    # the command, and must remain recoverable.
+    encoding = getpreferredencoding(do_setlocale=False)
+    payload = b'before \xf1 after'
+    runner = Runner()
+    res = runner.run(py2cmd(
+        'import sys; sys.stdout.buffer.write(%r); sys.stderr.buffer.write(%r)'
+        % (payload, payload)),
+        protocol=StdOutErrCapture,
+    )
+    assert isinstance(res, dict)
+    for stream in ('stdout', 'stderr'):
+        eq_(res[stream].encode(encoding, 'surrogateescape'), payload)
 
 
 def test_runner_failure() -> None:

--- a/datalad/tests/test_pytest_plugin.py
+++ b/datalad/tests/test_pytest_plugin.py
@@ -43,6 +43,9 @@ def test_plugin_registers_markers(pytester):
     result = pytester.runpytest_subprocess("--markers")
     # Check that key markers are registered (not order-dependent)
     output = result.stdout.str()
+    # the versions header is emitted by our pytest_report_header (gh-7911);
+    # asserting it here proves the pytest11 entry point is wired up at all
+    assert "Versions:" in output
     assert "@pytest.mark.network: marks tests requiring network access" in output
     assert "@pytest.mark.slow: marks slow tests" in output
     assert "@pytest.mark.integration: marks integration tests" in output

--- a/datalad/tests/test_pytest_plugin.py
+++ b/datalad/tests/test_pytest_plugin.py
@@ -43,9 +43,6 @@ def test_plugin_registers_markers(pytester):
     result = pytester.runpytest_subprocess("--markers")
     # Check that key markers are registered (not order-dependent)
     output = result.stdout.str()
-    # the versions header is emitted by our pytest_report_header (gh-7911);
-    # asserting it here proves the pytest11 entry point is wired up at all
-    assert "Versions:" in output
     assert "@pytest.mark.network: marks tests requiring network access" in output
     assert "@pytest.mark.slow: marks slow tests" in output
     assert "@pytest.mark.integration: marks integration tests" in output
@@ -69,6 +66,11 @@ def test_plugin_markers_work(pytester):
     result = pytester.runpytest_subprocess("-v", "-m", "network")
     result.stdout.fnmatch_lines(["*test_with_network*PASSED*"])
     assert "test_without_marker" not in result.stdout.str()
+    # the versions line comes from our pytest_report_header (gh-7911), and
+    # asserting it on a real session is the only check that the pytest11
+    # entry point is wired up at all.  It must not be asserted on a
+    # `--markers` run: that exits before a session starts, so no header.
+    assert "Versions:" in result.stdout.str()
 
 
 @pytest.mark.ai_generated

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -227,6 +227,13 @@ def skip_if_url_is_not_available(url, regex=None):
             pytest.skip("%s matched %r -- skipping the test" % (url, regex))
     except DownloadError:
         pytest.skip("%s failed to download" % url)
+    except Exception as exc:
+        # Anything else raised while merely probing availability also means
+        # we could not reach the URL.  Notably a 403 sends the downloader
+        # down its credential-entry path, which cannot work in a
+        # non-interactive test session.  (`pytest.skip` above raises a
+        # BaseException, so it is not caught here.)
+        pytest.skip("%s is not available: %r" % (url, exc))
 
 
 def check_not_generatorfunction(func):

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -236,25 +236,45 @@ def check_not_generatorfunction(func):
                            .format(func.__name__))
 
 
-def skip_if_no_network(func=None):
+def skip_if_no_network(func=None, url=None):
     """Skip test completely in NONETWORK settings
 
     If not used as a decorator, and just a function, could be used at the module level
+
+    Parameters
+    ----------
+    url: str, optional
+      Also skip if this URL cannot be retrieved, so that an outage of a
+      third-party service a test depends on does not turn CI red (gh-7912).
+      `datalad.tests.nonetwork` alone cannot express that: it only says
+      whether there is network at all, not whether this particular host
+      answers.  Given `url`, this must be used as a decorator --
+      `@skip_if_no_network(url=...)` -- since the URL is probed when the
+      test runs, not when the module is imported.
     """
-    check_not_generatorfunction(func)
 
     def check_and_raise():
         if dl_cfg.get('datalad.tests.nonetwork'):
             pytest.skip("Skipping since no network settings", allow_module_level=True)
+        if url is not None:
+            skip_if_url_is_not_available(url)
 
-    if func:
-        @wraps(func)
+    def decorate(func_):
+        check_not_generatorfunction(func_)
+
+        @wraps(func_)
         @attr('network')
         @attr('skip_if_no_network')
         def  _wrap_skip_if_no_network(*args, **kwargs):
             check_and_raise()
-            return func(*args, **kwargs)
+            return func_(*args, **kwargs)
         return  _wrap_skip_if_no_network
+
+    if func:
+        return decorate(func)
+    elif url is not None:
+        # invoked with arguments, so we are the decorator factory
+        return decorate
     else:
         check_and_raise()
 

--- a/datalad/tests/utils_pytest.py
+++ b/datalad/tests/utils_pytest.py
@@ -227,13 +227,6 @@ def skip_if_url_is_not_available(url, regex=None):
             pytest.skip("%s matched %r -- skipping the test" % (url, regex))
     except DownloadError:
         pytest.skip("%s failed to download" % url)
-    except Exception as exc:
-        # Anything else raised while merely probing availability also means
-        # we could not reach the URL.  Notably a 403 sends the downloader
-        # down its credential-entry path, which cannot work in a
-        # non-interactive test session.  (`pytest.skip` above raises a
-        # BaseException, so it is not caught here.)
-        pytest.skip("%s is not available: %r" % (url, exc))
 
 
 def check_not_generatorfunction(func):


### PR DESCRIPTION
## Overview

`datalad push --to REMOTE` did not offer a way to configure `REMOTE` as
the tracking (upstream) remote for the active branch -- users had to
follow up with a plain `git push -u REMOTE branch` or
`git branch --set-upstream-to` after the fact.

This adds a `-u`/`--set-upstream` flag to `push` that mimics
`git push -u`: given together with `--to SIBLING`, it configures
`SIBLING` as the upstream remote for the active branch as part of the
same push. Without `--to`, `--set-upstream` errors out immediately with
an actionable message (`--set-upstream (-u) requires the target sibling
to be given via --to`), since there'd otherwise be no unambiguous
target to track.

Fixes #7917

## Implementation notes

- The active branch (and, for annex repos, the `git-annex` branch) are
  already unconditionally included in every push by `push`'s existing
  refspec-selection logic. After that regular push succeeds,
  `--set-upstream` triggers one more, explicit push of just the active
  branch's refspec with git's own `--set-upstream` flag. Since the
  branch was already pushed above, this second push is a cheap
  "everything up-to-date" negotiation -- it does not transfer anything,
  it only has git itself record the tracking configuration, the same
  way `git push -u` does when the branch happens to already be current.
- This reuses `GitRepo.push()`/`_push_refspecs()` (refspec push +
  result/status handling) instead of hand-rolling the
  `branch.<name>.remote`/`branch.<name>.merge` config writes, and keeps
  the tracking change scoped to the active branch only -- so internal
  branches that ride along in the same push (notably `git-annex`) are
  not also marked as tracking the target sibling.
- `repo.config.reload()` is called afterwards so the in-process config
  cache picks up what the `git push` subprocess just wrote directly to
  `.git/config`, following the same pattern already used elsewhere in
  `GitRepo`/`AnnexRepo` after config-affecting git subprocess calls
  (e.g. `add_remote`).

## Testing

- Added `test_push_set_upstream` (`datalad/core/distributed/tests/test_push.py`):
  verifies no tracking branch is configured beforehand, that
  `ds.push(to='target', set_upstream=True)` configures it, and that a
  subsequent bare `ds.push()` (relying on the now-configured tracking
  branch) succeeds.
- Added a case to `test_invalid_call` asserting `ds.push(set_upstream=True)`
  (without `--to`) raises `ValueError`.
- Manually verified end-to-end with an annex-backed dataset via the CLI:
  `datalad push --to target -u` pushes `master`+`git-annex`, sets
  `branch.master.remote`/`branch.master.merge` (but not for
  `git-annex`), and a subsequent plain `git push` with no arguments
  then succeeds using the newly configured upstream.
- `datalad/core/distributed/tests/test_push.py` passes in full (20
  passed, 1 pre-existing skip).

### PR checklist

- [x] Provide an overview of the changes you're making and explain why you're proposing them.
- [ ] Create a changelog snippet (add the `CHANGELOG-missing` label to this pull request in order to have a snippet generated from its title; or use `scriv create` locally and include the generated file in the pull request, see [scriv](https://scriv.readthedocs.io/)).
- [x] Include `Fixes #NNN` somewhere in the description and `scriv` changelog entry if this PR addresses an existing issue.
- [x] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu. -- N/A, complete.
- [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.

Closes #7917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVEBQJ4A1arX3rwuSgbJuH


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVEBQJ4A1arX3rwuSgbJuH)_