### PR TITLE
Handle UUID mismatch in datalad special remote configuration

### DIFF
--- a/datalad/customremotes/base.py
+++ b/datalad/customremotes/base.py
@@ -24,6 +24,7 @@ from annexremote import (
 )
 
 from datalad.customremotes import SpecialRemote
+from datalad.support.exceptions import CommandError
 
 URI_PREFIX = "dl"
 
@@ -120,7 +121,23 @@ def init_datalad_remote(repo, remote, encryption=None, autoenable=False,
     # ATM only datalad/datalad-archives is expected,
     # so on purpose getitem
     remote_opts.append('uuid=%s' % DATALAD_SPECIAL_REMOTES_UUIDS[remote])
-    return repo.init_remote(remote, remote_opts + opts)
+    remote_opts += opts
+    try:
+        return repo.init_remote(remote, remote_opts)
+    except CommandError as e:
+        if 'git-annex: There is already a special remote named' in e.stderr:
+            # Fall back to enabling the existing one, as git-annex's own
+            # error message suggests.  uuid= is create-time-only and
+            # enableremote rejects it outright ("Unexpected parameters:
+            # uuid") -- the uuid of an existing special remote is not
+            # ours to (re)assign anyway.
+            enable_opts = [o for o in remote_opts
+                          if not o.startswith('uuid=')]
+            lgr.warning(
+                "Special remote %s already exists, enabling it instead "
+                "of failing: %s", remote, e)
+            return repo.enable_remote(remote, enable_opts)
+        raise
 
 
 def ensure_datalad_remote(repo, remote=None,
@@ -149,7 +166,24 @@ def ensure_datalad_remote(repo, remote=None,
         raise ValueError("'{}' is not a known datalad special remote: {}"
                          .format(remote,
                                  ", ".join(DATALAD_SPECIAL_REMOTES_UUIDS)))
-    name = repo.get_special_remotes().get(uuid, {}).get("name")
+    specialremotes = repo.get_special_remotes()
+    name = specialremotes.get(uuid, {}).get("name")
+    if not name:
+        # The dataset might have this special remote configured under a
+        # uuid other than the one currently hard-coded in
+        # DATALAD_SPECIAL_REMOTES_UUIDS -- e.g. a dataset created before
+        # that convention was introduced.  Fall back to a lookup by name,
+        # so we do not attempt (and fail) to initremote a duplicate.
+        name = next(
+            (sr["name"] for sr in specialremotes.values()
+             if sr.get("name") == remote),
+            None
+        )
+        if name:
+            lgr.warning(
+                "Special remote %s is known under a uuid other than the "
+                "expected %s -- dataset possibly predates that convention",
+                remote, uuid)
 
     if not name:
         init_datalad_remote(repo, remote,

--- a/datalad/customremotes/tests/test_base.py
+++ b/datalad/customremotes/tests/test_base.py
@@ -10,6 +10,7 @@
 
 
 from os.path import isabs
+from uuid import uuid4
 
 import pytest
 
@@ -20,6 +21,7 @@ from datalad.api import (
 from datalad.consts import DATALAD_SPECIAL_REMOTE
 from datalad.support.annexrepo import AnnexRepo
 from datalad.tests.utils_pytest import (
+    assert_equal,
     assert_false,
     assert_in,
     assert_not_in,
@@ -86,3 +88,44 @@ def test_ensure_datalad_remote_maybe_enable(path=None, *, autoenable):
         assert_not_in("datalad", repo.get_remotes())
     ensure_datalad_remote(repo)
     assert_in("datalad", repo.get_remotes())
+
+
+@with_tempfile
+def test_ensure_datalad_remote_uuid_mismatch(path=None):
+    # Regression test: a dataset can have the special remote already
+    # configured (in git-annex's remote.log) under a uuid other than the
+    # one currently hard-coded in DATALAD_SPECIAL_REMOTES_UUIDS -- e.g. a
+    # dataset created before a fixed uuid was adopted for it.  In that case
+    # the uuid-based lookup in ensure_datalad_remote would not find it,
+    # and it would try (and fail) to `initremote` a duplicate, since
+    # git-annex itself identifies special remotes by name too and refuses:
+    #   "There is already a special remote named ..."
+    path = Path(path)
+    legacy_uuid = str(uuid4())
+    ds_a = Dataset(path / "a").create(force=True)
+    # configure with a uuid distinct from DATALAD_SPECIAL_REMOTES_UUIDS
+    ds_a.repo.init_remote(
+        DATALAD_SPECIAL_REMOTE,
+        ['encryption=none', 'type=external', 'autoenable=false',
+         'externaltype=%s' % DATALAD_SPECIAL_REMOTE,
+         'uuid=%s' % legacy_uuid])
+
+    ds_b = clone(source=ds_a.path, path=path / "b")
+    repo = ds_b.repo
+    assert_not_in(DATALAD_SPECIAL_REMOTE, repo.get_remotes())
+    # must not raise despite the uuid mismatch
+    ensure_datalad_remote(repo)
+    assert_in(DATALAD_SPECIAL_REMOTE, repo.get_remotes())
+
+    # A direct, repeated init_datalad_remote() call (e.g. triggered by
+    # other code that did not go through the same uuid-mismatch-aware
+    # lookup) must likewise not fail with git-annex's "already a special
+    # remote" error, but fall back to enabling the existing one -- and that
+    # fallback must still apply the given options via enableremote, so
+    # flip autoenable to confirm it actually took effect rather than being
+    # silently dropped.
+    assert_equal(
+        repo.get_special_remotes()[legacy_uuid]["autoenable"], "false")
+    init_datalad_remote(repo, DATALAD_SPECIAL_REMOTE, autoenable=True)
+    assert_equal(
+        repo.get_special_remotes()[legacy_uuid]["autoenable"], "true")


### PR DESCRIPTION
## Overview

This PR fixes a regression where datasets created before a fixed UUID convention was adopted for the datalad special remote would fail when `ensure_datalad_remote()` was called. The issue occurs because the UUID-based lookup in `ensure_datalad_remote()` would not find the remote if it was configured under a different UUID, causing the code to attempt initializing a duplicate remote, which git-annex rejects with "There is already a special remote named...".

## Changes

### `datalad/customremotes/base.py`

1. **`init_datalad_remote()` function**: Added error handling to catch the "already a special remote named" error from git-annex. When this error occurs, the function now falls back to enabling the existing remote instead of failing. The fallback applies the provided options (except `uuid=`, which is create-time-only) via `enableremote`.

2. **`ensure_datalad_remote()` function**: Enhanced the special remote lookup to handle UUID mismatches. When the UUID-based lookup fails to find the remote, the function now falls back to a name-based lookup across all configured special remotes. This allows the function to locate remotes that were configured under legacy UUIDs.

### `datalad/customremotes/tests/test_base.py`

Added `test_ensure_datalad_remote_uuid_mismatch()` regression test that:
- Creates a dataset with a special remote configured under a legacy UUID
- Clones the dataset and verifies that `ensure_datalad_remote()` can locate and work with the existing remote despite the UUID mismatch
- Tests that repeated `init_datalad_remote()` calls gracefully fall back to enabling the existing remote and properly apply options

## Test Plan

The new regression test `test_ensure_datalad_remote_uuid_mismatch()` covers the fixed behavior. Existing tests continue to pass, ensuring backward compatibility.

https://claude.ai/code/session_01LRDjhBMNU4f4vR38oVTLDw