### PR TITLE
BF: runner - do not fail a command over undecodable output

### DIFF
--- a/changelog.d/pr-7924.md
+++ b/changelog.d/pr-7924.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Command output that is not valid in the preferred encoding no longer fails the command.  `WitlessProtocol._prepare_result()` decoded the captured `stdout`/`stderr` strictly, so a single undecodable byte raised `UnicodeDecodeError` -- and, since that happens while assembling the result, discarded the very output needed to diagnose it.  A mere libmagic warning on `stderr` (as emitted by the copy bundled with git-annex when its magic database does not match) was enough to abort an unrelated `git annex get`.  Output is now decoded with `surrogateescape`, keeping such bytes recoverable via `.encode(encoding, 'surrogateescape')`, the way Python itself handles undecodable file names.  Via [PR #7924](https://github.com/datalad/datalad/pull/7924)

--- a/datalad/runner/protocol.py
+++ b/datalad/runner/protocol.py
@@ -200,10 +200,20 @@ class WitlessProtocol:
             8,
             'Process %i exited with return code %i',
             self.process.pid, return_code)
-        # give captured process output back to the runner as string(s)
+        # give captured process output back to the runner as string(s).
+        # Decode with 'surrogateescape': output of a command is not
+        # guaranteed to be valid in `encoding` -- POSIX file names are
+        # arbitrary byte strings, and 3rd party libraries (e.g. libmagic
+        # used by git-annex) may echo raw bytes into their messages.  A
+        # strict decode would fail the entire command over such output,
+        # even when it is a mere warning on stderr, and would discard the
+        # very output needed to tell what happened.  'surrogateescape'
+        # keeps those bytes recoverable via
+        # `.encode(encoding, 'surrogateescape')`, the same way Python
+        # itself handles undecodable file names.
         results: dict[str, Any] = {
             name: (
-                bytes(byt).decode(self.encoding)
+                bytes(byt).decode(self.encoding, errors='surrogateescape')
                 if byt is not None
                 else '')
             for name, byt in self.fd_infos.values()

--- a/datalad/runner/tests/test_witless_runner.py
+++ b/datalad/runner/tests/test_witless_runner.py
@@ -16,6 +16,7 @@ import os
 import signal
 import sys
 import unittest.mock
+from locale import getpreferredencoding
 from threading import (
     Lock,
     Thread,
@@ -99,6 +100,25 @@ def test_runner_stdout_capture() -> None:
     assert isinstance(res, dict)
     eq_(res['stdout'].rstrip(), test_msg)
     ok_(not res['stderr'])
+
+
+@pytest.mark.ai_generated
+def test_runner_undecodable_output() -> None:
+    # command output is not guaranteed to be valid in the target encoding:
+    # POSIX file names are arbitrary byte strings, and 3rd party libraries
+    # may echo raw bytes into their messages.  Such output must not fail
+    # the command, and must remain recoverable.
+    encoding = getpreferredencoding(do_setlocale=False)
+    payload = b'before \xf1 after'
+    runner = Runner()
+    res = runner.run(py2cmd(
+        'import sys; sys.stdout.buffer.write(%r); sys.stderr.buffer.write(%r)'
+        % (payload, payload)),
+        protocol=StdOutErrCapture,
+    )
+    assert isinstance(res, dict)
+    for stream in ('stdout', 'stderr'):
+        eq_(res[stream].encode(encoding, 'surrogateescape'), payload)
 
 
 def test_runner_failure() -> None:


### PR DESCRIPTION
## What

`WitlessProtocol._prepare_result()` decoded the captured stdout/stderr buffers strictly:

```python
bytes(byt).decode(self.encoding)
```

so a single byte that is not valid in the target encoding raises `UnicodeDecodeError` and fails the whole command. This switches that decode to `errors='surrogateescape'`.

## Why

Command output carries no guarantee of being valid in the preferred encoding. POSIX file names are arbitrary byte strings, and third-party libraries can echo raw bytes into their own messages.

The latter is what prompted this. On the current GitHub Actions image, libmagic (as bundled with git-annex) rejects its magic database and prints the offending byte verbatim:

```
<path>/git_annex/magic.mgc, 1: Warning: offset `\xf1' invalid
<path>/git_annex/magic.mgc, 3: Warning: offset `' invalid
```

That is a *warning* on stderr, about something the command does not depend on — yet it was enough to abort an unrelated `git annex get`:

```
datalad/support/annexrepo.py:1091: in _call_annex_records
datalad/runner/nonasyncrunner.py:531: in process_loop
    self.result = self.protocol._prepare_result()
datalad/runner/protocol.py:206: UnicodeDecodeError
E   UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf1 in position 460: invalid continuation byte
```

Because the exception is raised while assembling the result, the output needed to work out what happened is discarded with it — the error names a byte offset and nothing else.

This currently reproduces on `maint`/`master` in the `datalad-next` extension job of the Extensions workflow, where it lands on `config/tests/test_core.py::test_bare`. It is also why that workflow was green on 2026-09-08 and red on 2026-09-09 with no code change in between: the magic/libmagic pairing in the runner image changed, not datalad.

## Why `surrogateescape` and not `replace`

`replace` would also stop the crash, and matches two existing spots in the codebase (`utils.py:706`, `create_sibling.py:226`). It is the wrong default here: this decode is also how command *output* reaches path-handling code, and turning bytes of a file name into `U+FFFD` trades a loud failure for silent corruption. `surrogateescape` keeps every byte recoverable via `.encode(encoding, 'surrogateescape')`, which is how Python itself handles undecodable file names (`os.fsdecode`).

The trade-off worth a reviewer's eye: a lone surrogate raises `UnicodeEncodeError` if such a string is later written to a strict stdout. `sys.stderr` defaults to `backslashreplace`, so logging is safe; result rendering to stdout is the exposed path. Happy to switch to `replace` if you would rather have the lossy-but-inert behaviour on this branch.

## Test

`test_runner_undecodable_output` writes `b'before \xf1 after'` to both streams and asserts each round-trips. Verified it fails without the fix (same `UnicodeDecodeError`, at `protocol.py:206`) and passes with it.

## Verification

- `datalad/runner/`, `datalad/tests/test_config.py`, `datalad/tests/test_cmd.py` — 101 passed
- `datalad/support/tests/test_annexrepo.py`, `test_gitrepo.py`, `datalad/core/local/` — 265 passed, 12 skipped

Found while investigating a red `test (datalad-next)` check on [PR #7920](https://github.com/datalad/datalad/pull/7920); unrelated to that PR's changes, hence this separate fix against `maint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tQFYm1tNU6GiGLFdLExAM

---
_Generated by [Claude Code](https://claude.ai/code/session_019tQFYm1tNU6GiGLFdLExAM)_