### PR TITLE
CI+DOC: keep AI assistants out of con/tributors' contributor lists

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -26,8 +26,18 @@ jobs:
           # Update lookup with GitHub metadata
           update_lookup: github
 
-          # Skip these users (example)
-          skip_users: manbat bhanuprasad14 yetanothertestuser bobknob23987
+          # Skip these users: spam/test accounts, and AI coding agents.
+          # con/tributors only auto-skips accounts GitHub reports as
+          # type "Bot" or whose login contains "[bot]" (dependabot[bot],
+          # github-actions[bot], Copilot, ...).  "claude" (uid 81847) is a
+          # plain "User" account, so it has to be listed here -- see
+          # https://github.com/datalad/datalad/pull/7922 .  GitHub attributes
+          # a commit to the account owning the *author* email, so an agent
+          # only shows up here if it authored (not just co-authored) commits;
+          # see CONTRIBUTING.md:Recognizing contributions.
+          # To extend this list, check for non-human logins in
+          # https://api.github.com/repos/datalad/datalad/contributors
+          skip_users: manbat bhanuprasad14 yetanothertestuser bobknob23987 claude Copilot
 
           # INFO, DEBUG, ERROR, WARNING, etc.
           log_level: DEBUG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,3 +14,12 @@ It contains the authoritative project conventions including:
 
 Do NOT guess or assume conventions — read the file. Additional documentation
 may be found under `docs/`.
+
+## Commit authorship
+
+The git **author** of a commit you create is the person you are working for,
+not the assistant — set `user.name`/`user.email` accordingly (e.g.
+`git -c user.name=... -c user.email=... commit`) if the environment's git
+identity says otherwise. Credit the model in the `Co-Authored-By:` trailer
+instead. GitHub counts commit authors, not trailers, towards the repository's
+contributor list; see `CONTRIBUTING.md`, section "Recognizing contributions".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -476,6 +476,34 @@ which runs automatically on merges to master and updates
 [.zenodo.json][link_zenodo] and [.all-contributorsrc](.all-contributorsrc).
 If you are new, please add yourself to [.zenodo.json][link_zenodo].
 
+### AI assistants are not contributors
+
+Those files credit people, not tools.  con/tributors takes its list from
+GitHub's [contributors API][gh-contributors-api], which attributes a commit to
+the account owning the commit's **author** email and ignores `Co-authored-by:`
+trailers.  Therefore:
+
+- Credit an AI assistant in `Co-authored-by:` trailers (and/or in the pull
+  request description).  That leaves the contributor and citation metadata
+  untouched -- as of this writing datalad has >150 such commits and none of
+  them added an entry.
+- Do *not* let an assistant be the commit **author**; the person running it
+  is the author and is responsible for the change.  Commits authored by e.g.
+  `Claude <noreply@anthropic.com>` are attributed by GitHub to the `claude`
+  account, which con/tributors then proposes to add to [.tributors](.tributors),
+  [.all-contributorsrc](.all-contributorsrc) and the README --
+  [PR #7922](https://github.com/datalad/datalad/pull/7922) is such a proposal.
+
+As a backstop, such accounts are listed in `skip_users` of the
+[update-contributors workflow](.github/workflows/update-contributors.yml).
+`skip_users` only prevents *adding* an entry: con/tributors never prunes, and
+entries already present in `.all-contributorsrc` are copied back into
+`.tributors` regardless of `skip_users`.  A `[tributors]` pull request that
+proposes an AI assistant should therefore be **closed**, not merged and
+cleaned up afterwards.
+
+[gh-contributors-api]: https://docs.github.com/en/rest/repos/repos#list-repository-contributors
+
 ## Useful tools
 
 - While performing IO/net heavy operations use [dool](https://github.com/scottchiefbaker/dool)


### PR DESCRIPTION
### Overview

Prevents `[tributors]` pull requests like https://github.com/datalad/datalad/pull/7922 (which proposes adding "Claude" to `.tributors`, `.all-contributorsrc` and the README) from happening again.

### Why it happened

con/tributors' only source is `GET /repos/datalad/datalad/contributors`. That endpoint attributes a commit to the account owning the commit's **author** email and **ignores `Co-authored-by:` trailers**. Verified against the API:

- `/repos/datalad/datalad/commits?author=claude` returns exactly **18** commits, every one authored by `Claude <noreply@anthropic.com>` — matching `contributions: 18` in the contributors listing.
- `master` carries **158** commits with an `@anthropic.com` `Co-authored-by:` trailer, and they contributed **nothing**.

So a trailer is free; being the commit *author* is what earns an entry. Those 18 commits come from Claude Code web sessions, whose container git identity is `Claude <noreply@anthropic.com>`.

con/tributors' built-in bot filter did not catch it because it only skips accounts GitHub reports as `type == "Bot"` or with `"[bot]"` in the login:

| account | uid | type | auto-skipped? |
| --- | --- | --- | --- |
| `dependabot[bot]`, `github-actions[bot]` | — | Bot | yes |
| `Copilot` | 175728472 | Bot | yes (already) |
| `claude` | 81847 | **User** | **no** |

### Changes

- `.github/workflows/update-contributors.yml`: add `claude` and `Copilot` to `skip_users`, with a comment on why Bot-typed accounts need no listing and how to extend the list.
- `CONTRIBUTING.md`: new subsection under *Recognizing contributions* — credit AI assistants in `Co-authored-by:` trailers, never as the commit author.
- `CLAUDE.md`: instruct agents to keep the human as the git author. This commit follows that rule (author is the maintainer, committer is Claude); revert that hunk if AI authorship in `git log` is preferred — `skip_users` covers it either way.

### Note on https://github.com/datalad/datalad/pull/7922

It should be **closed, not merged and cleaned up afterwards**:

1. `skip_users` only gates *adding*; nothing prunes. `yetanothertestuser` was added to `skip_users` on 2021-07-29 and is still in `.tributors` and `.all-contributorsrc` today.
2. `AllContribParser.update_lookup()` copies every login from `.all-contributorsrc` back into `.tributors` with no skip check, so a merged entry regenerates itself even with `skip_users` set.

Both are worth reporting upstream to https://github.com/con/tributors, along with pattern support in `skip_users` (exact string match today) and keeping the skip list in `.tributors` rather than in each workflow.

### Checklist

- [x] Overview of the changes and rationale provided above.
- [ ] Changelog snippet — CI/doc only, no user-facing change; suggest `semver-internal` (or `semver-documentation`).
- [x] Targets `maint` per request, for propagation into `master` (the workflow itself only runs on pushes to `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpMK9ntY9DNzPJwGpmsWLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpMK9ntY9DNzPJwGpmsWLC)_