### PR TITLE
NF: push: add -u/--set-upstream option to configure branch tracking

### DIFF
--- a/changelog.d/pr-7919.md
+++ b/changelog.d/pr-7919.md
@@ -1,4 +1,4 @@
-### 💫 Enhancements and new features
+### 🚀 Enhancements and New Features
 
 - `push` now supports `-u`/`--set-upstream` to configure the pushed branch
   to track the target sibling, mirroring `git push -u`.

--- a/changelog.d/pr-7919.md
+++ b/changelog.d/pr-7919.md
@@ -1,0 +1,6 @@
+### 💫 Enhancements and new features
+
+- `push` now supports `-u`/`--set-upstream` to configure the pushed branch
+  to track the target sibling, mirroring `git push -u`.
+  [PR #7919](https://github.com/datalad/datalad/pull/7919)
+  (by [@yarikoptic-gitmate](https://github.com/yarikoptic-gitmate))

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -266,8 +266,14 @@ class Push(Interface):
             pbars = {}
             yield from _push(
                 dspath, dsrecords, to, data, force, jobs, res_kwargs.copy(), pbars,
-                got_path_arg=True if path else False,
-                set_upstream=set_upstream)
+                got_path_arg=True if path else False)
+            if set_upstream:
+                # kept as an independent, follow-up step (rather than
+                # threaded through `_push()`/`_push_refspecs()`) so as to
+                # not alter the signature of functions that at least one
+                # widely-used extension (datalad-next) fully replaces --
+                # see gh-7917 discussion.
+                yield from _set_upstream_for_dataset(dspath, to)
             # take down progress bars for this dataset
             for i, ds in pbars.items():
                 log_progress(lgr.info, i, 'Finished push of %s', ds)
@@ -434,7 +440,7 @@ def _transfer_data(repo, ds, target, content, data, force, jobs, res_kwargs,
 
 
 def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
-          got_path_arg=False, set_upstream=False):
+          got_path_arg=False):
     force_git_push = force in ('all', 'gitpush')
 
     # nothing recursive in here, we only need a repo to work with
@@ -621,10 +627,6 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
             "skipping git push dry-run and refspec computation",
             target)
         refspecs2push = []
-        if set_upstream:
-            lgr.warning(
-                "Cannot set up tracking branch: '%s' is not a git remote",
-                target)
 
     # we know what to push and where, now dependency processing first
     for r in publish_depends:
@@ -728,46 +730,22 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
         lgr.debug('No refspecs found that need to be pushed')
         return
 
-    if set_upstream and not active_branch:
-        lgr.warning(
-            "Cannot set up tracking branch: no active branch")
-
-    # git's own -u/--set-upstream applies to *every* branch in a single
-    # push invocation (e.g. also 'git-annex'), not just the one the user
-    # asked to track -- split it off into its own push so only the active
-    # branch's refspec gets it
-    upstream_refspecs, other_refspecs = [], refspecs2push
-    if set_upstream and active_branch:
-        upstream_refspecs = [
-            r for r in refspecs2push
-            if _refspec_targets_branch(r, active_branch)
-        ]
-        other_refspecs = [
-            r for r in refspecs2push if r not in upstream_refspecs]
-
     # and push all relevant branches, plus the git-annex branch to announce
     # local availability info too
-    if upstream_refspecs:
-        yield from _push_refspecs(
-            repo, target, upstream_refspecs, force_git_push, True,
-            res_kwargs.copy())
-    if other_refspecs:
-        yield from _push_refspecs(
-            repo, target, other_refspecs, force_git_push, False,
-            res_kwargs.copy())
-
-
-def _branch_refspec_pattern(branch):
-    # try to anticipate any flavor of an idea of a branch ending up in a refspec
-    return re.compile(r'((^|.*:)refs/heads/|.*:|^){}$'.format(branch))
-
-
-def _refspec_targets_branch(refspec, branch):
-    return bool(_branch_refspec_pattern(branch).match(refspec))
+    yield from _push_refspecs(
+        repo,
+        target,
+        refspecs2push,
+        force_git_push,
+        res_kwargs.copy(),
+    )
 
 
 def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
-    if not any(_refspec_targets_branch(r, branch) for r in refspecs):
+    # try to anticipate any flavor of an idea of a branch ending up in a refspec
+    looks_like_that_branch = re.compile(
+        r'((^|.*:)refs/heads/|.*:|^){}$'.format(branch))
+    if all(not looks_like_that_branch.match(r) for r in refspecs):
         refspecs.append(
             branch
             if ds.config.get('branch.{}.merge'.format(branch), None)
@@ -775,17 +753,16 @@ def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
         )
 
 
-def _push_refspecs(repo, target, refspecs, force_git_push, set_upstream, res_kwargs):
-    git_options = []
-    if force_git_push:
-        git_options.append('--force')
-    if set_upstream:
-        git_options.append('--set-upstream')
+def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
     push_res = repo.push(
         remote=target,
         refspec=refspecs,
-        git_options=git_options or None,
+        git_options=['--force'] if force_git_push else None,
     )
+    yield from _pushres_to_results(push_res, res_kwargs)
+
+
+def _pushres_to_results(push_res, res_kwargs):
     # TODO maybe compress into a single message whenever everything is
     # OK?
     for pr in push_res:
@@ -823,6 +800,64 @@ def _push_refspecs(repo, target, refspecs, force_git_push, set_upstream, res_kwa
                 pr['to_ref'],
                 pr['note']),
         )
+
+
+def _set_upstream_for_dataset(dspath, target):
+    """Configure `target` as the tracking sibling for `dspath`'s active branch
+
+    Implemented as an independent, follow-up ``git push --set-upstream``
+    (rather than folded into ``_push()``/``_push_refspecs()``) for two
+    reasons:
+
+    - those two functions' call signatures are relied upon by at least one
+      widely-used extension (datalad-next) that fully replaces them; adding
+      a parameter to either breaks that extension outright (gh-7917).
+    - git's own ``-u``/``--set-upstream`` configures tracking for *every*
+      refspec given to a single ``git push`` invocation, not just one of
+      them. A dedicated call naming only the active branch's refspec avoids
+      also configuring tracking for e.g. the ``git-annex`` branch, which
+      would otherwise happen for any annex repo (both are normally pushed
+      together).
+
+    A push with ``--set-upstream`` for a refspec that was already pushed
+    moments ago by the main push machinery is a safe, idempotent no-op
+    ("everything up-to-date"); it still gets git to write the tracking
+    configuration, which is all this needs to achieve.
+    """
+    ds = Dataset(dspath)
+    repo = ds.repo
+    get_remote_kwargs = {'exclude_special_remotes': False} \
+        if isinstance(repo, AnnexRepo) else {}
+    if target not in repo.get_remotes(**get_remote_kwargs):
+        lgr.warning(
+            "Cannot set up tracking branch: '%s' is unknown to %s",
+            target, ds)
+        return
+    if repo.config.get('remote.{}.url'.format(target), None) is None:
+        lgr.warning(
+            "Cannot set up tracking branch: '%s' is not a git remote",
+            target)
+        return
+    active_branch = repo.get_active_branch()
+    if active_branch and isinstance(repo, AnnexRepo):
+        active_branch = repo.get_corresponding_branch(active_branch) \
+            or active_branch
+    if not active_branch:
+        lgr.warning("Cannot set up tracking branch: no active branch")
+        return
+    res_kwargs = dict(
+        action='publish', refds=ds.path, logger=lgr,
+        type='dataset', path=dspath)
+    yield from _push_set_upstream(repo, target, active_branch, res_kwargs)
+
+
+def _push_set_upstream(repo, target, branch, res_kwargs):
+    push_res = repo.push(
+        remote=target,
+        refspec=['{0}:{0}'.format(branch)],
+        git_options=['--set-upstream'],
+    )
+    yield from _pushres_to_results(push_res, res_kwargs)
 
 
 def _push_data(ds, target, content, data, force, jobs, res_kwargs,

--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -132,6 +132,13 @@ class Push(Interface):
             combine all force modes ('all').""",
             constraints=EnsureChoice(
                 'all', 'gitpush', 'checkdatapresent', None)),
+        set_upstream=Parameter(
+            args=("-u", "--set-upstream",),
+            action="store_true",
+            doc="""configure the pushed branch to track the target sibling,
+            equivalent to `git push -u`/`--set-upstream`. Requires
+            [CMD: --to CMD][PY: `to` PY] to be given explicitly, since the
+            tracking branch to set up would otherwise be ambiguous."""),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         jobs=jobs_opt,
@@ -183,6 +190,7 @@ class Push(Interface):
             since=None,
             data='auto-if-wanted',
             force=None,
+            set_upstream=False,
             recursive=False,
             recursion_limit=None,
             jobs=None):
@@ -190,6 +198,10 @@ class Push(Interface):
         # behavior. '' was/is (to be deprecated) used in `publish`. Alert user about the mistake
         if since == '':
             raise ValueError("'since' should point to commitish or use '^'.")
+        if set_upstream and not to:
+            raise ValueError(
+                "--set-upstream/-u requires an explicit target sibling "
+                "to be given via --to")
         # we resolve here, because we need to perform inspection on what was given
         # as an input argument further down
         paths = [resolve_path(p, dataset) for p in ensure_list(path)]
@@ -254,7 +266,8 @@ class Push(Interface):
             pbars = {}
             yield from _push(
                 dspath, dsrecords, to, data, force, jobs, res_kwargs.copy(), pbars,
-                got_path_arg=True if path else False)
+                got_path_arg=True if path else False,
+                set_upstream=set_upstream)
             # take down progress bars for this dataset
             for i, ds in pbars.items():
                 log_progress(lgr.info, i, 'Finished push of %s', ds)
@@ -421,7 +434,7 @@ def _transfer_data(repo, ds, target, content, data, force, jobs, res_kwargs,
 
 
 def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
-          got_path_arg=False):
+          got_path_arg=False, set_upstream=False):
     force_git_push = force in ('all', 'gitpush')
 
     # nothing recursive in here, we only need a repo to work with
@@ -608,6 +621,10 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
             "skipping git push dry-run and refspec computation",
             target)
         refspecs2push = []
+        if set_upstream:
+            lgr.warning(
+                "Cannot set up tracking branch: '%s' is not a git remote",
+                target)
 
     # we know what to push and where, now dependency processing first
     for r in publish_depends:
@@ -711,22 +728,46 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
         lgr.debug('No refspecs found that need to be pushed')
         return
 
+    if set_upstream and not active_branch:
+        lgr.warning(
+            "Cannot set up tracking branch: no active branch")
+
+    # git's own -u/--set-upstream applies to *every* branch in a single
+    # push invocation (e.g. also 'git-annex'), not just the one the user
+    # asked to track -- split it off into its own push so only the active
+    # branch's refspec gets it
+    upstream_refspecs, other_refspecs = [], refspecs2push
+    if set_upstream and active_branch:
+        upstream_refspecs = [
+            r for r in refspecs2push
+            if _refspec_targets_branch(r, active_branch)
+        ]
+        other_refspecs = [
+            r for r in refspecs2push if r not in upstream_refspecs]
+
     # and push all relevant branches, plus the git-annex branch to announce
     # local availability info too
-    yield from _push_refspecs(
-        repo,
-        target,
-        refspecs2push,
-        force_git_push,
-        res_kwargs.copy(),
-    )
+    if upstream_refspecs:
+        yield from _push_refspecs(
+            repo, target, upstream_refspecs, force_git_push, True,
+            res_kwargs.copy())
+    if other_refspecs:
+        yield from _push_refspecs(
+            repo, target, other_refspecs, force_git_push, False,
+            res_kwargs.copy())
+
+
+def _branch_refspec_pattern(branch):
+    # try to anticipate any flavor of an idea of a branch ending up in a refspec
+    return re.compile(r'((^|.*:)refs/heads/|.*:|^){}$'.format(branch))
+
+
+def _refspec_targets_branch(refspec, branch):
+    return bool(_branch_refspec_pattern(branch).match(refspec))
 
 
 def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
-    # try to anticipate any flavor of an idea of a branch ending up in a refspec
-    looks_like_that_branch = re.compile(
-        r'((^|.*:)refs/heads/|.*:|^){}$'.format(branch))
-    if all(not looks_like_that_branch.match(r) for r in refspecs):
+    if not any(_refspec_targets_branch(r, branch) for r in refspecs):
         refspecs.append(
             branch
             if ds.config.get('branch.{}.merge'.format(branch), None)
@@ -734,11 +775,16 @@ def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
         )
 
 
-def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
+def _push_refspecs(repo, target, refspecs, force_git_push, set_upstream, res_kwargs):
+    git_options = []
+    if force_git_push:
+        git_options.append('--force')
+    if set_upstream:
+        git_options.append('--set-upstream')
     push_res = repo.push(
         remote=target,
         refspec=refspecs,
-        git_options=['--force'] if force_git_push else None,
+        git_options=git_options or None,
     )
     # TODO maybe compress into a single message whenever everything is
     # OK?

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -96,6 +96,9 @@ def test_invalid_call(origin=None, tdir=None):
         ValueError,
         ds.push, to='target', since='09320957509720437523')
 
+    # --set-upstream without an explicit --to is ambiguous
+    assert_raises(ValueError, ds.push, set_upstream=True)
+
     # If a publish() user accidentally passes since='', which push() spells as
     # since='^', the call is aborted.
     assert_raises(
@@ -304,6 +307,34 @@ def check_push(annex, src_path, dst_path):
 @pytest.mark.parametrize("annex", [False, True])
 def test_push(annex):
     check_push(annex)
+
+
+@pytest.mark.ai_generated
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_push_set_upstream(src_path=None, dst_path=None):
+    # `src` is annex-enabled (the create() default), so this also covers
+    # that -u/--set-upstream must not leak tracking config onto the
+    # 'git-annex' branch that gets pushed alongside the active one.
+    src = Dataset(src_path).create()
+    src_repo = src.repo
+    mk_push_target(src, 'target', dst_path, annex=True)
+    # no tracking branch configured yet
+    eq_(src_repo.get_tracking_branch(), (None, None))
+    eq_(src_repo.get_tracking_branch('git-annex'), (None, None))
+
+    res = src.push(to='target', set_upstream=True)
+    assert_in_results(
+        res,
+        action='publish', status='ok', target='target',
+        refspec=DEFAULT_REFSPEC,
+        operations=['new-branch'])
+    # now it is, just like after `git push -u`
+    eq_(src_repo.get_tracking_branch(),
+        ('target', 'refs/heads/{}'.format(DEFAULT_BRANCH)))
+    # but the incidentally-pushed 'git-annex' branch must not have been
+    # dragged into tracking by the same -u flag
+    eq_(src_repo.get_tracking_branch('git-annex'), (None, None))
 
 
 def check_datasets_order(res, order='bottom-up'):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2060,6 +2060,10 @@ class GitRepo(CoreGitRepo):
             and cfg.get_from_source('local', cfg_push_var) is not None:
             lgr.debug("Removing %s variable from local git config after successful push", cfg_push_var)
             cfg.unset(cfg_push_var, 'local')
+        if {'-u', '--set-upstream'}.intersection(git_options):
+            # like checkout(), a push with -u/--set-upstream can (re)write
+            # branch.<name>.remote/.merge -- make sure it is reflected
+            cfg.reload()
         return push_res
 
     def push_(self, remote: Optional[str] = None, refspec: str | list[str] | None = None, all_: bool = False, git_options: Optional[list[str]] =None) -> Iterator[PushInfo]:


### PR DESCRIPTION
## Summary

Adds a `-u`/`--set-upstream` flag to `datalad push`, mirroring `git push
-u`. When given, the active branch is configured to track the target
sibling's branch (`branch.<name>.remote`/`.merge`), so subsequent `git
push`/`git pull` (and plain `datalad push`) know where to go without an
explicit `--to`.

Fixes #7917.

## Why

Setting up a push target currently requires either running `git push -u`
directly once, or a separate `datalad siblings` invocation, before `datalad
push` can be used without `--to`. This adds the option directly to `push`,
as suggested in the issue.

## Design notes

- `--set-upstream` requires an explicit `--to SIBLING` (errors out
  otherwise), since the branch to track would otherwise be ambiguous.
- `-u`/`--set-upstream` is handled by a small, independent follow-up step
  (`_set_upstream_for_dataset`) that runs after the main per-dataset push,
  doing a dedicated `git push --set-upstream` naming only the active
  branch's refspec. Pushing an already-just-pushed refspec with
  `--set-upstream` is a safe, idempotent no-op ("everything up-to-date")
  that still gets git to write the tracking config.
- This is deliberately *not* threaded through `_push()`/`_push_refspecs()`
  as an extra parameter: CI on this PR (`test (datalad-next)`) caught that
  doing so breaks the `datalad-next` extension, which fully replaces both
  functions with its own copies (`datalad_next.patches.push_optimize`).
  Keeping their signatures untouched avoids that, and as a side effect
  keeps `-u` from also configuring tracking for the `git-annex` branch that
  gets pushed alongside the active one in annex repos (git's own
  `--set-upstream` applies to *every* refspec in a single invocation, not
  just one).
- `GitRepo.push()` now reloads config after a push that used
  `-u`/`--set-upstream`, matching the existing convention in `checkout()`
  of reloading after git operations known to (re)write branch config —
  otherwise a subsequent `get_tracking_branch()` call in the same process
  would see stale, cached config.

## Testing

- `pytest datalad/core/distributed/tests/test_push.py -q` → 20 passed, 1
  skipped
- `pytest datalad/support/tests/test_gitrepo.py -k push -q` → 2 passed, 1
  skipped
- New tests cover: the `--to`-required validation error, tracking being set
  correctly for the active branch, and — since the default `create()` is
  annex-enabled — that the `git-annex` branch pushed alongside it does
  *not* get tracking config.
- Verified against `datalad-next` 1.6.0 locally (the extension CI runs
  against this PR): `pytest --pyargs datalad_next.patches.tests.test_push
  datalad_next.annexremotes.tests.test_uncurl::test_uncurl_ria_access
  datalad_next.patches.tests.test_patched_ria_ora -q` → all passing after
  the redesign above (they were failing with `TypeError: _push() got an
  unexpected keyword argument 'set_upstream'` before it).

This PR went through two rounds of independent review before being opened
(the git-annex-branch tracking leak was caught and fixed as a result), and
one more fix afterward in response to the `datalad-next` CI failure above.

## PR checklist

- [x] Overview of changes and rationale: see above.
- [x] Changelog snippet: `changelog.d/pr-7919.md`.
- [x] `Fixes #7917`.
- [x] Not a draft; test plan included.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016bLZsKVnaYpVGX9oRNFiDn)_