### PR TITLE
NF: add -u/--set-upstream option to push, mimicking 'git push -u'

### DIFF
--- a/datalad/core/distributed/push.py
+++ b/datalad/core/distributed/push.py
@@ -132,6 +132,18 @@ class Push(Interface):
             combine all force modes ('all').""",
             constraints=EnsureChoice(
                 'all', 'gitpush', 'checkdatapresent', None)),
+        set_upstream=Parameter(
+            args=("-u", "--set-upstream",),
+            action="store_true",
+            doc="""for each pushed branch, configure the target sibling as
+            its upstream (tracking) remote, equivalent to
+            [CMD: git push --set-upstream CMD][PY: `git push --set-upstream`
+            PY]. Requires [CMD: --to CMD][PY: `to` PY] to be given
+            explicitly, because it would otherwise be ambiguous which
+            sibling to track. Like Git itself, this applies to every branch
+            included in the push, not only the active one -- for an annex
+            repository this includes the ``git-annex`` branch, which will
+            also end up tracking the target sibling."""),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         jobs=jobs_opt,
@@ -183,6 +195,7 @@ class Push(Interface):
             since=None,
             data='auto-if-wanted',
             force=None,
+            set_upstream=False,
             recursive=False,
             recursion_limit=None,
             jobs=None):
@@ -190,6 +203,10 @@ class Push(Interface):
         # behavior. '' was/is (to be deprecated) used in `publish`. Alert user about the mistake
         if since == '':
             raise ValueError("'since' should point to commitish or use '^'.")
+        if set_upstream and not to:
+            raise ValueError(
+                "--set-upstream requires an explicit target sibling, "
+                "specify via --to.")
         # we resolve here, because we need to perform inspection on what was given
         # as an input argument further down
         paths = [resolve_path(p, dataset) for p in ensure_list(path)]
@@ -254,7 +271,8 @@ class Push(Interface):
             pbars = {}
             yield from _push(
                 dspath, dsrecords, to, data, force, jobs, res_kwargs.copy(), pbars,
-                got_path_arg=True if path else False)
+                got_path_arg=True if path else False,
+                set_upstream=set_upstream)
             # take down progress bars for this dataset
             for i, ds in pbars.items():
                 log_progress(lgr.info, i, 'Finished push of %s', ds)
@@ -421,7 +439,7 @@ def _transfer_data(repo, ds, target, content, data, force, jobs, res_kwargs,
 
 
 def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
-          got_path_arg=False):
+          got_path_arg=False, set_upstream=False):
     force_git_push = force in ('all', 'gitpush')
 
     # nothing recursive in here, we only need a repo to work with
@@ -719,6 +737,7 @@ def _push(dspath, content, target, data, force, jobs, res_kwargs, pbars,
         refspecs2push,
         force_git_push,
         res_kwargs.copy(),
+        set_upstream=set_upstream,
     )
 
 
@@ -734,11 +753,17 @@ def _append_branch_to_refspec_if_needed(ds, refspecs, branch):
         )
 
 
-def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs):
+def _push_refspecs(repo, target, refspecs, force_git_push, res_kwargs,
+                    set_upstream=False):
+    git_options = []
+    if force_git_push:
+        git_options.append('--force')
+    if set_upstream:
+        git_options.append('--set-upstream')
     push_res = repo.push(
         remote=target,
         refspec=refspecs,
-        git_options=['--force'] if force_git_push else None,
+        git_options=git_options or None,
     )
     # TODO maybe compress into a single message whenever everything is
     # OK?

--- a/datalad/core/distributed/tests/test_push.py
+++ b/datalad/core/distributed/tests/test_push.py
@@ -102,6 +102,9 @@ def test_invalid_call(origin=None, tdir=None):
         ValueError,
         ds.push, to='target', since='')
 
+    # --set-upstream/-u without an explicit --to target is ambiguous
+    assert_raises(ValueError, ds.push, set_upstream=True)
+
 
 @pytest.mark.ai_generated
 @with_tempfile(mkdir=True)
@@ -304,6 +307,48 @@ def check_push(annex, src_path, dst_path):
 @pytest.mark.parametrize("annex", [False, True])
 def test_push(annex):
     check_push(annex)
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def check_push_set_upstream(annex, src_path, dst_path):
+    src = Dataset(src_path).create(annex=annex)
+    src_repo = src.repo
+    mk_push_target(src, 'target', dst_path, annex=annex)
+
+    # nothing is configured as upstream/tracking remote yet
+    eq_(src_repo.get_tracking_branch(), (None, None))
+
+    # a plain push does not configure tracking
+    res = src.push(to='target')
+    assert_in_results(
+        res, action='publish', status='ok', target='target')
+    eq_(src_repo.get_tracking_branch(), (None, None))
+
+    # --set-upstream (mimicking `git push -u`) does, for a push that
+    # actually transfers something
+    (src.pathobj / 'test_mod_file').write_text("Some additional stuff.")
+    src.save(to_git=True, message="Modified.")
+    res = src.push(to='target', since='^', set_upstream=True)
+    assert_in_results(
+        res, action='publish', status='ok', target='target')
+    eq_(src_repo.get_tracking_branch(),
+        ('target', 'refs/heads/{}'.format(DEFAULT_BRANCH)))
+
+    # and a subsequent push without any explicit target now succeeds,
+    # because a tracking branch is configured
+    (src.pathobj / 'test_mod_file2').write_text("Yet more stuff.")
+    src.save(to_git=True, message="Modified again.")
+    res = src.push()
+    assert_in_results(
+        res,
+        action='publish', status='ok', target='target')
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize("annex", [False, True])
+def test_push_set_upstream(annex):
+    check_push_set_upstream(annex)
 
 
 def check_datasets_order(res, order='bottom-up'):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -2060,6 +2060,16 @@ class GitRepo(CoreGitRepo):
             and cfg.get_from_source('local', cfg_push_var) is not None:
             lgr.debug("Removing %s variable from local git config after successful push", cfg_push_var)
             cfg.unset(cfg_push_var, 'local')
+        if '--dry-run' not in git_options \
+                and any(o in git_options for o in ('-u', '--set-upstream')):
+            # git itself may have updated branch.<name>.{remote,merge} as a
+            # side-effect of this push (e.g. for tracking setup); make sure
+            # our config cache reflects that for any code running in this
+            # same process that queries it right after (e.g. get_tracking_branch()).
+            # No force needed: reload()'s own mtime-based staleness check
+            # (see add_remote()/remove_remote() for the same pattern) will
+            # pick up the change.
+            cfg.reload()
         return push_res
 
     def push_(self, remote: Optional[str] = None, refspec: str | list[str] | None = None, all_: bool = False, git_options: Optional[list[str]] =None) -> Iterator[PushInfo]:


### PR DESCRIPTION
Fixes #7917.

## Overview

`datalad push` had no equivalent of `git push -u`: setting up a tracking/upstream sibling required a separate `git branch --set-upstream-to`/`siblings configure` step (or an implicit `git push -u` outside datalad) before a bare `datalad push` (no `--to`) would work. This adds `-u`/`--set-upstream` to `push`, matching the issue's request.

## Changes

- **`datalad/core/distributed/push.py`**
  - New `set_upstream`/`-u`/`--set-upstream` `Parameter` on `Push`.
  - Validation: `set_upstream` without an explicit `--to` raises `ValueError` ("it would otherwise be ambiguous which sibling to track"), per the issue's own suggestion ("could be used with `--to REMOTE` (error otherwise)").
  - `set_upstream` is threaded through `_push()` → `_push_refspecs()`, which appends `--set-upstream` to the `git_options` passed to `GitRepo.push()` — reusing the existing `git push` invocation and `force`-flag plumbing rather than adding a second code path. It is *not* forwarded to the recursive `_push()` call used for `datalad-publish-depends` targets, so `-u` only affects the explicit `--to` target, never a dependency sibling.
  - Documented that, like `git push -u` itself, this applies to every branch included in the push — for an annex repository that includes the `git-annex` branch, which will also end up tracking the target.

- **`datalad/support/gitrepo.py`**
  - `GitRepo.push()`: after a push that included `-u`/`--set-upstream`, call `self.config.reload()`. Git itself writes `branch.<name>.{remote,merge}` as a side effect of `--set-upstream`, and without this, code running later in the same process (e.g. `get_tracking_branch()`, or a subsequent `push()` with no explicit target) would see a stale config cache. Uses the same non-forced `reload()` already used by `add_remote()`/`remove_remote()` right above it — `reload()`'s own mtime-based staleness check is sufficient, no `force=True` needed.

- **`datalad/core/distributed/tests/test_push.py`**
  - `test_invalid_call`: assert `ValueError` for `set_upstream=True` without `--to`.
  - `test_push_set_upstream` (parametrized over `annex`): verifies tracking is unset before and after a plain push, gets set correctly by `--set-upstream`, and that a subsequent bare `push()` (no `--to`) then succeeds via the newly configured tracking branch.

## Testing

- `pytest datalad/core/distributed/tests/test_push.py datalad/support/tests/test_gitrepo.py -k push -v` → 23 passed, 2 skipped (unrelated), 0 failures.
- `flake8`/`codespell` on all touched files: only pre-existing, unrelated findings (none introduced by this diff).
- Reviewed by two independent subagent passes (correctness/reuse-focus and adversarial/edge-case-focus); both rounds' findings addressed:
  - A config-cache staleness bug (tracking branch appearing unset immediately after a successful `--set-upstream` push within the same process) was found and fixed during development, and the added test empirically catches it (verified by reverting the fix and re-running).
  - A follow-up review flagged that `cfg.reload(force=True)` was broader than needed given the codebase's existing non-forced `reload()` pattern, and that the `git-annex`-branch tracking side effect should be documented — both addressed in the pushed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6oQszpSsabyzb7f9VWRLR

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6oQszpSsabyzb7f9VWRLR)_