### PR TITLE
BF: run: concurrent `run --explicit` in one dataset

### DIFF
--- a/changelog.d/pr-7922.md
+++ b/changelog.d/pr-7922.md
@@ -1,0 +1,10 @@
+### 🐛 Bug Fixes
+
+- Concurrent `run` invocations in one dataset no longer commit each other's
+  outputs, lose run records, or fail on `index.lock`: the saving phase is
+  serialized on the topmost superdataset of the hierarchy, an `--explicit`
+  commit is limited to the declared outputs, and only a run's own commits
+  are wrapped into its merge commit.  On the rare occasion the lock cannot
+  be acquired, `run` proceeds unlocked and warns that a concurrent `run`
+  could commit its results under its own record.
+  Fixes [#7899](https://github.com/datalad/datalad/issues/7899)

--- a/changelog.d/pr-7925.md
+++ b/changelog.d/pr-7925.md
@@ -7,4 +7,5 @@
   are wrapped into its merge commit.  On the rare occasion the lock cannot
   be acquired, `run` proceeds unlocked and warns that a concurrent `run`
   could commit its results under its own record.
-  Fixes [#7899](https://github.com/datalad/datalad/issues/7899)
+  Fixes [#7899](https://github.com/datalad/datalad/issues/7899) via
+  [PR #7925](https://github.com/datalad/datalad/pull/7925)

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -399,7 +399,14 @@ def _lock_save(ds):
             InterProcessLock(str(lock_path)),
             purpose='save results of `run` in %s' % ds.path,
             timeouts=(5, 60, 600, 1800),
-            proceed_unlocked=True):
+            proceed_unlocked=True) as locked:
+        if not locked:
+            # proceeding unlocked is exactly the mode this lock exists to
+            # remove, so say so at a level that matches the consequence
+            lgr.warning(
+                'Saving the results of `run` in %s without a lock on %s. '
+                'A `run` saving concurrently could commit them under its '
+                'own record (gh-7899).', ds.path, lock_path)
         yield
 
 

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -1701,18 +1701,30 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                     recursive=True,
                     message=msg,
                     jobs=jobs,
-                    # Only use since= when the command created commits
-                    # (in the top-level or any subdataset).  Without
-                    # inner commits, use since=None (standard Status path).
-                    since=pre_cmd_hexsha if wrap_commits_in_merge else None,
+                    # Only use since= when the command created commits (in
+                    # the top-level or any subdataset).  Without inner
+                    # commits, use since=None (standard Status path).
+                    # Note this is keyed on cmd_made_commits, not on
+                    # wrap_commits_in_merge: a subdataset-only commit needs
+                    # the diff_dataset-based discovery below (and
+                    # _since_sub_info) to be seen at all on an adjusted
+                    # branch (gh-7925 review) even when a concurrent commit
+                    # means the result must not be wrapped in a merge --
+                    # _no_merge is what suppresses the merge in that case.
+                    since=pre_cmd_hexsha if cmd_made_commits else None,
                     # Pass pre-command sub HEADs so Save can detect
                     # subdataset commits on adjusted branches where
                     # diff_dataset can't see them.  Parse from the
                     # lightweight submodule status snapshot.
                     _since_sub_info=_parse_sub_status(
                         pre_cmd_sub_status, ds_path)
-                    if wrap_commits_in_merge and pre_cmd_sub_status
+                    if cmd_made_commits and pre_cmd_sub_status
                     else None,
+                    # A concurrent run's commit can make `since`-based
+                    # discovery necessary (above) while also making it
+                    # unsafe to wrap the result in a merge -- discover
+                    # through it, but never merge it in (gh-7925 review).
+                    _no_merge=not wrap_commits_in_merge,
                     # Message for the auxiliary commit that wraps
                     # uncommitted changes before the run-merge.  Keeps
                     # the run-record out of the intermediate commit.

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -17,8 +17,12 @@ import os
 import os.path as op
 import warnings
 from argparse import REMAINDER
+from contextlib import contextmanager
 from pathlib import Path
 from tempfile import mkdtemp
+from uuid import uuid4
+
+from fasteners import InterProcessLock
 
 import datalad
 import datalad.support.ansi_colors as ac
@@ -105,9 +109,31 @@ def _parse_sub_status(sub_status_output, ds_path):
 
 RUN_COMMIT_MARKER = '[DATALAD RUNCMD]'
 RUN_RECORD_MARKER = '=== Do not change lines below ==='
+# environment variable that lets a `run` executed by another `run`'s
+# command discover the chain of `run`s it is nested in
+RUN_ANCESTRY_ENVVAR = 'DATALAD_RUN_ANCESTRY'
+# commit message trailer reporting that chain for a nested `run`
+RUN_ANCESTRY_TRAILER = 'DataLad-Run-Ancestry:'
 # commit message git-annex uses for the commits it makes to maintain an
 # adjusted branch (cf. AnnexRepo._save_post(), which matches it likewise)
 ANNEX_ADJUSTMENT_MESSAGE = 'git-annex adjusted branch'
+
+
+def _get_run_ancestry():
+    """Return the tokens of the `run`s this process is running inside of
+
+    Outermost first. Empty for a `run` that was not started by the command
+    of another `run`.
+    """
+    return os.environ.get(RUN_ANCESTRY_ENVVAR, '').split()
+
+
+def _get_commit_ancestry(message):
+    """Return the `run` ancestry tokens recorded in a commit message"""
+    for line in reversed(message.splitlines()):
+        if line.startswith(RUN_ANCESTRY_TRAILER):
+            return line[len(RUN_ANCESTRY_TRAILER):].split()
+    return []
 
 
 def _is_run_commit_message(message):
@@ -199,6 +225,34 @@ def _unrecorded_commit_paths(repo, base, head):
     return unrecorded
 
 
+def _has_own_commits(repo, base, head, token):
+    """Return whether any commit in ``base..head`` came from this `run`
+
+    Commits appearing in a dataset while a command is executed need not be
+    the command's doing: a concurrent `run` may have committed its own
+    results in the meantime, and wrapping those into this run's merge
+    commit would attribute them to the wrong command (gh-7899).
+
+    A commit is attributed to this `run` when it reports this run's
+    `token` among its ancestry (i.e. it was made by a nested `run` that
+    this command started), or when it carries no `run` record at all --
+    then it is a plain commit of the command itself.
+
+    Parameters
+    ----------
+    repo : GitRepo
+    base, head : str
+      Any commit-ish that delimits the range to report on.
+    token : str
+      Ancestry token of the `run` asking.
+    """
+    for _, _, message in _iter_commits(repo, base, head):
+        if not _is_run_commit_message(message) \
+                or token in _get_commit_ancestry(message):
+            return True
+    return False
+
+
 def _is_run_recorded_range(repo, base, head):
     """Return whether ``base..head`` is non-empty and fully `run`-recorded"""
     if not any(True for _ in _iter_commits(repo, base, head)):
@@ -281,6 +335,43 @@ def _get_dirty_inputs(ds, globbed_inputs, pwd):
     return sorted(dirty)
 
 
+@contextmanager
+def _lock_save(ds):
+    """Serialize the result-saving phase of `run` within a dataset
+
+    Concurrent `run` invocations in a dataset share its Git index. Without
+    serialization one process can commit what another one just staged --
+    misattributing it in a `run` record, and leaving the other command
+    with nothing to commit and no record at all -- or fail outright on
+    `index.lock` (gh-7899). Only the (short) saving phase is serialized,
+    command execution itself remains parallel.
+
+    Parameters
+    ----------
+    ds : Dataset
+    """
+    lock_path = ds.repo.dot_git / 'datalad' / 'run-save.lck'
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        # e.g. a read-only .git -- nothing we could (or need to) fix,
+        # a lock is an optimization of the concurrent case, not a
+        # requirement for the (predominant) serial one
+        lgr.debug('Cannot create %s, proceeding without a lock: %s',
+                  lock_path.parent, CapturedException(exc))
+        yield
+        return
+    lock = InterProcessLock(str(lock_path))
+    if not lock.acquire(blocking=False):
+        lgr.info('Waiting for a concurrent `run` to save its results in %s',
+                 ds.path)
+        lock.acquire()
+    try:
+        yield
+    finally:
+        lock.release()
+
+
 assume_ready_opt = Parameter(
     args=("--assume-ready",),
     constraints=EnsureChoice(None, "inputs", "outputs", "both"),
@@ -332,7 +423,7 @@ class Run(Interface):
     this reason the provenance record contains the dataset ID of that
     superdataset.
 
-    *Nested execution*
+    *Nested and concurrent execution*
 
     || REFLOW >>
     A command may run `datalad run` itself. Such a nested run records its own
@@ -342,6 +433,14 @@ class Run(Interface):
     [CMD: --explicit CMD][PY: `explicit` PY] mode must be covered by an output
     declaration -- set the configuration variable
     'datalad.run.dirty-committed' to 'ignore' to disable that check.
+    << REFLOW ||
+
+    || REFLOW >>
+    Several `run` invocations can operate in one dataset simultaneously. Only
+    the recording of results is serialized between them, command execution is
+    not. In [CMD: --explicit CMD][PY: `explicit` PY] mode a commit is limited
+    to the declared outputs, so that no run record can claim a concurrently
+    produced result of another command.
     << REFLOW ||
 
     *Command format*
@@ -928,12 +1027,26 @@ def _format_iospecs(specs, **kwargs):
     ]
 
 
-def _execute_command(command, pwd):
+def _execute_command(command, pwd, env=None):
+    """Execute `command` in `pwd`
+
+    Parameters
+    ----------
+    command : str
+    pwd : str
+    env : dict, optional
+      Complete environment for the command. The environment of this
+      process is inherited when none is given.
+
+    Returns
+    -------
+    (int, CommandError or None)
+    """
     from datalad.cmd import WitlessRunner
 
     exc = None
     cmd_exitcode = None
-    runner = WitlessRunner(cwd=pwd)
+    runner = WitlessRunner(cwd=pwd, env=env)
     try:
         lgr.info("== Command start (output follows) =====")
         runner.run(
@@ -1275,8 +1388,17 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         ds.repo.call_git(["submodule", "status", "--recursive"])
         if pre_cmd_hexsha is not None else None)
 
+    # identity of this `run`, for any `run` that its command may start
+    # to report back in its commit (see _has_own_commits())
+    run_token = uuid4().hex
+    run_ancestry = _get_run_ancestry()
+
     if not inject:
-        cmd_exitcode, exc = _execute_command(cmd_expanded, pwd)
+        cmd_exitcode, exc = _execute_command(
+            cmd_expanded, pwd,
+            env=dict(os.environ,
+                     **{RUN_ANCESTRY_ENVVAR: ' '.join(
+                         run_ancestry + [run_token])}))
         run_info['exit'] = cmd_exitcode
 
     # Detect if the command created commits — either in the top-level
@@ -1288,6 +1410,11 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         pre_cmd_hexsha is not None
         and post_cmd_hexsha is not None
         and pre_cmd_hexsha != post_cmd_hexsha
+        # not everything that got committed while the command was running
+        # is the command's doing -- a concurrent `run` must not end up
+        # inside this run's merge commit (gh-7899)
+        and _has_own_commits(
+            ds.repo, pre_cmd_hexsha, post_cmd_hexsha, run_token)
     )
 
     # Also detect subdataset-only commits by comparing the single-string
@@ -1333,6 +1460,11 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     msg = msg.format(
         message if message is not None else cmd_shorty,
         '"{}"'.format(record) if record_path else record)
+    if run_ancestry:
+        # a `run` nested in another one: let the enclosing `run` tell this
+        # commit apart from one of a concurrent, unrelated `run`
+        msg += '\n{} {}\n'.format(
+            RUN_ANCESTRY_TRAILER, ' '.join(run_ancestry))
 
     # Safety: if the command switched branches, creating a merge commit
     # would be wrong — it would link two unrelated lines of history.
@@ -1478,10 +1610,16 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     yield run_result
 
     if do_save:
-        with chpwd(pwd):
+        # serialize with any concurrent `run` in this dataset: staging
+        # and committing share the Git index (gh-7899)
+        with _lock_save(ds), chpwd(pwd):
             for r in Save.__call__(
                     dataset=ds_path,
                     path=outputs_to_save,
+                    # under --explicit only the declared outputs must end
+                    # up in the commit, even when something else got
+                    # staged in the meantime (gh-7899)
+                    _partial_commit=bool(explicit and outputs_to_save),
                     recursive=True,
                     message=msg,
                     jobs=jobs,

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -59,6 +59,7 @@ from datalad.support.exceptions import (
     CommandError,
 )
 from datalad.support.globbedpaths import GlobbedPaths
+from datalad.support.locking import try_lock_informatively
 from datalad.support.json_py import dump2stream
 from datalad.support.param import Parameter
 from datalad.ui import ui
@@ -225,8 +226,8 @@ def _unrecorded_commit_paths(repo, base, head):
     return unrecorded
 
 
-def _has_own_commits(repo, base, head, token):
-    """Return whether any commit in ``base..head`` came from this `run`
+def _classify_commits(repo, base, head, token):
+    """Report who made the commits in ``base..head``
 
     Commits appearing in a dataset while a command is executed need not be
     the command's doing: a concurrent `run` may have committed its own
@@ -236,7 +237,8 @@ def _has_own_commits(repo, base, head, token):
     A commit is attributed to this `run` when it reports this run's
     `token` among its ancestry (i.e. it was made by a nested `run` that
     this command started), or when it carries no `run` record at all --
-    then it is a plain commit of the command itself.
+    then it is a plain commit of the command itself. A commit with a `run`
+    record that does not name this run was made by a concurrent one.
 
     Parameters
     ----------
@@ -245,12 +247,21 @@ def _has_own_commits(repo, base, head, token):
       Any commit-ish that delimits the range to report on.
     token : str
       Ancestry token of the `run` asking.
+
+    Returns
+    -------
+    (bool, bool)
+      Whether the range contains a commit of this `run`, and whether it
+      contains a commit of a concurrent one.
     """
-    for _, _, message in _iter_commits(repo, base, head):
+    own = concurrent = False
+    for _, _, message in _iter_command_commits(repo, base, head):
         if not _is_run_commit_message(message) \
                 or token in _get_commit_ancestry(message):
-            return True
-    return False
+            own = True
+        else:
+            concurrent = True
+    return own, concurrent
 
 
 def _is_run_recorded_range(repo, base, head):
@@ -335,9 +346,23 @@ def _get_dirty_inputs(ds, globbed_inputs, pwd):
     return sorted(dirty)
 
 
+def _save_lock_path(ds):
+    """Return the lock file that guards saving in `ds`'s hierarchy
+
+    Parameters
+    ----------
+    ds : Dataset
+    """
+    # topmost=True reports `ds` itself when it has no superdataset, and
+    # registered_only=True (the default) keeps an unrelated Git repository
+    # that merely contains the dataset out of it
+    lock_ds = ds.get_superdataset(topmost=True) or ds
+    return lock_ds.repo.dot_git / 'datalad' / 'run-save.lck'
+
+
 @contextmanager
 def _lock_save(ds):
-    """Serialize the result-saving phase of `run` within a dataset
+    """Serialize the result-saving phase of `run` within a dataset hierarchy
 
     Concurrent `run` invocations in a dataset share its Git index. Without
     serialization one process can commit what another one just staged --
@@ -346,11 +371,16 @@ def _lock_save(ds):
     `index.lock` (gh-7899). Only the (short) saving phase is serialized,
     command execution itself remains parallel.
 
+    The lock is taken on the topmost superdataset, not on `ds`: saving is
+    recursive, so a `run` in a superdataset writes the index of every
+    subdataset underneath it, and a `run` in one of those subdatasets
+    would otherwise guard the very same index with a different lock.
+
     Parameters
     ----------
     ds : Dataset
     """
-    lock_path = ds.repo.dot_git / 'datalad' / 'run-save.lck'
+    lock_path = _save_lock_path(ds)
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
@@ -361,15 +391,16 @@ def _lock_save(ds):
                   lock_path.parent, CapturedException(exc))
         yield
         return
-    lock = InterProcessLock(str(lock_path))
-    if not lock.acquire(blocking=False):
-        lgr.info('Waiting for a concurrent `run` to save its results in %s',
-                 ds.path)
-        lock.acquire()
-    try:
+    # generous timeouts: the command already ran, so giving up on the lock
+    # would mean discarding its results. Wait (with a report on who holds
+    # the lock) far longer than any plausible queue of saves, and only
+    # then proceed unlocked rather than fail
+    with try_lock_informatively(
+            InterProcessLock(str(lock_path)),
+            purpose='save results of `run` in %s' % ds.path,
+            timeouts=(5, 60, 600, 1800),
+            proceed_unlocked=True):
         yield
-    finally:
-        lock.release()
 
 
 assume_ready_opt = Parameter(
@@ -1389,7 +1420,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         if pre_cmd_hexsha is not None else None)
 
     # identity of this `run`, for any `run` that its command may start
-    # to report back in its commit (see _has_own_commits())
+    # to report back in its commit (see _classify_commits())
     run_token = uuid4().hex
     run_ancestry = _get_run_ancestry()
 
@@ -1406,16 +1437,18 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     # which routes through diff_dataset for merge creation.  Without
     # inner commits, since=None uses the standard Status-based save.
     post_cmd_hexsha = ds.repo.get_hexsha() if not inject else None
-    cmd_made_commits = (
+    head_moved = (
         pre_cmd_hexsha is not None
         and post_cmd_hexsha is not None
         and pre_cmd_hexsha != post_cmd_hexsha
-        # not everything that got committed while the command was running
-        # is the command's doing -- a concurrent `run` must not end up
-        # inside this run's merge commit (gh-7899)
-        and _has_own_commits(
-            ds.repo, pre_cmd_hexsha, post_cmd_hexsha, run_token)
     )
+    # not everything that got committed while the command was running is
+    # the command's doing -- a concurrent `run` must not end up inside
+    # this run's merge commit (gh-7899)
+    own_commits, concurrent_commits = _classify_commits(
+        ds.repo, pre_cmd_hexsha, post_cmd_hexsha, run_token) \
+        if head_moved else (False, False)
+    cmd_made_commits = own_commits
 
     # Also detect subdataset-only commits by comparing the single-string
     # submodule status snapshot (one git call, not N Dataset objects).
@@ -1424,6 +1457,20 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
             ["submodule", "status", "--recursive"])
         if pre_cmd_sub_status != post_sub_status:
             cmd_made_commits = True
+
+    # A merge can only ever have one range of commits as its second
+    # parent. Once a concurrent run's commits are interleaved with this
+    # command's own, no such range covers only this command, so a merge
+    # would necessarily claim the other run's work -- and a `rerun` of
+    # this record would re-execute it. Record the results without a merge
+    # instead: the interleaved commits keep the records they came with.
+    wrap_commits_in_merge = cmd_made_commits and not concurrent_commits
+    if cmd_made_commits and concurrent_commits:
+        lgr.info(
+            'Commits of a concurrent `run` are interleaved with those of '
+            'this command in %s. Recording the results without a merge '
+            'commit, so that no record claims the other run\'s commits.',
+            ds.path)
 
     # Re-glob to capture any new outputs.
     #
@@ -1469,7 +1516,7 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
     # Safety: if the command switched branches, creating a merge commit
     # would be wrong — it would link two unrelated lines of history.
     # Save the run record for manual recovery and error out.
-    if cmd_made_commits and pre_cmd_branch is not None:
+    if head_moved and pre_cmd_branch is not None:
         post_cmd_branch = ds.repo.get_active_branch()
         if post_cmd_branch != pre_cmd_branch:
             repo = ds.repo
@@ -1626,14 +1673,14 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                     # Only use since= when the command created commits
                     # (in the top-level or any subdataset).  Without
                     # inner commits, use since=None (standard Status path).
-                    since=pre_cmd_hexsha if cmd_made_commits else None,
+                    since=pre_cmd_hexsha if wrap_commits_in_merge else None,
                     # Pass pre-command sub HEADs so Save can detect
                     # subdataset commits on adjusted branches where
                     # diff_dataset can't see them.  Parse from the
                     # lightweight submodule status snapshot.
                     _since_sub_info=_parse_sub_status(
                         pre_cmd_sub_status, ds_path)
-                    if cmd_made_commits and pre_cmd_sub_status
+                    if wrap_commits_in_merge and pre_cmd_sub_status
                     else None,
                     # Message for the auxiliary commit that wraps
                     # uncommitted changes before the run-merge.  Keeps

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -1675,6 +1675,10 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
                 # same misattribution gh-7899 is about. Re-classify the
                 # full range now that we hold the lock, so no further
                 # commit can land before our own save/merge decides.
+                # post_cmd_hexsha is never None here: wrap_commits_in_merge
+                # is only ever True when cmd_made_commits is, which
+                # requires pre_cmd_hexsha (hence post_cmd_hexsha) to be
+                # set -- i.e. not inject=True.
                 current_hexsha = ds.repo.get_hexsha()
                 if current_hexsha != post_cmd_hexsha:
                     _, concurrent_commits = _classify_commits(

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -381,16 +381,11 @@ def _lock_save(ds):
     ds : Dataset
     """
     lock_path = _save_lock_path(ds)
-    try:
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        # e.g. a read-only .git -- nothing we could (or need to) fix,
-        # a lock is an optimization of the concurrent case, not a
-        # requirement for the (predominant) serial one
-        lgr.debug('Cannot create %s, proceeding without a lock: %s',
-                  lock_path.parent, CapturedException(exc))
-        yield
-        return
+    # deliberately not guarded: if this directory cannot be created, the
+    # `save` that follows writes the very same `.git` and fails anyway, so
+    # swallowing the error here would only defer the failure and discard
+    # the reason for it
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
     # generous timeouts: the command already ran, so giving up on the lock
     # would mean discarding its results. Wait (with a report on who holds
     # the lock) far longer than any plausible queue of saves, and only

--- a/datalad/core/local/run.py
+++ b/datalad/core/local/run.py
@@ -1662,6 +1662,31 @@ def run_command(cmd, dataset=None, inputs=None, outputs=None, expand=None,
         # serialize with any concurrent `run` in this dataset: staging
         # and committing share the Git index (gh-7899)
         with _lock_save(ds), chpwd(pwd):
+            if wrap_commits_in_merge:
+                # `cmd_made_commits`/`concurrent_commits` above were
+                # decided from a snapshot taken right after this
+                # command's own execution -- but a concurrent `run` can
+                # still commit to the top-level dataset in the window
+                # between that snapshot and now (record creation, output
+                # globbing, waiting for this very lock), a range
+                # `_classify_commits()` was never asked to look at. Left
+                # unchecked, the merge below (`since=pre_cmd_hexsha`)
+                # would silently claim that other run's commits -- the
+                # same misattribution gh-7899 is about. Re-classify the
+                # full range now that we hold the lock, so no further
+                # commit can land before our own save/merge decides.
+                current_hexsha = ds.repo.get_hexsha()
+                if current_hexsha != post_cmd_hexsha:
+                    _, concurrent_commits = _classify_commits(
+                        ds.repo, pre_cmd_hexsha, current_hexsha, run_token)
+                    if concurrent_commits:
+                        lgr.info(
+                            'Commits of a concurrent `run` are interleaved '
+                            'with those of this command in %s. Recording '
+                            'the results without a merge commit, so that '
+                            'no record claims the other run\'s commits.',
+                            ds.path)
+                        wrap_commits_in_merge = False
             for r in Save.__call__(
                     dataset=ds_path,
                     path=outputs_to_save,

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -44,6 +44,7 @@ from datalad.support.constraints import (
     EnsureStr,
 )
 from datalad.support.exceptions import CommandError
+from datalad.support.gitrepo import to_options
 from datalad.support.parallel import (
     ProducerConsumerProgressLog,
     no_subds_in_futures,
@@ -620,6 +621,23 @@ class Save(Interface):
                         logger=lgr)
                     return
                 _merged_datasets.add(pdspath)
+            elif (_no_merge and pdspath == ds.path and had_inner
+                    and pds_repo.get_hexsha() == start_commit):
+                # `had_inner` means this dataset had commits of its own
+                # (`run`'s command committing directly, e.g. gh-7925
+                # review) that would normally be wrapped in the merge
+                # above -- but a concurrent commit made that merge unsafe,
+                # so `_no_merge` suppressed it. If the plain save above
+                # also found nothing dirty left to commit (HEAD is still
+                # where it was when this call started), the run's own
+                # record has nowhere to land: it would be silently
+                # dropped even though `run_command()` reported success.
+                # Force a commit -- empty if need be -- carrying the run
+                # message, the same way `message` would otherwise have
+                # ended up on the (now suppressed) merge commit.
+                pds_repo.commit(
+                    msg=message,
+                    options=to_options(allow_empty=True))
 
             # report on the dataset itself
             dsres = dict(

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -357,6 +357,9 @@ class Save(Interface):
                  since=None,
                  _since_sub_info=None,
                  _sub_message=None,
+                 # limit the commit to the given `path`s, even when nothing
+                 # was staged beforehand (see GitRepo.save())
+                 _partial_commit=False,
                  ):
         if message and message_file:
             raise ValueError(
@@ -576,7 +579,8 @@ class Save(Interface):
                         # detect anything else
                         untracked='no',
                         _status=pds_status,
-                        amend=amend):
+                        amend=amend,
+                        _partial_commit=_partial_commit):
                     for k in ('path', 'refds'):
                         if k in res:
                             res[k] = str(

--- a/datalad/core/local/save.py
+++ b/datalad/core/local/save.py
@@ -360,6 +360,16 @@ class Save(Interface):
                  # limit the commit to the given `path`s, even when nothing
                  # was staged beforehand (see GitRepo.save())
                  _partial_commit=False,
+                 # use `since` only to discover what changed at `dataset`
+                 # itself (needed to see through the corresponding-branch
+                 # blind spot on adjusted branches, gh-7899/gh-7925), but
+                 # never wrap *that* dataset's result in a merge commit --
+                 # `run` sets this once a concurrent commit lands there,
+                 # making a merge unsafe, while still needing `since`-based
+                 # discovery for a subdataset-only change. Subdatasets are
+                 # unaffected and still merge normally when they have inner
+                 # commits of their own.
+                 _no_merge=False,
                  ):
         if message and message_file:
             raise ValueError(
@@ -553,7 +563,15 @@ class Save(Interface):
                 and any(str(p) in _merged_datasets
                         for p, props in paths.items()
                         if props.get('type') == 'dataset'))
-            will_merge = had_inner or child_merged
+            # `_no_merge` only ever suppresses the merge at the dataset
+            # `run` was invoked in -- an interloping commit there is what
+            # makes merging unsafe (gh-7925 review). A subdataset's own
+            # inner commits are unaffected by that and still get merged
+            # normally, same as without `_no_merge`; that merge also syncs
+            # the subdataset's corresponding branch on an adjusted branch,
+            # which the superdataset's own gitlink update below relies on.
+            will_merge = (had_inner or child_merged) and not (
+                _no_merge and pdspath == ds.path)
 
             if not all(p['state'] == 'clean'
                        for p in pds_status.values()) or \

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -33,6 +33,7 @@ from datalad.cli.main import main
 from datalad.core.local.run import (
     _format_iospecs,
     _get_substitutions,
+    _lock_save,
     _save_lock_path,
     format_command,
     run_command,
@@ -1672,3 +1673,65 @@ def test_run_explicit_no_merge_of_concurrent_commits(path=None, scriptpath=None)
     assert_in("[DATALAD RUNCMD] outer", last_commit_msg(ds.repo))
     # ... but not as a merge that would subsume the concurrent record
     _assert_no_run_merge(ds)
+
+
+@with_tempfile(mkdir=True)
+@pytest.mark.ai_generated
+def test_run_explicit_concurrent_subdataset_only_no_merge(path=None):
+    """No merge when the command's only top-level effect is a subdataset commit
+
+    When a command only commits inside a subdataset, the top-level HEAD
+    never moves during execution, so `cmd_made_commits` above is set True
+    by the subdataset-status check rather than by `_classify_commits()`
+    -- which is only ever asked to look at the (necessarily empty)
+    `pre_cmd_hexsha..post_cmd_hexsha` range in that case. A concurrent
+    `run` can still land its own, unrelated commit at the top level in
+    the window between that check and this run's own save -- serialized
+    only later, by `_lock_save()` -- and deciding the merge from the
+    stale range would silently wrap that commit in (gh-7925 review).
+    """
+    ds = Dataset(path).create()
+    ds.create("sub")
+    assert_repo_status(ds.path)
+
+    # Simulate a concurrent `run`'s commit landing in the window between
+    # this command's own execution finishing and `_lock_save()` being
+    # entered -- the one window the classification above cannot see.
+    def _lock_save_after_concurrent_commit(ds_):
+        (ds.pathobj / "elsewhere").write_text("y")
+        ds.repo.call_git(["add", "elsewhere"])
+        ds.repo.call_git(["commit", "-m",
+                           "[DATALAD RUNCMD] concurrent\n\n"
+                           "=== Do not change lines below ===\n"
+                           '{"cmd": "other", "exit": 0, "chain": [], '
+                           '"inputs": [], "outputs": ["elsewhere"], '
+                           '"pwd": "."}\n'
+                           "^^^ Do not change lines above ^^^\n\n"
+                           "DataLad-Run-Ancestry: "
+                           "0123456789abcdef0123456789abcdef\n"])
+        return _lock_save(ds_)
+
+    # the command's only top-level-visible effect is a subdataset commit,
+    # and its declared output never materializes -- forcing
+    # run_command()'s "force full save" override
+    with patch("datalad.core.local.run._lock_save",
+               side_effect=_lock_save_after_concurrent_commit):
+        res = ds.run(
+            ["git", "-C", "sub", "commit", "--allow-empty", "-m", "inner"],
+            outputs=["ghost"], explicit=True, message="outer",
+            on_failure='ignore', result_renderer='disabled')
+    assert_not_in_results(res, action='run', status='error')
+    assert_repo_status(ds.path)
+    # the outer command is recorded ...
+    assert_in("[DATALAD RUNCMD] outer", last_commit_msg(ds.repo))
+    # ... but not as a merge that would subsume the concurrent record
+    _assert_no_run_merge(ds)
+    # ... and its own commit does not claim the concurrent run's file
+    committed = [
+        str(p.relative_to(ds.pathobj))
+        for p in ds.repo.diff("HEAD^", "HEAD")
+    ]
+    assert_not_in("elsewhere", committed)
+    # the concurrent commit is untouched: a standalone, non-merge parent
+    assert_in("[DATALAD RUNCMD] concurrent",
+               ds.repo.format_commit("%B", "HEAD^"))

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -1735,3 +1735,73 @@ def test_run_explicit_concurrent_subdataset_only_no_merge(path=None):
     # the concurrent commit is untouched: a standalone, non-merge parent
     parent_msg = ds.repo.format_commit("%B", "HEAD^")
     assert_in("[DATALAD RUNCMD] concurrent", parent_msg)
+
+
+@with_tempfile(mkdir=True)
+@pytest.mark.ai_generated
+def test_run_explicit_concurrent_no_merge_self_committed(path=None):
+    """The run record survives when the command self-commits and no merge happens
+
+    A command run under `--explicit` may commit its own declared output
+    directly (bypassing datalad's own save), leaving nothing dirty for
+    `run_command()`'s own save step to pick up afterward. When a
+    concurrent `run`'s commit also lands -- in the window `_lock_save()`
+    guards -- and rules out wrapping the result in a merge (the same
+    situation as test_run_explicit_concurrent_subdataset_only_no_merge,
+    but here at the top level, on a normal, non-adjusted filesystem),
+    both routes that would normally carry this run's record -- the merge,
+    and an ordinary dirty-tree commit -- are unavailable. The record must
+    still land somewhere rather than being silently dropped even though
+    `run` reports success (gh-7925 review).
+    """
+    ds = Dataset(path).create()
+
+    # Simulate a concurrent `run`'s commit landing in the window between
+    # this command's own execution finishing and `_lock_save()` being
+    # entered -- same injection technique as
+    # test_run_explicit_concurrent_subdataset_only_no_merge.
+    def _lock_save_after_concurrent_commit(ds_):
+        (ds.pathobj / "elsewhere").write_text("y")
+        ds.repo.call_git(["add", "elsewhere"])
+        concurrent_msg = (
+            "[DATALAD RUNCMD] concurrent\n\n"
+            "=== Do not change lines below ===\n"
+            '{"cmd": "other", "exit": 0, "chain": [], '
+            '"inputs": [], "outputs": ["elsewhere"], "pwd": "."}\n'
+            "^^^ Do not change lines above ^^^\n\n"
+            "DataLad-Run-Ancestry: 0123456789abcdef0123456789abcdef\n"
+        )
+        ds.repo.call_git(["commit", "-m", concurrent_msg])
+        return _lock_save(ds_)
+
+    # The command commits its declared output *itself* (bypassing
+    # datalad's own save) -- nothing is left uncommitted for
+    # run_command()'s own save step to pick up via the ordinary
+    # working-tree diff.
+    cmd = [
+        sys.executable, "-c",
+        "import subprocess; "
+        "open('out', 'w').write('x'); "
+        "subprocess.check_call(['git', 'add', 'out']); "
+        "subprocess.check_call(['git', 'commit', '-m', 'own commit'])"
+    ]
+
+    with patch("datalad.core.local.run._lock_save",
+               side_effect=_lock_save_after_concurrent_commit):
+        res = ds.run(
+            cmd, outputs=["out"], explicit=True, message="outer",
+            on_failure='ignore', result_renderer='disabled')
+    assert_not_in_results(res, action='run', status='error')
+    assert_repo_status(ds.path)
+    # the outer command's record is not silently dropped ...
+    assert_in("[DATALAD RUNCMD] outer", last_commit_msg(ds.repo))
+    # ... but not as a merge that would subsume the concurrent record
+    _assert_no_run_merge(ds)
+    # ... it is its own (auxiliary, empty) commit -- it claims neither
+    # the command's own output (already committed beforehand) nor the
+    # concurrent run's file
+    eq_([str(p.relative_to(ds.pathobj))
+         for p in ds.repo.diff("HEAD^", "HEAD")], [])
+    # the concurrent commit is untouched: a standalone, non-merge parent
+    parent_msg = ds.repo.format_commit("%B", "HEAD^")
+    assert_in("[DATALAD RUNCMD] concurrent", parent_msg)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -33,6 +33,7 @@ from datalad.cli.main import main
 from datalad.core.local.run import (
     _format_iospecs,
     _get_substitutions,
+    _save_lock_path,
     format_command,
     run_command,
 )
@@ -1569,3 +1570,94 @@ def test_run_explicit_concurrent(path=None):
             for p in ds.repo.diff(rev + "^", rev)
         ]
         eq_(sorted(committed), sorted(info["outputs"]))
+
+
+@with_tempfile(mkdir=True)
+@pytest.mark.ai_generated
+def test_run_explicit_concurrent_subdataset(path=None):
+    """A run in a subdataset does not race a run in its superdataset
+
+    Saving is recursive, so a `run` in a superdataset writes the index of
+    every subdataset underneath it.  Guarding only the dataset a `run` was
+    invoked in would leave those two writing one index under two different
+    locks (gh-7901 review).
+    """
+    import subprocess
+    ds = Dataset(path).create()
+    sub = ds.create("sub")
+    assert_repo_status(ds.path)
+
+    # one lock governs the whole hierarchy...
+    eq_(_save_lock_path(sub), _save_lock_path(ds))
+
+    # ...so a run in the superdataset that declares an output *in* the
+    # subdataset can run concurrently with a run inside that subdataset
+    def _run_in(dspath, output, message):
+        return subprocess.Popen(
+            [sys.executable, "-c",
+             "from datalad.api import run\n"
+             "run(cmd=[%r, '-c', \"open(%r, 'w').write('x')\"],\n"
+             "    outputs=[%r], explicit=True, message=%r,\n"
+             "    result_renderer='disabled')\n"
+             % (sys.executable, output, output, message)],
+            cwd=dspath, stderr=subprocess.PIPE)
+
+    for trial in range(3):
+        procs = [_run_in(ds.path, "sub/a%d" % trial, "super %d" % trial),
+                 _run_in(sub.path, "b%d" % trial, "sub %d" % trial)]
+        errs = [p.communicate()[1].decode() for p in procs]
+        eq_([p.returncode for p in procs], [0, 0],
+            msg="concurrent super/sub runs failed:\n%s" % "\n".join(errs))
+        # neither run left its declared output behind uncommitted
+        ok_((sub.pathobj / ("a%d" % trial)).exists())
+        ok_((sub.pathobj / ("b%d" % trial)).exists())
+        eq_(sub.repo.call_git(["status", "--porcelain"]).strip(), "")
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@pytest.mark.ai_generated
+def test_run_explicit_no_merge_of_concurrent_commits(path=None, scriptpath=None):
+    """A run's merge commit never wraps a concurrent run's commits
+
+    A merge has a single second parent, so once a concurrent run's commits
+    are interleaved with this command's own there is no range that covers
+    only this command.  Recording without a merge is the way out: a merge
+    would claim the other run's commits, and a `rerun` of this record
+    would then re-execute them (gh-7901 review).
+    """
+    ds = Dataset(path).create()
+    # the command commits one declared output itself, and also fabricates
+    # the commit a concurrent `run` would have landed in the meantime --
+    # a run record whose ancestry does not name this run
+    script = op.join(scriptpath, "concurrent.py")
+    with open(script, "w") as f:
+        f.write(
+            "import json, subprocess\n"
+            "open('declared_committed', 'w').write('x')\n"
+            "subprocess.check_call(['git', 'add', 'declared_committed'])\n"
+            "subprocess.check_call(['git', 'commit', '-m', 'own commit'])\n"
+            "open('elsewhere', 'w').write('y')\n"
+            "subprocess.check_call(['git', 'add', 'elsewhere'])\n"
+            "record = json.dumps({'cmd': 'other', 'exit': 0, 'chain': [],\n"
+            "                     'inputs': [], 'outputs': ['elsewhere'],\n"
+            "                     'pwd': '.'})\n"
+            "msg = ('[DATALAD RUNCMD] concurrent\\n\\n'\n"
+            "       '=== Do not change lines below ===\\n'\n"
+            "       + record + '\\n'\n"
+            "       '^^^ Do not change lines above ^^^\\n\\n'\n"
+            "       'DataLad-Run-Ancestry: '\n"
+            "       '0123456789abcdef0123456789abcdef\\n')\n"
+            "subprocess.check_call(['git', 'commit', '-m', msg])\n"
+            "open('declared_left', 'w').write('z')\n")
+
+    res = ds.run([sys.executable, script],
+                 outputs=["declared_committed", "declared_left"],
+                 explicit=True, message="outer",
+                 on_failure='ignore', result_renderer='disabled')
+    assert_not_in_results(res, action='run', status='error')
+    assert_repo_status(ds.path)
+    # the outer command is recorded ...
+    assert_in("[DATALAD RUNCMD] outer", last_commit_msg(ds.repo))
+    # ... but not as a merge that would subsume the concurrent record
+    _assert_no_run_merge(ds)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -1700,15 +1700,15 @@ def test_run_explicit_concurrent_subdataset_only_no_merge(path=None):
     def _lock_save_after_concurrent_commit(ds_):
         (ds.pathobj / "elsewhere").write_text("y")
         ds.repo.call_git(["add", "elsewhere"])
-        ds.repo.call_git(["commit", "-m",
-                           "[DATALAD RUNCMD] concurrent\n\n"
-                           "=== Do not change lines below ===\n"
-                           '{"cmd": "other", "exit": 0, "chain": [], '
-                           '"inputs": [], "outputs": ["elsewhere"], '
-                           '"pwd": "."}\n'
-                           "^^^ Do not change lines above ^^^\n\n"
-                           "DataLad-Run-Ancestry: "
-                           "0123456789abcdef0123456789abcdef\n"])
+        concurrent_msg = (
+            "[DATALAD RUNCMD] concurrent\n\n"
+            "=== Do not change lines below ===\n"
+            '{"cmd": "other", "exit": 0, "chain": [], '
+            '"inputs": [], "outputs": ["elsewhere"], "pwd": "."}\n'
+            "^^^ Do not change lines above ^^^\n\n"
+            "DataLad-Run-Ancestry: 0123456789abcdef0123456789abcdef\n"
+        )
+        ds.repo.call_git(["commit", "-m", concurrent_msg])
         return _lock_save(ds_)
 
     # the command's only top-level-visible effect is a subdataset commit,
@@ -1733,5 +1733,5 @@ def test_run_explicit_concurrent_subdataset_only_no_merge(path=None):
     ]
     assert_not_in("elsewhere", committed)
     # the concurrent commit is untouched: a standalone, non-merge parent
-    assert_in("[DATALAD RUNCMD] concurrent",
-               ds.repo.format_commit("%B", "HEAD^"))
+    parent_msg = ds.repo.format_commit("%B", "HEAD^")
+    assert_in("[DATALAD RUNCMD] concurrent", parent_msg)

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -535,9 +535,11 @@ def test_run_cmdline_disambiguation(path=None):
         with patch("datalad.core.local.run._execute_command") as exec_cmd:
             with assert_raises(SystemExit):
                 main(["datalad", "run", "--", "--message"])
-            exec_cmd.assert_called_once_with(
-                '"--message"' if on_windows else "--message",
-                path)
+            # ATTN: only the positional arguments are of interest here,
+            # `run` also passes an `env` for the command
+            eq_(exec_cmd.call_count, 1)
+            eq_(exec_cmd.call_args.args,
+                ('"--message"' if on_windows else "--message", path))
 
         # Our parser used to mishandle --version (gh-3067),
         # treating 'datalad run CMD --version' as 'datalad --version'.
@@ -547,9 +549,10 @@ def test_run_cmdline_disambiguation(path=None):
             with patch("datalad.core.local.run._execute_command") as exec_cmd:
                 with assert_raises(SystemExit):
                     main(["datalad", "run"] + sep + ["echo", "--version"])
-                exec_cmd.assert_called_once_with(
-                    '"echo" "--version"' if on_windows else "echo --version",
-                    path)
+                eq_(exec_cmd.call_count, 1)
+                eq_(exec_cmd.call_args.args,
+                    ('"echo" "--version"' if on_windows else "echo --version",
+                     path))
 
 
 @with_tempfile(mkdir=True)
@@ -1528,3 +1531,41 @@ def test_run_explicit_nested_run_in_subdataset(path=None, scriptpath=None):
     assert_in_results(res, action='run', status='error')
     ok_(any('not declared as --output' in str(r.get('message', ''))
             for r in res))
+
+
+@with_tempfile(mkdir=True)
+@pytest.mark.ai_generated
+def test_run_explicit_concurrent(path=None):
+    """Concurrent `--explicit` runs record what they produced (gh-7899)"""
+    import subprocess
+    ds = Dataset(path).create()
+    nruns = 3
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c",
+             "from datalad.api import run\n"
+             "run(cmd=[%r, '-c', \"open('o%d', 'w').write('x')\"],\n"
+             "    dataset=%r, outputs=['o%d'], explicit=True,\n"
+             "    message='cell %d', result_renderer='disabled')\n"
+             % (sys.executable, i, ds.path, i, i)],
+            # ATTN: paths are resolved against the CWD when the dataset is
+            # given as a path (gh-3435)
+            cwd=ds.path, stderr=subprocess.PIPE)
+        for i in range(nruns)
+    ]
+    errs = [p.communicate()[1].decode() for p in procs]
+    eq_([p.returncode for p in procs], [0] * nruns,
+        msg="concurrent runs failed:\n%s" % "\n".join(errs))
+
+    assert_repo_status(ds.path)
+    # no record went missing...
+    revs = ds.repo.get_revisions(options=["--grep", "DATALAD RUNCMD"])
+    eq_(len(revs), nruns)
+    # ...and none of them claims an output it did not produce
+    for rev in revs:
+        info = get_run_info(ds, ds.repo.format_commit("%B", rev))[1]
+        committed = [
+            str(p.relative_to(ds.pathobj))
+            for p in ds.repo.diff(rev + "^", rev)
+        ]
+        eq_(sorted(committed), sorted(info["outputs"]))

--- a/datalad/core/local/tests/test_run.py
+++ b/datalad/core/local/tests/test_run.py
@@ -1608,10 +1608,21 @@ def test_run_explicit_concurrent_subdataset(path=None):
         errs = [p.communicate()[1].decode() for p in procs]
         eq_([p.returncode for p in procs], [0, 0],
             msg="concurrent super/sub runs failed:\n%s" % "\n".join(errs))
-        # neither run left its declared output behind uncommitted
-        ok_((sub.pathobj / ("a%d" % trial)).exists())
-        ok_((sub.pathobj / ("b%d" % trial)).exists())
-        eq_(sub.repo.call_git(["status", "--porcelain"]).strip(), "")
+        # neither run left its declared output behind: both were produced,
+        # both are tracked (the losing run of the race used to leave its
+        # own output untracked and unrecorded), and both are recorded.
+        # ATTN: `git status` is not the check to make here -- on an
+        # adjusted branch git-annex maintains an index state of its own
+        outputs = ["a%d" % trial, "b%d" % trial]
+        for f in outputs:
+            ok_((sub.pathobj / f).exists())
+        eq_(sorted(sub.repo.call_git(["ls-files", "--"] + outputs).split()),
+            outputs)
+        for message in ("super %d" % trial, "sub %d" % trial):
+            ok_(any("[DATALAD RUNCMD] " + message == subject
+                    for subject in sub.repo.call_git(
+                        ["log", "--format=%s"]).splitlines()),
+                msg="no run record for %r in %s" % (message, sub.path))
 
 
 @with_tempfile(mkdir=True)

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3482,12 +3482,7 @@ class GitRepo(CoreGitRepo):
         #   potential pre-staged bits)
 
         staged_paths = self.get_staged_paths()
-        # a partial commit is unavoidable when something was staged
-        # before this save. It can also be requested by a caller that
-        # must not commit anything but the paths it gave -- even if
-        # some concurrent process stages content in the meantime
-        need_partial_commit = bool(staged_paths) or force_partial_commit
-        if need_partial_commit and hasattr(self, "call_annex"):
+        if staged_paths and hasattr(self, "call_annex"):
             # so we have some staged content. let's check which ones
             # are symlinks -- those could be annex key links that
             # are broken after a `git-mv` operation
@@ -3678,7 +3673,9 @@ class GitRepo(CoreGitRepo):
         # possibly different message). If an empty commit was okay before, it's
         # okay now.
         status_state.pop('modified_or_untracked')  # pop the hybrid state
-        self._save_post(message, chain(*status_state.values()), need_partial_commit, amend=amend,
+        self._save_post(message, chain(*status_state.values()),
+                        force_partial_commit,
+                        amend=amend,
                         allow_empty=amend)
         # TODO yield result for commit, prev helper checked hexsha pre
         # and post...

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3442,6 +3442,12 @@ class GitRepo(CoreGitRepo):
             passed to Repo.status()
           - untracked : {'no', 'normal', 'all'} - passed to Repo.status()
           - amend : bool (passed to GitRepo.commit)
+          - _partial_commit : bool
+            If True, the commit is always limited to the paths reported by
+            the status, even when nothing was staged beforehand. Use this
+            when no content but the given paths may end up in the commit,
+            e.g. because a concurrent process could stage content in the
+            same repository.
         """
         return list(
             self.save_(
@@ -3456,6 +3462,7 @@ class GitRepo(CoreGitRepo):
         """Like `save()` but working as a generator."""
         from datalad.interface.results import get_status_dict
 
+        force_partial_commit = kwargs.pop('_partial_commit', False)
         status_state = _get_save_status_state(
             self._save_pre(paths, _status, **kwargs) or {}
         )
@@ -3475,7 +3482,11 @@ class GitRepo(CoreGitRepo):
         #   potential pre-staged bits)
 
         staged_paths = self.get_staged_paths()
-        need_partial_commit = bool(staged_paths)
+        # a partial commit is unavoidable when something was staged
+        # before this save. It can also be requested by a caller that
+        # must not commit anything but the paths it gave -- even if
+        # some concurrent process stages content in the meantime
+        need_partial_commit = bool(staged_paths) or force_partial_commit
         if need_partial_commit and hasattr(self, "call_annex"):
             # so we have some staged content. let's check which ones
             # are symlinks -- those could be annex key links that

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -3674,7 +3674,14 @@ class GitRepo(CoreGitRepo):
         # okay now.
         status_state.pop('modified_or_untracked')  # pop the hybrid state
         self._save_post(message, chain(*status_state.values()),
-                        force_partial_commit,
+                        # a partial commit is unavoidable when something was
+                        # staged before this save: committing without a
+                        # pathspec would sweep it in (see
+                        # test_save_partial_commit_shrinking_annex).  It can
+                        # also be requested by a caller that must not commit
+                        # anything but the paths it gave -- even if some
+                        # concurrent process stages content in the meantime
+                        bool(staged_paths) or force_partial_commit,
                         amend=amend,
                         allow_empty=amend)
         # TODO yield result for commit, prev helper checked hexsha pre

--- a/docs/designs/run-explicit/02-concurrent-runs.md
+++ b/docs/designs/run-explicit/02-concurrent-runs.md
@@ -1,0 +1,123 @@
+# Concurrent `datalad run` in one dataset
+
+## Status: implemented
+
+## Problem
+
+The use case is N parallel `datalad run --explicit` in a single dataset,
+without giving each run a worktree or a branch of its own -- a sweep
+where every cell writes its own declared output into the same tree.
+
+Staging and committing go through the shared Git index, so the runs raced
+([gh-7899](https://github.com/datalad/datalad/issues/7899)):
+
+- With nothing pre-staged, `save` committed **without a pathspec**, so a
+  sibling run's staged output was swept into the wrong commit.  The
+  sibling then found nothing left to commit and exited 0 **without any
+  record** -- the loss is silent.
+
+- `run` decides that its command created commits by comparing HEAD before
+  and after execution.  A sibling committing in that window is
+  indistinguishable from a nested run by inspection alone, so a
+  concurrent run's commits were wrapped into an unrelated run's merge
+  commit.  A `rerun` of that record then re-executes the other run's
+  command.
+
+- At higher concurrency the same race also surfaced as an outright
+  `index.lock` failure.
+
+Measured on the issue's reproducer at N=8: 1-2 records of 8, outputs
+attributed to the wrong command, plus `index.lock` crashes.  After the
+changes below: 8 of 8, each commit containing exactly its own declared
+output, no crashes (independently reproduced up to N=64).
+
+## Solution
+
+Three independent measures, in the order in which they take effect:
+
+- **Only own commits are wrapped in a merge.**  A `run` passes its
+  identity to its command in the `DATALAD_RUN_ANCESTRY` environment
+  variable, and a run that finds itself nested reports the chain it
+  inherited in a `DataLad-Run-Ancestry:` commit message trailer.  A
+  commit is attributed to this run when it names this run in that
+  trailer, or when it carries no run record at all (then it is a plain
+  commit of the command itself).  Since a merge has a single second
+  parent, once a sibling's commits are interleaved with this command's
+  own *no* range covers only this command; the results are then recorded
+  **without** a merge, so the interleaved commits keep the records they
+  came with.  The run record itself is unchanged, so a sidecar record
+  keeps its content-based identity.
+
+- **The commit is limited to the declared outputs.**  `save` commits with
+  a pathspec whenever content is already staged; with the new private
+  `_partial_commit` an `--explicit` run requests the same
+  unconditionally, so a sibling's staged output cannot enter this run's
+  commit.
+
+- **The saving phase is serialized.**  An `InterProcessLock` on
+  `.git/datalad/run-save.lck` is held across the `Save` call, which keeps
+  staging and committing atomic with respect to another `run` and removes
+  the `index.lock` failures.  The lock is taken on the **topmost
+  superdataset**, not on the invoked dataset: saving is recursive, so a
+  run in a superdataset writes the index of every subdataset underneath
+  it, and a lock per invoked dataset would leave a super run and a sub
+  run writing one index while each holds a lock of its own.  Command
+  execution stays parallel -- the lock is taken after the command has
+  run, via `try_lock_informatively()`, so a wait reports who holds it.
+
+  If the lock cannot be acquired within the timeouts, `run` proceeds
+  unlocked and warns, rather than discarding the results of a command
+  that has already run.  Failing to *create* the lock directory is not
+  caught: the `save` that follows writes the same `.git` and would fail
+  anyway, so swallowing that error would only defer the failure and
+  discard its cause.
+
+## Non-goals / limitations
+
+- **`run` outside of `datalad`.**  A concurrent plain `git commit` from
+  another process during command execution is still attributed to the
+  command.  Nothing in the commit can tell the two apart.
+
+- **A command that hides its environment.**  Ancestry detection needs
+  `DATALAD_RUN_ANCESTRY` to reach a nested `run`.  A command that scrubs
+  its environment makes a nested run look like a concurrent one: the
+  result is the pre-existing behaviour (a merge commit), not an error.
+
+- **Saving without `run`.**  `datalad save <path>` in one process can
+  still commit what another process staged.  `_partial_commit` is
+  available to `Save` callers, but only `run --explicit` sets it, because
+  a pathspec commit takes the worktree state of the given paths and
+  ignores what is staged for them -- a change of semantics that a general
+  `save` should not silently adopt.
+
+- **Nothing to commit is not an error.**  An `--explicit` run whose
+  command changed nothing still produces no record, and reports
+  `save(notneeded)`.  Making that an error was considered (gh-7899,
+  suggestion 2) and rejected: it is the normal outcome of a `rerun` of a
+  deterministic command.
+
+## Alternatives considered
+
+- **Retrying on `index.lock`** instead of locking.  Rejected in the issue
+  itself, and rightly so: it fixes the visible crash and leaves the
+  silent misattribution in place.
+
+- **Recording the nesting relation in the `chain` field of the run
+  record.**  `chain` is the `rerun` trail (which record this record was
+  re-executed from) and overloading it would break that meaning.  The
+  nesting relation is reported in the `DataLad-Run-Ancestry:` trailer
+  instead, which keeps the record -- and hence the content-based identity
+  of a sidecar record -- unchanged.
+
+- **Locking each invoked dataset** rather than the topmost superdataset.
+  Leaves a super run and a sub run writing the same index while each
+  holds a lock of its own; see above.
+
+## Tests
+
+| Test | Purpose |
+| --- | --- |
+| `test_run_explicit_concurrent` | 3 real `run` processes: every one has a record, and none claims another's output |
+| `test_run_explicit_concurrent_subdataset` | The same in a subdataset, where the lock is taken on the superdataset |
+| `test_run_explicit_no_merge_of_concurrent_commits` | A sibling's commits are not wrapped into this run's merge |
+| `test_save_partial_commit_shrinking_annex` | Unchanged: a pre-staged partial commit still behaves as before |


### PR DESCRIPTION
Split out of #7901 per review. **Based on #7901** — the diff shown here is the concurrency work alone; retarget to `maint` once #7901 lands.

Fixes #7899.

### The use case

N parallel `datalad run --explicit` in a *single* dataset, without giving each run a worktree or a branch of its own — a sweep where every cell writes its own declared output into the same tree. That is what brought this up, and it is what the design document (`docs/designs/run-explicit/02-concurrent-runs.md`) is now written around.

### What went wrong

Staging and committing go through the shared Git index, so the runs raced three different ways:

- With nothing pre-staged, `save` committed **without a pathspec**, so a sibling's staged output was swept into the wrong commit. The sibling then found nothing left to commit and exited 0 **with no record at all** — a silent loss.
- `run` infers "my command made commits" from HEAD moving during execution, which under concurrency also catches a sibling's commit, wrapping it into an unrelated run's merge. A `rerun` of that record then re-executes the *other* run's command.
- At higher concurrency the same race surfaced as an outright `index.lock` failure.

On the issue's reproducer at N=8: 1–2 records of 8, misattributed outputs, plus `index.lock` crashes. Afterwards: 8 of 8, each commit containing exactly its own declared output, no crashes — independently reproduced up to N=64.

### Three measures

- **A merge never wraps another run's commits.** A `run` passes its identity to its command in `DATALAD_RUN_ANCESTRY`, and a run that finds itself nested reports the inherited chain in a `DataLad-Run-Ancestry:` commit message trailer — that is what tells a nested run apart from a concurrent one. Since a merge has a single second parent, once a sibling's commits are interleaved with this command's own *no* range covers only this command; the results are then recorded **without** a merge, so the interleaved commits keep the records they came with. The run record itself is unchanged, so a sidecar record keeps its content-based identity.
- **A commit is limited to the declared outputs** under `--explicit`, via a new private `_partial_commit` for `Save`/`GitRepo.save_`.
- **The saving phase is serialized** with an inter-process lock on the *topmost superdataset*: saving is recursive, so a run in a superdataset writes the index of every subdataset underneath it, and a lock per invoked dataset would leave a super run and a sub run writing one index while each holds a lock of its own. Command execution stays parallel — the lock is taken after the command has run, via `try_lock_informatively()` so a wait reports who holds it.

### Why the lock lives in `run` and not in `save`

You suspected it belonged to "overall `save`". Answered at length in [this comment](https://github.com/datalad/datalad/pull/7925#issuecomment-5621162756); the short of it:

- **It would not be sufficient.** The merge decision compares HEAD with `pre_cmd_hexsha`, captured *before* the command ran — a window spanning command execution, which must stay parallel. And `_partial_commit` is about committing *selectively*; no lock provides that.
- **It would be much wider than the bug.** `save` is called by nearly everything; an inter-process lock there serializes every datalad process touching the dataset, to fix a race that only arises when several `run`s share one index.
- **The scope would still have to come from `run`.** The lock is on the topmost superdataset precisely because saving is recursive.

If you would rather have it available generally — an opt-in `save(..., lock=True)` that `run` uses — that is a clean refactor and I will do it here; I did not want to widen `save`'s contract unasked.

### On the lock's failure modes (your review comment)

You were right that swallowing the error and carrying on was the wrong instinct. The `except OSError` around creating the lock directory is **gone**: if `.git` genuinely cannot be written, the `save` that follows fails anyway, so catching it there only deferred the failure and discarded its cause.

For the record on gh-7921, which you asked about: this code never reached it. `_get_dot_git()` already resolves the `gitdir: …` link file, so in a worktree `dot_git` is the real directory and the `mkdir` succeeds; gh-7921 fails further in.

What remains is the *other* fallback, and it is deliberate: if the lock cannot be **acquired** within the timeouts, `run` proceeds unlocked and warns loudly, rather than discarding the results of a command that has already run. Both the timeout ladder and that choice are now stated in the design document rather than left implicit. If you would rather it failed instead, say so — it is a one-line change and this is the right PR to argue it in.

### Notes for the reviewer

- Suggestion 2 of #7899 (error when an `--explicit` run has nothing to commit) is deliberately not implemented: it is the normal outcome of a `rerun` of a deterministic command, and #7906 has since documented that contract.
- Tests: `test_run_explicit_concurrent` (spawns 3 real `run` processes), `test_run_explicit_concurrent_subdataset` (the lock taken on the superdataset), `test_run_explicit_no_merge_of_concurrent_commits`.
- Up to date with the base branch, which is up to date with `maint` (`2bc08a6`) — merged, never rebased, since both branches are published.
- Locally green on this head: `datalad/core/local/tests/`, `datalad/support/tests/test_gitrepo.py` and `test_rerun.py` (211 passed, 6 skipped, 1 xfailed); codespell clean.
- `datalad/core/local/tests/test_save.py::test_save_partial_commit_shrinking_annex` is the pre-existing test that pins the `save_()` partial-commit behaviour these changes touch; it passes unchanged.

### PR checklist

- [x] Overview of the changes provided above
- [x] Changelog snippet in `changelog.d/pr-7925.md`
- [x] `Fixes #7899` above and in the snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmhmXEbZsgtpcNGECpbiYw